### PR TITLE
docs: note attendee legal-link defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Pure writing skills. They take the event details you give them and produce copy.
 | `aaif-attendee-reminder` | Pre‑event reminder to people who RSVP'd |
 | `aaif-recap-post` | Post‑event LinkedIn recap (within 48h) |
 
+> **Attendee legal defaults.** The attendee‑facing skills (`aaif-announcement-post`,
+> `aaif-luma-description`, `aaif-attendee-reminder`) append two standing links by
+> default — the [Code of Conduct](https://events.linuxfoundation.org/about/code-of-conduct/)
+> and [Privacy Policy](https://www.linuxfoundation.org/legal/privacy-policy).
+> Running your own chapter? Swap these URLs in each skill's `SKILL.md`.
+
 ### 🛠️ Ops skills — need Google Workspace access
 These drive Google Drive / Sheets through the `gws` CLI (see below).
 


### PR DESCRIPTION
## What

Documents the Code of Conduct + Privacy Policy defaults that the attendee-facing skills now append (merged in #4).

Adds a short **"Attendee legal defaults"** callout under the content-skills table noting that `aaif-announcement-post`, `aaif-luma-description`, and `aaif-attendee-reminder` append two standing links by default:
- Code of Conduct — https://events.linuxfoundation.org/about/code-of-conduct/
- Privacy Policy — https://www.linuxfoundation.org/legal/privacy-policy

…and how to swap the URLs when running your own chapter.

## Why

The behavior shipped in #4 but wasn't reflected in the README. This closes that gap so organizers know the links appear and can customize them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)