### PR TITLE
Address Copilot PR #1 feedback + document required OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,19 @@ Install it, then authenticate with one of:
 - **Pre‑obtained token:** set `GOOGLE_WORKSPACE_CLI_TOKEN=<access_token>`
 - **Client app:** set `GOOGLE_WORKSPACE_CLI_CLIENT_ID` and `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET`, then `gws auth login`
 
-On your Google Cloud project, enable the **Sheets**, **Drive**, and **Docs** APIs.
+On your Google Cloud project, enable the **Sheets**, **Drive**, **Docs**, and
+**Forms** APIs.
+
+**OAuth scopes.** The ops skills *read and write* Sheets/Drive (clone, rebrand,
+clean) and read Form responses, so grant **read-write** scopes — read-only access
+passes the verify step below but then fails on the first write:
+
+- `https://www.googleapis.com/auth/spreadsheets` — read/write the intake sheet
+- `https://www.googleapis.com/auth/drive` — copy, create, and update Drive files
+  (chapter/series asset clones)
+- `https://www.googleapis.com/auth/forms.body` — read/edit the intake form
+- `https://www.googleapis.com/auth/forms.responses.readonly` — read form responses
+
 Verify with:
 
 ```bash

--- a/scripts/check_frontmatter.py
+++ b/scripts/check_frontmatter.py
@@ -16,7 +16,8 @@ FRONTMATTER = re.compile(r"^---\n(.*?)\n---", re.S)
 
 
 def check(path: str) -> list[str]:
-    text = open(path, encoding="utf-8").read()
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
     m = FRONTMATTER.match(text)
     if not m:
         return [f"{path}: no `---` YAML frontmatter block at the top of the file"]

--- a/skills/aaif-announcement-post/SKILL.md
+++ b/skills/aaif-announcement-post/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-announcement-post
 description: Write the LinkedIn launch/announcement post for an AAIF meetup when RSVPs open. Use when asked to draft the announcement, launch post, or "RSVPs are open" post for an AAIF event.
-argument-hint: [event title / paste tracker entry]
+argument-hint: '[event title / paste tracker entry]'
 ---
 
 # AAIF Event Announcement (LinkedIn)

--- a/skills/aaif-attendee-reminder/SKILL.md
+++ b/skills/aaif-attendee-reminder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-attendee-reminder
 description: Write the pre-event reminder to people who RSVP'd to an AAIF meetup (sent ~1 week out and the morning of). Use when asked to draft the attendee reminder / "see you tomorrow" note for an AAIF event.
-argument-hint: [event title / paste tracker entry]
+argument-hint: '[event title / paste tracker entry]'
 ---
 
 # AAIF Attendee Reminder

--- a/skills/aaif-carousel-copy/SKILL.md
+++ b/skills/aaif-carousel-copy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-carousel-copy
 description: Write copy for a 6-slide LinkedIn carousel announcing an AAIF meetup. Use when asked to draft carousel slides/copy for an AAIF event (built from the LinkedIn Carousel template).
-argument-hint: [event title / paste tracker entry]
+argument-hint: '[event title / paste tracker entry]'
 ---
 
 # AAIF LinkedIn Carousel Copy

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -249,7 +249,7 @@ def install_flags():
         # (it must not turn the row bright red). It's surfaced by `scan` instead.
         parts = []
         if email:
-            parts.append(f'IF(ISNUMBER(SEARCH("@",${email}2:${email})),"","missing/bad email; ")')
+            parts.append(f'IF(REGEXMATCH(${email}2:${email},"^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"),"","missing/bad email; ")')
         if link:
             parts.append(f'IF(REGEXMATCH(LOWER(${link}2:${link}),"linkedin\\.com/"),"","bad LinkedIn; ")')
         concat = "&".join(parts) if parts else '""'

--- a/skills/aaif-dayof-slides/SKILL.md
+++ b/skills/aaif-dayof-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-dayof-slides
 description: Turn an event's tracker entry into the slide text for the AAIF "Day of Event" deck. Use when asked to fill/write the day-of slides or event deck for an AAIF meetup.
-argument-hint: [event title / paste tracker entry]
+argument-hint: '[event title / paste tracker entry]'
 ---
 
 # AAIF Day-of Slides (from the tracker)

--- a/skills/aaif-luma-description/SKILL.md
+++ b/skills/aaif-luma-description/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-luma-description
 description: Write the Luma event-page description for an AAIF in-person meetup. Use when asked to draft the Luma description / event page copy for an AAIF event.
-argument-hint: [event title / paste tracker entry]
+argument-hint: '[event title / paste tracker entry]'
 ---
 
 # AAIF Luma Event Description

--- a/skills/aaif-recap-post/SKILL.md
+++ b/skills/aaif-recap-post/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-recap-post
 description: Write the post-event LinkedIn recap for an AAIF meetup (posted within 48 hours, with photos). Use when asked to draft the recap, thank-you, or wrap-up post after an AAIF event.
-argument-hint: [event title / paste tracker entry]
+argument-hint: '[event title / paste tracker entry]'
 ---
 
 # AAIF Post-Event Recap (LinkedIn)

--- a/skills/aaif-speaker-bio/SKILL.md
+++ b/skills/aaif-speaker-bio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-speaker-bio
 description: Write a speaker bio (a 60-80 word bio + a one-liner) for an AAIF in-person meetup speaker. Use when asked to draft/write a speaker bio for an AAIF event or chapter.
-argument-hint: [speaker name / paste their tracker row]
+argument-hint: '[speaker name / paste their tracker row]'
 ---
 
 # AAIF Speaker Bio

--- a/skills/aaif-speaker-invite/SKILL.md
+++ b/skills/aaif-speaker-invite/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-speaker-invite
 description: Write a short, warm speaker-invite DM or email for an AAIF in-person meetup. Use when asked to draft a speaker invite, outreach DM, or ask-someone-to-speak message for an AAIF event.
-argument-hint: [speaker name + event / paste tracker entry]
+argument-hint: '[speaker name + event / paste tracker entry]'
 ---
 
 # AAIF Speaker Outreach / Invite

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -43,7 +43,13 @@ def fetch(tab):
         sys.exit(f"gws error reading {tab}: {out.stderr.strip()}")
     # gws prints a keyring banner line before the JSON; find the JSON start.
     txt = out.stdout
-    data = json.loads(txt[txt.index("{"):])
+    start = txt.find("{")
+    if start < 0:
+        sys.exit(f"gws returned no JSON for {tab} (got: {txt.strip()[:200]!r})")
+    try:
+        data = json.loads(txt[start:])
+    except json.JSONDecodeError as e:
+        sys.exit(f"gws returned invalid JSON for {tab}: {e}")
     vals = data.get("values", [])
     if not vals:
         return [], []


### PR DESCRIPTION
## Summary

PR #1 merged before its Copilot review comments were addressed. This follow-up applies all 11 of Copilot's inline findings, and additionally documents the OAuth scopes the ops skills require.

## Changesets

**Convention — quote `argument-hint` (8 files)**
Copilot flagged `argument-hint` written as a bare YAML flow sequence (`[...]`), which violates the repo convention (CONTRIBUTING.md) to fully-quote the value so it stays a single scalar string. Single-quoted in:
`aaif-announcement-post`, `aaif-attendee-reminder`, `aaif-carousel-copy`, `aaif-dayof-slides`, `aaif-luma-description`, `aaif-recap-post`, `aaif-speaker-bio`, `aaif-speaker-invite`.

**Robustness (3 files)**
- `skills/aaif-triage-intake/scripts/intake.py` — `fetch()` previously did `json.loads(txt[txt.index("{"):])`, crashing with an unhelpful `ValueError`/`JSONDecodeError` when `gws` returns a non-JSON banner, empty output, or a different format. Now finds the JSON start safely and exits with a clear message on missing/invalid JSON.
- `skills/aaif-clean-data/scripts/clean.py` — the Issues "bad email" rule used `ISNUMBER(SEARCH("@", …))`, which passes `foo@` and `foo@bar`. Tightened to a `REGEXMATCH` requiring `local@domain.tld`.
- `scripts/check_frontmatter.py` — read the file via a context manager instead of `open(...).read()` (avoids `ResourceWarning`).

**Docs — required OAuth scopes (README)**
Enabling the Google APIs alone is insufficient: the ops skills write to Sheets/Drive and read Form responses. Documented the read-write scopes (`spreadsheets`, `drive`) plus Forms (`forms.body`, `forms.responses.readonly`) and added the **Forms** API to the enable list, with a note that read-only access passes the verify step but fails on the first write.

## Test Plan

- [x] `py_compile` clean on all 3 scripts
- [x] `check_frontmatter.py` parses all 12 SKILL.md blocks (quoted hints load as strings)
- [x] `pre-commit run` passes on all changed files (ruff, codespell, gitleaks, frontmatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)