### PR TITLE
docs: complete OAuth scope list (Sheets/Docs/Slides/Drive/Forms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,20 @@ Install it, then authenticate with one of:
 - **Pre‑obtained token:** set `GOOGLE_WORKSPACE_CLI_TOKEN=<access_token>`
 - **Client app:** set `GOOGLE_WORKSPACE_CLI_CLIENT_ID` and `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET`, then `gws auth login`
 
-On your Google Cloud project, enable the **Sheets**, **Drive**, **Docs**, and
-**Forms** APIs.
+On your Google Cloud project, enable the **Sheets**, **Docs**, **Slides**,
+**Drive**, and **Forms** APIs.
 
-**OAuth scopes.** The ops skills *read and write* Sheets/Drive (clone, rebrand,
-clean) and read Form responses, so grant **read-write** scopes — read-only access
-passes the verify step below but then fails on the first write:
+**OAuth scopes.** Grant **read-write** scopes — read-only access passes the verify
+step below but then fails on the first write. The bundled scripts use only the
+Sheets and Drive scopes; the Docs, Slides, and Forms scopes are for operating on
+those assets directly (interactive ops via the connector/MCP, and the
+chapter/series source docs and decks):
 
-- `https://www.googleapis.com/auth/spreadsheets` — read/write the intake sheet
-- `https://www.googleapis.com/auth/drive` — copy, create, and update Drive files
-  (chapter/series asset clones)
+- `https://www.googleapis.com/auth/spreadsheets` — read/write the intake sheet *(scripts)*
+- `https://www.googleapis.com/auth/drive` — copy, create, and update Drive files,
+  incl. chapter/series asset clones *(scripts)*
+- `https://www.googleapis.com/auth/documents` — read/edit chapter/series Docs
+- `https://www.googleapis.com/auth/presentations` — read/edit day-of / series Slides
 - `https://www.googleapis.com/auth/forms.body` — read/edit the intake form
 - `https://www.googleapis.com/auth/forms.responses.readonly` — read form responses
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ Install it, then authenticate with one of:
 On your Google Cloud project, enable the **Sheets**, **Docs**, **Slides**,
 **Drive**, and **Forms** APIs.
 
-**OAuth scopes.** Grant **read-write** scopes — read-only access passes the verify
-step below but then fails on the first write. The bundled scripts use only the
-Sheets and Drive scopes; the Docs, Slides, and Forms scopes are for operating on
-those assets directly (interactive ops via the connector/MCP, and the
-chapter/series source docs and decks):
+**OAuth scopes.** Grant **read-write** scopes for anything you write to —
+read-only access passes the verify step below but then fails on the first write
+(form responses are read-only by nature, hence the `.readonly` scope). The
+bundled scripts use only the Sheets and Drive scopes; the Docs, Slides, and Forms
+scopes are for operating on those assets directly — the chapter/series source docs
+and decks, and the intake form (e.g. via Claude's Google connector or an MCP
+server):
 
 - `https://www.googleapis.com/auth/spreadsheets` — read/write the intake sheet *(scripts)*
 - `https://www.googleapis.com/auth/drive` — copy, create, and update Drive files,


### PR DESCRIPTION
## Summary

Follow-up to the self-review of PR #2. Documents the **full** OAuth scope set the AAIF meetup ops workflows need — Sheets, Docs, Slides, Drive, and Forms — and clarifies which scopes the bundled scripts actually exercise vs. which are for operating the underlying assets directly.

## Why

The README scopes note added in #2 listed only Sheets/Drive/Forms and implied Forms was a *script* dependency. In practice:
- The bundled Python scripts use **Sheets + Drive** only.
- **Docs**, **Slides**, and **Forms** scopes are needed for interactive ops (connector/MCP) and for working with the chapter/series source docs and decks and the intake form directly.

## Changeset

- `README.md` — enable list now includes **Slides** (and keeps Docs/Forms); scope list adds `documents` and `presentations`, annotates `spreadsheets`/`drive` as *(scripts)*, and reframes the intro so Forms/Docs/Slides are correctly described as asset/interactive scopes rather than script requirements.

## Test Plan

- [x] `pre-commit run --files README.md` passes (codespell, gitleaks, hygiene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)