### PR TITLE
AAIF intake: City (Existing)/City (New) schema, provenance colors + review flow, and aaif-backup skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 *.pyc
 .DS_Store
 .ruff_cache/
+
+# Local versioned backups from the aaif-backup skill (binary snapshots stay out of git)
+backups/*
+!backups/README.md

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These drive Google Drive / Sheets through the `gws` CLI (see below).
 | `aaif-create-online-series` | Clone the **TemplateSeries** folder under **Online/** and rebrand it for a new online series | Google Drive |
 | `aaif-triage-intake` | Summarize who's awaiting review in the Community Intake sheet + draft outreach | Google Sheets |
 | `aaif-clean-data` | Normalize/flag data quality in the Intake sheet (LinkedIn, casing, City=Other…) | Google Sheets |
+| `aaif-backup` | Versioned local snapshots of critical data (Intake sheet by default, or any file) before risky edits | Google Drive |
 
 > **Heads up — these ship with AAIF's own IDs.** The ops skills reference AAIF's
 > Google resources (the Chapters Drive, the Intake Ops spreadsheet ID, Luma slug

--- a/backups/README.md
+++ b/backups/README.md
@@ -1,0 +1,32 @@
+# backups/
+
+Local, versioned snapshots written by the **`aaif-backup`** skill. Everything in this
+folder **except this README is git-ignored** — the binary `.xlsx`/`.docx`/`.pptx`
+snapshots are deliberately kept out of the published plugin repo.
+
+## Layout
+
+```
+backups/<slug>/<UTC-timestamp>.<ext>
+   e.g.  backups/aaif-community-intake-ops/2026-07-03T142530Z.xlsx
+```
+
+Each run of the skill adds a **new immutable file** — nothing is overwritten — so a
+folder listing is the full version history, in chronological order.
+
+## Make a backup
+
+```bash
+# default: the AAIF Community Intake Ops sheet
+python3 skills/aaif-backup/scripts/backup.py
+
+# any Drive file, or a local file
+python3 skills/aaif-backup/scripts/backup.py <driveFileId>
+python3 skills/aaif-backup/scripts/backup.py ./path/to/file.xlsx
+```
+
+## Restore
+
+Manual and deliberate — see the "Restore" section of `skills/aaif-backup/SKILL.md`.
+For the Intake Ops sheet, copy values back from the snapshot rather than replacing the
+file, so the role-tab formulas and conditional formats survive.

--- a/docs/superpowers/specs/2026-07-03-new-city-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-03-new-city-fixes-design.md
@@ -1,0 +1,70 @@
+# new-city-fixes — design
+
+Branch: `new-city-fixes`. Three parts.
+
+## Part A — `aaif-backup` skill
+A new ops skill that snapshots critical AAIF data to local, versioned files.
+
+- **Files:** `skills/aaif-backup/SKILL.md`, `skills/aaif-backup/scripts/backup.py`.
+- **Default (no arg):** back up the AAIF Community Intake Ops sheet
+  (`1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o`), exported Sheet → `.xlsx`.
+- **Optional arg:** back up any file — a Drive fileId (native Docs/Sheets/Slides
+  exported to `.docx/.xlsx/.pptx`, already-binary files via `alt=media`) or a local
+  path (copied).
+- **Versioned snapshots, gitignored:** each run writes an immutable
+  `backups/<slug>/<UTC-timestamp>.<ext>` under the repo. Never overwrites, so the
+  folder is a full version history. `backups/` is added to `.gitignore` so binary
+  snapshots never enter the published plugin repo; a tracked `backups/README.md`
+  documents the folder and the manual restore path (re-upload the `.xlsx` via `gws`).
+- The agent drives `gws`; `backup.py` does the deterministic export/copy + naming.
+  Restore is documented, not automated (YAGNI).
+
+## Part B — intake schema edits (dictated verbatim)
+Match the sheet's renamed city columns: role tabs now show **City (Existing)** (col G,
+submitted dropdown) and **City (New)** (col H, resolved "Other" city). The physical
+source column in Form Responses stays **"Resolved City"** — never renamed.
+
+- `skills/aaif-clean-data/scripts/clean.py` — (a) flag message text → "City (New)";
+  (b) provenance color constants (VIOLET/AMBER/GREEN, col indices, COLOR_FORMULAS);
+  (c) `_conditional_formats()` + `install_colors()`; (d) call `install_colors()` at the
+  end of `install_flags()`; (e) `install-colors` subcommand; (f) docstring entry.
+- `skills/aaif-clean-data/SKILL.md` — reword resolved-city step (source at CF, shown as
+  City (New); City (Existing) = submitted dropdown; City (New) holds net-new only);
+  add `install-colors` as a 4th maintenance mode.
+- `skills/aaif-triage-intake/scripts/intake.py` — split `"City"` into
+  `"City (Existing)", "City (New)"` in each `TABS` entry; digest header shows
+  `City (New)` else `City (Existing)`; update the skip-set.
+
+Rules: keep bright-red error rule at top priority (city colors sit below it);
+`install_colors` idempotent (matches its own rules by formula); scripts import cleanly.
+
+## Part C — colors + flowchart in the sheet + repo docs
+On the Intake Ops **"How to use"** tab (first page, where colors are defined):
+
+- **New colors** in the legend: 🟪 Violet = `Existing (from MLOps)` (prior organizer,
+  whole row). New **CITY COLORS** note: 🟨 Amber on *City (New)* = net-new resolved
+  city; 🟩 light-green on *City (Existing)* = a real submitted city.
+- **HELPER COLUMNS** update: *Resolved City* now surfaces as *City (New)*; *City
+  (Existing)* = submitted dropdown.
+- **ORGANIZER REVIEW FLOW** (text/cell flowchart):
+
+  ```
+  Form submission → New
+     └ Review LinkedIn: credible organizer?  — no → Denied
+          │ yes
+          ▼  Tentative (vetted, not yet accepted)
+          ├ Prior organizer, existing chapter (MLOps) → Violet → Accepted (existing MLOps)
+          ├ Existing city, net-new → City (Existing) → intro chapter champs → interview → Accepted (after interview)
+          └ New city / new chapter → City (New) → interview → Accepted (after interview)
+     On final Accept (either) → grant: chapter Drive folder + local-champs channel + guidelines (confirm read & understood)
+  ```
+
+- Mirror the color + flow summary into `aaif-triage-intake/SKILL.md`'s Status-model
+  section so repo docs match the sheet.
+
+## Commits
+1. Part B edits + repo doc/flow updates (`clean.py`, `clean-data/SKILL.md`,
+   `intake.py`, `triage-intake/SKILL.md`).
+2. `aaif-backup` skill (+ `.gitignore`, `backups/README.md`).
+
+Part C is a live Drive write to the sheet, done after the code lands.

--- a/skills/aaif-backup/SKILL.md
+++ b/skills/aaif-backup/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: aaif-backup
+description: Take a versioned local backup of critical AAIF ops data — the Community Intake Ops sheet by default, or any Drive file / local file you name. Snapshots are immutable and timestamped so you keep a full history. Use when asked to back up / snapshot the intake data (or another file) before a risky edit.
+argument-hint: "[driveFileId | ./local/path]"
+---
+
+# Backup AAIF Ops Data
+
+Snapshot irreplaceable data to **local, versioned files** before risky edits (a bulk
+clean, a schema change, a column move). Every run writes a **new immutable file** —
+nothing is ever overwritten — so the backup folder is a full version history you can
+diff or restore from.
+
+Prereq: the `gws` CLI must be installed and authenticated (`gws-cli-access` memory) for
+Drive targets. Local-file backups need no auth.
+
+## Usage (engine: `scripts/backup.py`)
+
+```bash
+# default — back up the AAIF Community Intake Ops sheet (exported to .xlsx)
+python3 ${CLAUDE_SKILL_DIR}/scripts/backup.py
+
+# back up any Drive file by id (native Docs/Sheets/Slides -> .docx/.xlsx/.pptx)
+python3 ${CLAUDE_SKILL_DIR}/scripts/backup.py <driveFileId>
+
+# back up a local file (copied verbatim)
+python3 ${CLAUDE_SKILL_DIR}/scripts/backup.py ./path/to/file.xlsx
+
+# write snapshots somewhere other than ./backups
+python3 ${CLAUDE_SKILL_DIR}/scripts/backup.py --dest /some/dir
+```
+
+## Where snapshots land
+
+```
+<dest>/<slug>/<UTC-timestamp>.<ext>
+   e.g.  backups/aaif-community-intake-ops/2026-07-03T142530Z.xlsx
+```
+
+- `<dest>` defaults to **`./backups`** (relative to where you run it — inside the
+  `meetups/` repo when run from there). `backups/` is **git-ignored**, so the binary
+  snapshots never enter the repo.
+- Filenames are UTC timestamps, so a folder listing is the version history in order.
+- The target's type decides the format: a Google Sheet is exported to `.xlsx`, a Doc to
+  `.docx`, Slides to `.pptx`; already-binary Drive files and local files are copied as-is.
+
+## Restore (manual)
+
+There's no automated restore — it's a deliberate, eyes-open step:
+1. Pick the snapshot you want from `backups/<slug>/`.
+2. Re-upload it over the live file with `gws drive files update`
+   (`--upload <file> --upload-content-type <mime>`), or open the `.xlsx`/`.docx` and
+   copy the needed cells/sections back by hand.
+   For the Intake Ops sheet, prefer copying values back over replacing the file so the
+   role-tab formulas and conditional formats stay intact.
+
+## Notes
+
+- Default target is the Intake Ops sheet (id `1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o`),
+  the one source of applicant data that can't be regenerated.
+- Run this **before** `aaif-clean-data apply` or any bulk sheet edit.
+- Snapshots accumulate; prune old ones by hand if the folder grows large.

--- a/skills/aaif-backup/scripts/backup.py
+++ b/skills/aaif-backup/scripts/backup.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Snapshot critical AAIF ops data to local, versioned files.
+
+Default target is the AAIF Community Intake Ops sheet. Pass a target to back up any
+other file: a Google Drive fileId (native Docs/Sheets/Slides are exported to
+.docx/.xlsx/.pptx; already-binary Drive files are downloaded as-is) or a local path
+(copied verbatim).
+
+Every run writes a NEW immutable file — nothing is ever overwritten:
+    <dest>/<slug>/<UTC-timestamp>.<ext>
+so the folder is a full version history you can diff or restore from. <dest> defaults
+to ./backups (kept out of git); restore is manual (re-upload the .xlsx via gws).
+
+Usage:
+    backup.py                       # back up the Intake Ops sheet
+    backup.py <driveFileId>         # back up any Drive file by id
+    backup.py ./path/to/file.xlsx   # back up a local file
+    backup.py --dest /some/dir      # write snapshots under a different root
+"""
+import argparse, datetime, json, os, re, shutil, subprocess, sys
+
+# The one irreplaceable source of intake data — the default backup target.
+INTAKE_OPS_ID = "1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o"
+
+# Google-native mime type -> (export mime type, file extension).
+EXPORT = {
+    "application/vnd.google-apps.spreadsheet":
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx"),
+    "application/vnd.google-apps.document":
+        ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
+    "application/vnd.google-apps.presentation":
+        ("application/vnd.openxmlformats-officedocument.presentationml.presentation", "pptx"),
+}
+# Binary mime type -> extension, for files downloaded via alt=media as-is.
+BINARY_EXT = {
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+    "application/pdf": "pdf",
+}
+
+
+def gws_json(args):
+    """Run a gws command expecting JSON on stdout (skips the keyring banner line)."""
+    out = subprocess.run(["gws"] + args, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"gws error: {' '.join(args[:4])}...\n{out.stderr.strip()}")
+    txt = out.stdout
+    i = txt.find("{")
+    if i < 0:
+        sys.exit(f"gws returned no JSON (got: {txt.strip()[:200]!r})")
+    return json.loads(txt[i:])
+
+
+def gws_download(args):
+    """Run a gws command that writes bytes to --output; fail loudly on error."""
+    out = subprocess.run(["gws"] + args, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"gws error: {' '.join(args[:4])}...\n{out.stderr.strip()}")
+
+
+def slugify(name):
+    s = re.sub(r"[^\w.-]+", "-", name.strip()).strip("-.")
+    return (s or "backup").lower()
+
+
+def timestamp():
+    # UTC, filename-safe, sorts chronologically. Second resolution is plenty.
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+
+
+def snapshot_path(dest_root, slug, ext):
+    d = os.path.join(dest_root, slug)
+    os.makedirs(d, exist_ok=True)
+    return os.path.join(d, f"{timestamp()}.{ext}")
+
+
+def backup_local(path, dest_root):
+    if not os.path.isfile(path):
+        sys.exit(f"ABORT: local file not found: {path}")
+    base = os.path.basename(path)
+    slug = slugify(os.path.splitext(base)[0])
+    ext = base.rsplit(".", 1)[1] if "." in base else "bin"
+    out = snapshot_path(dest_root, slug, ext)
+    shutil.copy2(path, out)
+    return out
+
+
+def backup_drive(file_id, dest_root):
+    meta = gws_json(["drive", "files", "get", "--params",
+                     json.dumps({"fileId": file_id, "fields": "name,mimeType"}),
+                     "--format", "json"])
+    name, mime = meta.get("name", file_id), meta.get("mimeType", "")
+    slug = slugify(name)
+    if mime in EXPORT:
+        export_mime, ext = EXPORT[mime]
+        out = snapshot_path(dest_root, slug, ext)
+        gws_download(["drive", "files", "export", "--params",
+                      json.dumps({"fileId": file_id, "mimeType": export_mime}),
+                      "--output", out])
+    else:
+        ext = BINARY_EXT.get(mime, "bin")
+        out = snapshot_path(dest_root, slug, ext)
+        gws_download(["drive", "files", "get", "--params",
+                      json.dumps({"fileId": file_id, "alt": "media"}),
+                      "--output", out])
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Snapshot AAIF ops data to versioned files.")
+    ap.add_argument("target", nargs="?",
+                    help="Drive fileId or local path (default: Intake Ops sheet)")
+    ap.add_argument("--dest", default=os.path.join(os.getcwd(), "backups"),
+                    help="Root folder for snapshots (default: ./backups)")
+    a = ap.parse_args()
+    dest_root = os.path.abspath(a.dest)
+    if a.target and os.path.exists(a.target):
+        out = backup_local(a.target, dest_root)
+    else:
+        out = backup_drive(a.target or INTAKE_OPS_ID, dest_root)
+    size = os.path.getsize(out)
+    print(f"Backed up -> {out}  ({size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-backup/scripts/backup.py
+++ b/skills/aaif-backup/scripts/backup.py
@@ -8,8 +8,10 @@ other file: a Google Drive fileId (native Docs/Sheets/Slides are exported to
 
 Every run writes a NEW immutable file — nothing is ever overwritten:
     <dest>/<slug>/<UTC-timestamp>.<ext>
-so the folder is a full version history you can diff or restore from. <dest> defaults
-to ./backups (kept out of git); restore is manual (re-upload the .xlsx via gws).
+so the folder is a full version history you can diff or restore from (two runs of the
+same target within one second get a `-1`, `-2`, … suffix so neither clobbers the other).
+<dest> defaults to ./backups (kept out of git); restore is manual (re-upload the
+snapshot via gws).
 
 Usage:
     backup.py                       # back up the Intake Ops sheet
@@ -52,11 +54,22 @@ def gws_json(args):
     return json.loads(txt[i:])
 
 
-def gws_download(args):
-    """Run a gws command that writes bytes to --output; fail loudly on error."""
+def gws_download(args, out_path):
+    """Run a gws command that writes bytes to --output; fail loudly on error AND
+    on an empty result. A backup that silently produced a 0-byte file (e.g. Drive's
+    ~10MB export limit, or a dropped connection returning exit 0) is worse than an
+    error, so verify the snapshot is non-empty before we ever report success."""
     out = subprocess.run(["gws"] + args, capture_output=True, text=True)
     if out.returncode != 0:
         sys.exit(f"gws error: {' '.join(args[:4])}...\n{out.stderr.strip()}")
+    if not os.path.isfile(out_path) or os.path.getsize(out_path) == 0:
+        sys.exit(f"ABORT: backup wrote no data to {out_path} — the source may exceed "
+                 f"the export limit or the transfer failed. Snapshot NOT trustworthy.")
+
+
+# A Drive fileId is a run of URL-safe chars with no path separators or dots;
+# used to tell a fileId apart from a (possibly mistyped) local path.
+DRIVE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{20,}$")
 
 
 def slugify(name):
@@ -70,19 +83,30 @@ def timestamp():
 
 
 def snapshot_path(dest_root, slug, ext):
+    """A fresh, non-colliding path. Never returns a path that already exists, so
+    two runs in the same second can't overwrite each other (breaking "immutable")."""
     d = os.path.join(dest_root, slug)
     os.makedirs(d, exist_ok=True)
-    return os.path.join(d, f"{timestamp()}.{ext}")
+    stamp = timestamp()
+    p = os.path.join(d, f"{stamp}.{ext}")
+    n = 1
+    while os.path.exists(p):
+        p = os.path.join(d, f"{stamp}-{n}.{ext}")
+        n += 1
+    return p
 
 
 def backup_local(path, dest_root):
     if not os.path.isfile(path):
-        sys.exit(f"ABORT: local file not found: {path}")
+        what = "is a directory" if os.path.isdir(path) else "not found"
+        sys.exit(f"ABORT: local file {what}: {path}")
     base = os.path.basename(path)
     slug = slugify(os.path.splitext(base)[0])
     ext = base.rsplit(".", 1)[1] if "." in base else "bin"
     out = snapshot_path(dest_root, slug, ext)
     shutil.copy2(path, out)
+    if os.path.getsize(out) == 0:
+        sys.exit(f"ABORT: copied 0 bytes from {path} — snapshot NOT trustworthy.")
     return out
 
 
@@ -91,19 +115,23 @@ def backup_drive(file_id, dest_root):
                      json.dumps({"fileId": file_id, "fields": "name,mimeType"}),
                      "--format", "json"])
     name, mime = meta.get("name", file_id), meta.get("mimeType", "")
+    # A Google-native type we can't export (Forms, Drawings, Sites, Jamboard) is
+    # not fetchable via alt=media either — refuse rather than write a broken .bin.
+    if mime.startswith("application/vnd.google-apps.") and mime not in EXPORT:
+        sys.exit(f"ABORT: {name!r} is a {mime} — no export format; can't back it up here.")
     slug = slugify(name)
     if mime in EXPORT:
         export_mime, ext = EXPORT[mime]
         out = snapshot_path(dest_root, slug, ext)
         gws_download(["drive", "files", "export", "--params",
                       json.dumps({"fileId": file_id, "mimeType": export_mime}),
-                      "--output", out])
+                      "--output", out], out)
     else:
         ext = BINARY_EXT.get(mime, "bin")
         out = snapshot_path(dest_root, slug, ext)
         gws_download(["drive", "files", "get", "--params",
                       json.dumps({"fileId": file_id, "alt": "media"}),
-                      "--output", out])
+                      "--output", out], out)
     return out
 
 
@@ -115,10 +143,18 @@ def main():
                     help="Root folder for snapshots (default: ./backups)")
     a = ap.parse_args()
     dest_root = os.path.abspath(a.dest)
-    if a.target and os.path.exists(a.target):
+    # Dispatch explicitly so a mistyped local path can't silently fall through to
+    # Drive (and die with a cryptic 404): existing path -> local; a clean Drive-id
+    # shape -> Drive; anything else is a mistake, so say so.
+    if a.target is None:
+        out = backup_drive(INTAKE_OPS_ID, dest_root)
+    elif os.path.exists(a.target):
         out = backup_local(a.target, dest_root)
+    elif DRIVE_ID_RE.match(a.target):
+        out = backup_drive(a.target, dest_root)
     else:
-        out = backup_drive(a.target or INTAKE_OPS_ID, dest_root)
+        sys.exit(f"ABORT: {a.target!r} is neither an existing local file nor a "
+                 f"Drive fileId. Check the path, or pass a valid fileId.")
     size = os.path.getsize(out)
     print(f"Backed up -> {out}  ({size:,} bytes)")
 

--- a/skills/aaif-backup/scripts/test_backup.py
+++ b/skills/aaif-backup/scripts/test_backup.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import backup  # noqa: E402
+
+
+class TestSlugify(unittest.TestCase):
+    def test_normalizes_name(self):
+        self.assertEqual(backup.slugify("AAIF Community Intake Ops"),
+                         "aaif-community-intake-ops")
+
+    def test_collapses_runs_and_strips_edges(self):
+        self.assertEqual(backup.slugify("  --Foo!!Bar--  "), "foo-bar")
+
+    def test_empty_or_garbage_falls_back(self):
+        self.assertEqual(backup.slugify("   "), "backup")
+        self.assertEqual(backup.slugify("!!!"), "backup")
+
+
+class TestTimestamp(unittest.TestCase):
+    def test_utc_filename_safe_format(self):
+        self.assertRegex(backup.timestamp(), r"^\d{4}-\d{2}-\d{2}T\d{6}Z$")
+
+
+class TestSnapshotPath(unittest.TestCase):
+    def test_never_overwrites_within_same_second(self):
+        with tempfile.TemporaryDirectory() as d:
+            p1 = backup.snapshot_path(d, "s", "xlsx")
+            open(p1, "w").close()
+            p2 = backup.snapshot_path(d, "s", "xlsx")
+            self.assertNotEqual(p1, p2)
+            self.assertFalse(os.path.exists(p2))
+
+
+class TestBackupLocal(unittest.TestCase):
+    def test_copies_and_keeps_extension(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "thing.xlsx")
+            with open(src, "w") as f:
+                f.write("data")
+            out = backup.backup_local(src, os.path.join(d, "bk"))
+            self.assertTrue(out.endswith(".xlsx"))
+            self.assertTrue(os.path.isfile(out))
+
+    def test_no_extension_becomes_bin(self):
+        with tempfile.TemporaryDirectory() as d:
+            src = os.path.join(d, "noext")
+            with open(src, "w") as f:
+                f.write("x")
+            out = backup.backup_local(src, os.path.join(d, "bk"))
+            self.assertTrue(out.endswith(".bin"))
+
+    def test_missing_file_exits_not_silent(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(SystemExit):
+                backup.backup_local(os.path.join(d, "nope.xlsx"), d)
+
+
+class TestDriveIdDispatch(unittest.TestCase):
+    def test_id_shape_matches_but_paths_do_not(self):
+        self.assertTrue(backup.DRIVE_ID_RE.match(backup.INTAKE_OPS_ID))
+        self.assertIsNone(backup.DRIVE_ID_RE.match("./intake.xlsx"))
+        self.assertIsNone(backup.DRIVE_ID_RE.match("intake.xlsx"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-clean-data/SKILL.md
+++ b/skills/aaif-clean-data/SKILL.md
@@ -17,7 +17,7 @@ Prereq: the `gws` CLI must be installed and authenticated (`gws-cli-access` memo
 See `aaif-intake-ops-sheet` memory for the sheet's structure. All reads/writes go
 by **header name**, never column letter.
 
-## The three modes (engine: `scripts/clean.py`)
+## The modes (engine: `scripts/clean.py`)
 
 1. **Scan (default, read-only)** — detect & propose:
    ```bash
@@ -50,6 +50,19 @@ by **header name**, never column letter.
    surfaced by `scan`), so it never turns a row red. Already installed — re-run only
    to refresh after a column move.
 
+4. **Install-colors (maintenance)** — label the two city columns and provenance-color
+   the role tabs:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/clean.py install-colors
+   ```
+   Labels col G **`City (Existing)`** / col H **`City (New)`** and installs three
+   rules just **under** the bright-red error rule (so errors keep top priority):
+   **violet** whole-row when `Status = "Existing (from MLOps)"`, **amber** on
+   `City (New)` when it has a value (a net-new resolved city), and **green** on
+   `City (Existing)` when it holds a real city (non-empty, not "Other"). Idempotent —
+   it matches and refreshes its own rules by formula, safe to re-run after a column
+   move. `install-flags` now also runs this, so one command does the full setup.
+
 ## Procedure
 
 1. **Scan** and show the user the proposed mechanical fixes and the flags, grouped
@@ -58,10 +71,12 @@ by **header name**, never column letter.
    `City="Other"` row, read that person's free-text in `Form Responses` (their
    "Why organize / ties", "Have you helped run events before?", LinkedIn, etc.) and
    infer the real city — e.g. Bangalore, Frankfurt, Luxembourg. Write the inferred
-   value into the **`Resolved City`** column (a dedicated source column at `CE`),
-   **never overwrite the submitted `City` dropdown** — that's the non-destructive
-   rule. The role tabs show `Resolved City` right after `City`, and a row stops
-   being flagged once `Resolved City` is filled. Don't guess with no signal.
+   value into the **`Resolved City`** source column (now at `CF`; shown in the role
+   tabs as **`City (New)`**), **never overwrite the submitted `City` dropdown**
+   (shown as **`City (Existing)`**) — that's the non-destructive rule. `City (New)`
+   holds **only net-new cities** (rows where `City = "Other"`); existing form cities
+   stay in `City (Existing)` and must **not** be copied across. A row stops being
+   flagged once `Resolved City` is filled. Don't guess with no signal.
 3. **Confirm with the user** which fixes to apply. Mechanical fixes are safe to
    batch; city resolutions should be eyeballed since they're inferred.
 4. **Build `changes.json`** (rows + header names + new values) and run `apply`.

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -11,6 +11,8 @@ Subcommands:
                     "Autofixes" column (created if missing).
     install-flags   Add/refresh the live "Issues" column + bright-red row rule on the
                     role tabs (Organizers/Hosts/Speakers).
+    install-colors  Label City (Existing)/City (New) + (re)install the violet/
+                    amber/green provenance rules on the role tabs. Idempotent.
 
 Nothing is written unless you run `apply` or `install-flags`. `scan` only reports.
 """
@@ -30,6 +32,17 @@ EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 AUTOFIX_COL = "Autofixes"
 AUTOFIX_PHRASE = {"LinkedIn URL": "LinkedIn normalized", "Email": "email normalized",
                   "Full name": "name normalized", "Resolved City": "city resolved"}
+
+# ---------- role-tab provenance colors ----------
+# City (Existing) = col G (submitted dropdown); City (New) = col H (resolved
+# "Other" city). Fixed positions: the role-tab array formula emits
+# ...,City,Resolved City,... as adjacent columns, landing at G then H.
+CITY_EXISTING_COL, CITY_NEW_COL = 7, 8            # 1-based (G, H)
+VIOLET = {"red": 0.60, "green": 0.20, "blue": 0.90}   # Status = Existing (from MLOps)
+AMBER  = {"red": 0.99, "green": 0.76, "blue": 0.30}   # net-new resolved city
+GREEN  = {"red": 0.72, "green": 0.88, "blue": 0.70}   # existing form city
+COLOR_FORMULAS = {'=$A2="Existing (from MLOps)"', '=$H2<>""',
+                  '=AND($G2<>"",$G2<>"Other")'}
 
 
 # ---------- gws helpers ----------
@@ -162,7 +175,7 @@ def scan():
             flags.append({"row": rn, "who": who, "issue": f"LinkedIn not a profile URL: {row[li].strip()}"})
         resolved = (row[ri].strip() if ri is not None and ri < len(row) else "")
         if city.lower() == "other" and not resolved:
-            flags.append({"row": rn, "who": who, "issue": "city=Other (resolve into 'Resolved City' from their text)"})
+            flags.append({"row": rn, "who": who, "issue": "city=Other (resolve into 'City (New)' from their text)"})
         if email:
             seen_email.setdefault(email, []).append(rn)
     for email, rns in seen_email.items():
@@ -281,6 +294,67 @@ def install_flags():
                  json.dumps({"requests": [req, hdrfmt]}), "--format", "json"])
         print(f"{tab}: Issues column at {ilet}, bright-red rule "
               f"{'kept' if 'Issues' in hdr else 'added'}.")
+    install_colors()
+
+
+# ---------- install City (Existing)/City (New) labels + provenance colors ----------
+def _conditional_formats(sid):
+    """Return the conditionalFormats list for one role tab (by sheetId)."""
+    d = gws(["sheets", "spreadsheets", "get", "--params",
+             json.dumps({"spreadsheetId": SHEET_ID}), "--format", "json"])
+    for sh in d.get("sheets", []):
+        if sh["properties"]["sheetId"] == sid:
+            return sh.get("conditionalFormats", [])
+    return []
+
+
+def install_colors():
+    """Label the two city columns and (re)install violet/amber/green rules.
+
+    Idempotent: deletes the rules it owns (matched by formula) and re-adds them
+    just under the bright-red error rule, so error keeps top priority and the
+    city colors override the whole-row Status colors on their own columns.
+    """
+    for tab, sid in ROLE_TABS.items():
+        hdr, _ = read_tab(tab, "A1:BB")
+        lastcol = len(hdr)
+        gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
+             json.dumps({"spreadsheetId": SHEET_ID}), "--json",
+             json.dumps({"valueInputOption": "USER_ENTERED", "data": [
+                 {"range": f"{tab}!{colletter(CITY_EXISTING_COL)}1",
+                  "values": [["City (Existing)"]]},
+                 {"range": f"{tab}!{colletter(CITY_NEW_COL)}1",
+                  "values": [["City (New)"]]}]}), "--format", "json"])
+        cfs = _conditional_formats(sid)
+        def formula_of(cf):
+            c = cf.get("booleanRule", {}).get("condition", {})
+            vals = c.get("values", [])
+            return vals[0].get("userEnteredValue") if c.get("type") == "CUSTOM_FORMULA" and vals else None
+        stale = [i for i, cf in enumerate(cfs) if formula_of(cf) in COLOR_FORMULAS]
+        dels = [{"deleteConditionalFormatRule": {"sheetId": sid, "index": i}}
+                for i in sorted(stale, reverse=True)]
+        base = 1 if any(cf.get("booleanRule", {}).get("format", {})
+                        .get("backgroundColor") == BRIGHT_RED for cf in cfs) else 0
+        def rule(index, c0, c1, formula, bg, white=False):
+            fmt = {"backgroundColor": bg}
+            if white:
+                fmt["textFormat"] = {"foregroundColor": {"red": 1, "green": 1, "blue": 1}, "bold": True}
+            return {"addConditionalFormatRule": {"index": index, "rule": {
+                "ranges": [{"sheetId": sid, "startRowIndex": 1, "endRowIndex": 1000,
+                            "startColumnIndex": c0, "endColumnIndex": c1}],
+                "booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
+                                "values": [{"userEnteredValue": formula}]}, "format": fmt}}}}
+        adds = [
+            rule(base + 0, 0, lastcol, '=$A2="Existing (from MLOps)"', VIOLET, white=True),
+            rule(base + 1, CITY_NEW_COL - 1, CITY_NEW_COL, '=$H2<>""', AMBER),
+            rule(base + 2, CITY_EXISTING_COL - 1, CITY_EXISTING_COL,
+                 '=AND($G2<>"",$G2<>"Other")', GREEN),
+        ]
+        gws(["sheets", "spreadsheets", "batchUpdate", "--params",
+             json.dumps({"spreadsheetId": SHEET_ID}), "--json",
+             json.dumps({"requests": dels + adds}), "--format", "json"])
+        print(f"{tab}: labeled City (Existing)/City (New); "
+              f"{len(stale)} old rule(s) refreshed, 3 installed.")
 
 
 def main():
@@ -289,6 +363,7 @@ def main():
     sp = sub.add_parser("scan"); sp.add_argument("--json", action="store_true")
     ap_apply = sub.add_parser("apply"); ap_apply.add_argument("file")
     sub.add_parser("install-flags")
+    sub.add_parser("install-colors")
     a = ap.parse_args()
     if a.cmd == "scan":
         changes, flags = scan()
@@ -300,6 +375,8 @@ def main():
         apply(a.file)
     elif a.cmd == "install-flags":
         install_flags()
+    elif a.cmd == "install-colors":
+        install_colors()
 
 
 if __name__ == "__main__":

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -14,7 +14,8 @@ Subcommands:
     install-colors  Label City (Existing)/City (New) + (re)install the violet/
                     amber/green provenance rules on the role tabs. Idempotent.
 
-Nothing is written unless you run `apply` or `install-flags`. `scan` only reports.
+Nothing is written unless you run `apply`, `install-flags`, or `install-colors`.
+`scan` only reports.
 """
 import argparse, json, re, subprocess, sys
 
@@ -32,17 +33,6 @@ EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 AUTOFIX_COL = "Autofixes"
 AUTOFIX_PHRASE = {"LinkedIn URL": "LinkedIn normalized", "Email": "email normalized",
                   "Full name": "name normalized", "Resolved City": "city resolved"}
-
-# ---------- role-tab provenance colors ----------
-# City (Existing) = col G (submitted dropdown); City (New) = col H (resolved
-# "Other" city). Fixed positions: the role-tab array formula emits
-# ...,City,Resolved City,... as adjacent columns, landing at G then H.
-CITY_EXISTING_COL, CITY_NEW_COL = 7, 8            # 1-based (G, H)
-VIOLET = {"red": 0.60, "green": 0.20, "blue": 0.90}   # Status = Existing (from MLOps)
-AMBER  = {"red": 0.99, "green": 0.76, "blue": 0.30}   # net-new resolved city
-GREEN  = {"red": 0.72, "green": 0.88, "blue": 0.70}   # existing form city
-COLOR_FORMULAS = {'=$A2="Existing (from MLOps)"', '=$H2<>""',
-                  '=AND($G2<>"",$G2<>"Other")'}
 
 
 # ---------- gws helpers ----------
@@ -73,6 +63,57 @@ def colletter(n):  # 1-based -> A1 letter
         n, r = divmod(n - 1, 26)
         s = chr(65 + r) + s
     return s
+
+
+# ---------- role-tab provenance colors ----------
+# City (Existing) = col G (submitted dropdown); City (New) = col H (resolved
+# "Other" city). These two are addressed by fixed LETTER position — an explicit
+# exception to this module's usual header-name rule — because they are the
+# adjacent City,Resolved City pair the role-tab array formula always emits at
+# G then H. install_colors() guards that G/H really hold that pair before writing.
+CITY_EXISTING_COL, CITY_NEW_COL = 7, 8            # 1-based (G, H)
+VIOLET = {"red": 0.60, "green": 0.20, "blue": 0.90}   # Status = Existing (from MLOps)
+AMBER  = {"red": 0.99, "green": 0.76, "blue": 0.30}   # net-new resolved city
+GREEN  = {"red": 0.72, "green": 0.88, "blue": 0.70}   # existing form city
+# Build the three rule formulas ONCE from the column constants, so the set used
+# to detect our own rules (for idempotent refresh) can never drift from the set
+# used to install them.
+VIOLET_FORMULA = '=$A2="Existing (from MLOps)"'
+AMBER_FORMULA = f'=${colletter(CITY_NEW_COL)}2<>""'
+GREEN_FORMULA = (f'=AND(${colletter(CITY_EXISTING_COL)}2<>"",'
+                 f'${colletter(CITY_EXISTING_COL)}2<>"Other")')
+COLOR_FORMULAS = {VIOLET_FORMULA, AMBER_FORMULA, GREEN_FORMULA}
+# The two source-column headers we expect at G/H before (or after) labeling.
+CITY_SRC_HEADERS = ({"City", "City (Existing)"}, {"Resolved City", "City (New)"})
+
+
+def _rgb8(c):
+    """Quantize a color dict to 8-bit ints — Sheets round-trips colors at 8-bit,
+    so compare with this, never with exact float equality."""
+    return tuple(round(c.get(k, 0) * 255) for k in ("red", "green", "blue"))
+
+
+def formula_of(cf):
+    """The CUSTOM_FORMULA text of a conditional-format rule, or None."""
+    c = cf.get("booleanRule", {}).get("condition", {})
+    vals = c.get("values", [])
+    return vals[0].get("userEnteredValue") if c.get("type") == "CUSTOM_FORMULA" and vals else None
+
+
+def _is_red(cf):
+    """True if this rule is the bright-red error rule (matched by 8-bit color)."""
+    bg = cf.get("booleanRule", {}).get("format", {}).get("backgroundColor")
+    return bool(bg) and _rgb8(bg) == _rgb8(BRIGHT_RED)
+
+
+def color_rule_plan(cfs):
+    """Pure planner for install_colors: given a tab's conditionalFormats, return
+    (stale_indices_desc, base_index). stale = our own color rules to delete
+    (matched by formula); base = insert index just BELOW the bright-red error
+    rule so it keeps top priority. Testable without touching Sheets."""
+    stale = [i for i, cf in enumerate(cfs) if formula_of(cf) in COLOR_FORMULAS]
+    base = 1 if any(_is_red(cf) for cf in cfs) else 0
+    return sorted(stale, reverse=True), base
 
 
 # ---------- normalizers ----------
@@ -298,26 +339,52 @@ def install_flags():
 
 
 # ---------- install City (Existing)/City (New) labels + provenance colors ----------
-def _conditional_formats(sid):
-    """Return the conditionalFormats list for one role tab (by sheetId)."""
+def _all_conditional_formats():
+    """One spreadsheet fetch -> {sheetId: conditionalFormats}. Fetched once and
+    indexed, rather than re-fetching the whole spreadsheet per role tab."""
     d = gws(["sheets", "spreadsheets", "get", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--format", "json"])
-    for sh in d.get("sheets", []):
-        if sh["properties"]["sheetId"] == sid:
-            return sh.get("conditionalFormats", [])
-    return []
+    return {sh["properties"]["sheetId"]: sh.get("conditionalFormats", [])
+            for sh in d.get("sheets", [])}
+
+
+def _color_rule(sid, index, c0, c1, formula, bg, white=False):
+    """One addConditionalFormatRule request over 0-based half-open columns."""
+    fmt = {"backgroundColor": bg}
+    if white:
+        fmt["textFormat"] = {"foregroundColor": {"red": 1, "green": 1, "blue": 1}, "bold": True}
+    return {"addConditionalFormatRule": {"index": index, "rule": {
+        "ranges": [{"sheetId": sid, "startRowIndex": 1, "endRowIndex": 1000,
+                    "startColumnIndex": c0, "endColumnIndex": c1}],
+        "booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
+                        "values": [{"userEnteredValue": formula}]}, "format": fmt}}}}
 
 
 def install_colors():
     """Label the two city columns and (re)install violet/amber/green rules.
 
-    Idempotent: deletes the rules it owns (matched by formula) and re-adds them
-    just under the bright-red error rule, so error keeps top priority and the
-    city colors override the whole-row Status colors on their own columns.
+    Idempotent: deletes the rules it owns (matched by formula, via
+    `color_rule_plan`) and re-adds them just below the bright-red error rule so
+    the error keeps top priority. The violet whole-row rule sits above amber/
+    green, so on an "Existing (from MLOps)" row the whole row (city cells
+    included) reads violet — the Status color wins over the city colors where
+    they overlap.
     """
+    all_cfs = _all_conditional_formats()
     for tab, sid in ROLE_TABS.items():
         hdr, _ = read_tab(tab, "A1:BB")
         lastcol = len(hdr)
+        # Guard the fixed G/H positions before overwriting those header cells:
+        # bail loudly if a column move has shifted the City / Resolved City pair
+        # (accepts both the pre-label and already-labeled header text).
+        gcur = hdr[CITY_EXISTING_COL - 1] if len(hdr) >= CITY_EXISTING_COL else ""
+        hcur = hdr[CITY_NEW_COL - 1] if len(hdr) >= CITY_NEW_COL else ""
+        if gcur not in CITY_SRC_HEADERS[0] or hcur not in CITY_SRC_HEADERS[1]:
+            sys.exit(f"ABORT: {tab} G/H are {gcur!r}/{hcur!r}, not the expected "
+                     f"City / Resolved City pair — columns moved? Fix before recoloring.")
+        cfs = all_cfs.get(sid)
+        if cfs is None:
+            sys.exit(f"ABORT: sheetId {sid} ({tab}) not found in the spreadsheet.")
         gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",
              json.dumps({"valueInputOption": "USER_ENTERED", "data": [
@@ -325,30 +392,14 @@ def install_colors():
                   "values": [["City (Existing)"]]},
                  {"range": f"{tab}!{colletter(CITY_NEW_COL)}1",
                   "values": [["City (New)"]]}]}), "--format", "json"])
-        cfs = _conditional_formats(sid)
-        def formula_of(cf):
-            c = cf.get("booleanRule", {}).get("condition", {})
-            vals = c.get("values", [])
-            return vals[0].get("userEnteredValue") if c.get("type") == "CUSTOM_FORMULA" and vals else None
-        stale = [i for i, cf in enumerate(cfs) if formula_of(cf) in COLOR_FORMULAS]
+        stale, base = color_rule_plan(cfs)
         dels = [{"deleteConditionalFormatRule": {"sheetId": sid, "index": i}}
-                for i in sorted(stale, reverse=True)]
-        base = 1 if any(cf.get("booleanRule", {}).get("format", {})
-                        .get("backgroundColor") == BRIGHT_RED for cf in cfs) else 0
-        def rule(index, c0, c1, formula, bg, white=False):
-            fmt = {"backgroundColor": bg}
-            if white:
-                fmt["textFormat"] = {"foregroundColor": {"red": 1, "green": 1, "blue": 1}, "bold": True}
-            return {"addConditionalFormatRule": {"index": index, "rule": {
-                "ranges": [{"sheetId": sid, "startRowIndex": 1, "endRowIndex": 1000,
-                            "startColumnIndex": c0, "endColumnIndex": c1}],
-                "booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
-                                "values": [{"userEnteredValue": formula}]}, "format": fmt}}}}
+                for i in stale]
         adds = [
-            rule(base + 0, 0, lastcol, '=$A2="Existing (from MLOps)"', VIOLET, white=True),
-            rule(base + 1, CITY_NEW_COL - 1, CITY_NEW_COL, '=$H2<>""', AMBER),
-            rule(base + 2, CITY_EXISTING_COL - 1, CITY_EXISTING_COL,
-                 '=AND($G2<>"",$G2<>"Other")', GREEN),
+            _color_rule(sid, base + 0, 0, lastcol, VIOLET_FORMULA, VIOLET, white=True),
+            _color_rule(sid, base + 1, CITY_NEW_COL - 1, CITY_NEW_COL, AMBER_FORMULA, AMBER),
+            _color_rule(sid, base + 2, CITY_EXISTING_COL - 1, CITY_EXISTING_COL,
+                        GREEN_FORMULA, GREEN),
         ]
         gws(["sheets", "spreadsheets", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -110,9 +110,15 @@ def color_rule_plan(cfs):
     """Pure planner for install_colors: given a tab's conditionalFormats, return
     (stale_indices_desc, base_index). stale = our own color rules to delete
     (matched by formula); base = insert index just BELOW the bright-red error
-    rule so it keeps top priority. Testable without touching Sheets."""
+    rule so it keeps top priority — computed from the red rule's ACTUAL position
+    (not assumed to be index 0), adjusted for the stale rules deleted above it,
+    since deletes and adds run in one batch. Testable without touching Sheets."""
     stale = [i for i, cf in enumerate(cfs) if formula_of(cf) in COLOR_FORMULAS]
-    base = 1 if any(_is_red(cf) for cf in cfs) else 0
+    red = next((i for i, cf in enumerate(cfs) if _is_red(cf)), None)
+    if red is None:
+        base = 0
+    else:
+        base = red - sum(1 for s in stale if s < red) + 1
     return sorted(stale, reverse=True), base
 
 

--- a/skills/aaif-clean-data/scripts/test_clean.py
+++ b/skills/aaif-clean-data/scripts/test_clean.py
@@ -63,6 +63,20 @@ class TestColorRulePlan(unittest.TestCase):
         self.assertEqual(stale, [2, 1])   # descending, red at index 0 untouched
         self.assertEqual(base, 1)
 
+    def test_base_follows_red_when_not_first(self):
+        # red is NOT at index 0 (a Status color rule precedes it); we must still
+        # insert just below red, not at index 1.
+        other = _our_rule('=$A2="In progress"')   # not ours, not red -> not stale
+        stale, base = clean.color_rule_plan([other, _red_rule()])
+        self.assertEqual(stale, [])
+        self.assertEqual(base, 2)                  # just below red at index 1
+
+    def test_base_accounts_for_stale_deleted_above_red(self):
+        # a stale rule sits above red; deleting it shifts red up by one.
+        stale, base = clean.color_rule_plan([_our_rule(clean.AMBER_FORMULA), _red_rule()])
+        self.assertEqual(stale, [0])
+        self.assertEqual(base, 1)                  # red -> index 0 after delete, insert at 1
+
 
 class TestFormulaConsistency(unittest.TestCase):
     def test_detected_set_equals_installed_formulas(self):

--- a/skills/aaif-clean-data/scripts/test_clean.py
+++ b/skills/aaif-clean-data/scripts/test_clean.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import clean  # noqa: E402
+
+
+def _red_rule():
+    # Sheets round-trips BRIGHT_RED (0.91,0.26,0.21) at 8-bit: 232/66/54 over 255.
+    return {"booleanRule": {
+        "format": {"backgroundColor": {"red": 232 / 255, "green": 66 / 255, "blue": 54 / 255}},
+        "condition": {"type": "CUSTOM_FORMULA",
+                      "values": [{"userEnteredValue": '=$I2<>""'}]}}}
+
+
+def _our_rule(formula):
+    return {"booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
+            "values": [{"userEnteredValue": formula}]}}}
+
+
+class TestColletter(unittest.TestCase):
+    def test_city_columns_and_wraparound(self):
+        self.assertEqual(clean.colletter(7), "G")   # City (Existing)
+        self.assertEqual(clean.colletter(8), "H")   # City (New)
+        self.assertEqual(clean.colletter(27), "AA")
+
+
+class TestFormulaOf(unittest.TestCase):
+    def test_reads_custom_formula(self):
+        self.assertEqual(clean.formula_of(_our_rule('=$H2<>""')), '=$H2<>""')
+
+    def test_non_custom_and_empty_return_none(self):
+        self.assertIsNone(clean.formula_of({}))
+        self.assertIsNone(clean.formula_of({"booleanRule": {"condition": {
+            "type": "NUMBER_GREATER", "values": [{"userEnteredValue": "5"}]}}}))
+
+
+class TestIsRed(unittest.TestCase):
+    def test_matches_despite_8bit_quantization(self):
+        # The whole point: exact float equality would FAIL here; _is_red must not.
+        self.assertTrue(clean._is_red(_red_rule()))
+
+    def test_rejects_other_colors_and_missing_bg(self):
+        self.assertFalse(clean._is_red(_our_rule('=$H2<>""')))  # no backgroundColor
+        self.assertFalse(clean._is_red({"booleanRule": {"format": {
+            "backgroundColor": clean.VIOLET}}}))
+
+
+class TestColorRulePlan(unittest.TestCase):
+    def test_base_1_and_no_stale_when_only_red_present(self):
+        stale, base = clean.color_rule_plan([_red_rule()])
+        self.assertEqual(base, 1)      # our rules go BELOW the red rule
+        self.assertEqual(stale, [])
+
+    def test_base_0_when_no_red(self):
+        _, base = clean.color_rule_plan([])
+        self.assertEqual(base, 0)
+
+    def test_stale_lists_only_our_rules_descending(self):
+        cfs = [_red_rule(), _our_rule(clean.VIOLET_FORMULA), _our_rule(clean.AMBER_FORMULA)]
+        stale, base = clean.color_rule_plan(cfs)
+        self.assertEqual(stale, [2, 1])   # descending, red at index 0 untouched
+        self.assertEqual(base, 1)
+
+
+class TestFormulaConsistency(unittest.TestCase):
+    def test_detected_set_equals_installed_formulas(self):
+        # Guards the idempotency contract: the set used to find our rules must be
+        # exactly the formulas we install.
+        self.assertEqual(clean.COLOR_FORMULAS,
+                         {clean.VIOLET_FORMULA, clean.AMBER_FORMULA, clean.GREEN_FORMULA})
+        self.assertEqual(clean.AMBER_FORMULA, '=$H2<>""')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -18,14 +18,43 @@ sheet's structure.
 
 ## Status model (drives the queue and the sheet's cell colors)
 
-The five Status values (dropdown on column A, matched exactly by the sheet's
+The Status values (dropdown on column A, matched exactly by the sheet's
 whole-row colors): `New` (blue) → `In progress` (orange) → `Accepted` (green) /
-`Denied` (maroon); `Inactive` (gray). A **blank** Status cell is treated as `New`.
-Two overrides beat the status color: a **data error** (missing/invalid email or
-broken LinkedIn) paints the row bright red, and an **SLA breach** — a `New`/blank
+`Denied` (maroon); `Inactive` (gray); and `Existing (from MLOps)` (**violet**) for a
+prior organizer imported from the MLOps community. A **blank** Status cell is treated
+as `New`. Two overrides beat the status color: a **data error** (missing/invalid email
+or broken LinkedIn) paints the row bright red, and an **SLA breach** — a `New`/blank
 row older than 1 week (of a 2-week response SLA) — paints it pink. Acting on a row
 (moving it off `New`) clears the pink. Each role tab also has `Reviewed by`,
 `Reviewed at`, `Decision notes`, and a `Chapter` assignment.
+
+**City provenance colors** (on the two city columns, below the error rule; installed by
+`aaif-clean-data install-colors`): the role tabs show **`City (Existing)`** (col G, the
+submitted dropdown) and **`City (New)`** (col H, the resolved city for `Other` rows).
+`City (New)` is painted **amber** when it holds a net-new resolved city; `City
+(Existing)` is painted **green** when it holds a real submitted city (non-empty, not
+"Other"). These tell you at a glance whether an applicant is from an existing chapter
+city or a brand-new one.
+
+## Organizer review flow
+
+Every credible applicant goes to **Tentative** first — no one is accepted directly.
+MLOps veterans convert straight through; everyone else is accepted only **after an
+interview** (existing-city candidates also get an intro to the chapter champs):
+
+```
+Form submission ─→ New
+   └ Review LinkedIn: credible organizer?  ── no ─→ Denied
+        │ yes
+        ▼  Tentative (vetted, not yet accepted)
+        ├ Prior organizer, existing chapter (MLOps) → violet → Accepted (existing MLOps)
+        ├ Existing city, net-new → green City (Existing) → intro chapter champs → interview → Accepted (after interview)
+        └ New city / new chapter → amber City (New) → interview → Accepted (after interview)
+   On final Accept (either) ─→ grant: local chapter Drive folder + local-champs
+        channel + guidelines (confirm they've read & understood them)
+```
+
+The same flow (and colors) is documented on the sheet's **"How to use"** tab.
 
 ## Procedure
 

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -19,10 +19,12 @@ sheet's structure.
 ## Status model (drives the queue and the sheet's cell colors)
 
 The Status values (dropdown on column A, matched exactly by the sheet's
-whole-row colors): `New` (blue) → `In progress` (orange) → `Accepted` (green) /
-`Denied` (maroon); `Inactive` (gray); and `Existing (from MLOps)` (**violet**) for a
-prior organizer imported from the MLOps community. A **blank** Status cell is treated
-as `New`. Two overrides beat the status color: a **data error** (missing/invalid email
+whole-row colors): `New` (blue) → `In progress` (orange) → `Tentative` (teal) →
+`Accepted` (green) / `Denied` (maroon); `Inactive` (gray); and `Existing (from MLOps)`
+(**violet**) for a prior organizer imported from the MLOps community. `Tentative` is a
+real dropdown value: it marks a candidate who has passed LinkedIn vetting but isn't yet
+accepted (pending the interview / chapter-champs intro in the review flow below). A
+**blank** Status cell is treated as `New`. Two overrides beat the status color: a **data error** (missing/invalid email
 or broken LinkedIn) paints the row bright red, and an **SLA breach** — a `New`/blank
 row older than 1 week (of a 2-week response SLA) — paints it pink. Acting on a row
 (moving it off `New`) clears the pink. Each role tab also has `Reviewed by`,

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -16,8 +16,8 @@ import argparse, json, subprocess, sys
 SHEET_ID = "1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o"
 
 # Per-tab: the header names to surface in the digest (resolved by name).
-# Name / Email / LinkedIn / City are shown for every tab; these add the
-# distinctive, decision-relevant fields per applicant type.
+# Name / Email / LinkedIn / City (Existing) / City (New) are shown for every tab;
+# these add the distinctive, decision-relevant fields per applicant type.
 TABS = {
     "Organizers": ["Full name", "Email", "LinkedIn", "City (Existing)", "City (New)",
                    "Chapter / city wanted", "Technical expertise",
@@ -30,6 +30,12 @@ TABS = {
 
 # Rows in these Status states (or blank) are "awaiting review".
 DEFAULT_NEEDS_REVIEW = {"", "New", "In progress"}
+
+# The City columns were renamed to City (Existing)/City (New). They only carry
+# those headers after `aaif-clean-data install-colors` has run; until then the
+# role tabs still show the legacy City/Resolved City. Fall back so the digest
+# degrades to the old value instead of silently blanking every applicant's city.
+LEGACY_ALIASES = {"City (Existing)": "City", "City (New)": "Resolved City"}
 
 
 def fetch(tab):
@@ -88,6 +94,8 @@ def collect(status_filter, show_all):
             rec = {"row": rn, "status": status or "New"}
             for f in fields:
                 ci = col(headers, f)
+                if ci is None and f in LEGACY_ALIASES:
+                    ci = col(headers, LEGACY_ALIASES[f])
                 rec[f] = (row[ci].strip() if ci is not None else "")
             picked.append(rec)
         result[tab] = picked

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -19,12 +19,12 @@ SHEET_ID = "1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o"
 # Name / Email / LinkedIn / City are shown for every tab; these add the
 # distinctive, decision-relevant fields per applicant type.
 TABS = {
-    "Organizers": ["Full name", "Email", "LinkedIn", "City",
+    "Organizers": ["Full name", "Email", "LinkedIn", "City (Existing)", "City (New)",
                    "Chapter / city wanted", "Technical expertise",
                    "Run events before?", "Why organize / ties"],
-    "Hosts":      ["Name", "Email", "LinkedIn", "City", "Company",
+    "Hosts":      ["Name", "Email", "LinkedIn", "City (Existing)", "City (New)", "Company",
                    "Venue name", "Capacity", "Holds 30+?", "A/V available?"],
-    "Speakers":   ["Name", "Email", "LinkedIn", "City", "Headline",
+    "Speakers":   ["Name", "Email", "LinkedIn", "City (Existing)", "City (New)", "Headline",
                    "Talk title", "Ships in production?", "Past talks / portfolio"],
 }
 
@@ -110,9 +110,10 @@ def text_digest(data):
         for r in recs:
             name = r.get("Full name") or r.get("Name") or "(no name)"
             print(f"  • [{r['status']}] {name} — {r.get('Email','')}"
-                  f"  {r.get('City','')}  (row {r['row']})")
+                  f"  {(r.get('City (New)') or r.get('City (Existing)', ''))}  (row {r['row']})")
             for f, v in r.items():
-                if f in ("row", "status", "Full name", "Name", "Email", "City"):
+                if f in ("row", "status", "Full name", "Name", "Email",
+                         "City (Existing)", "City (New)"):
                     continue
                 if v:
                     print(f"      {f}: {truncate(v)}")

--- a/skills/aaif-triage-intake/scripts/test_intake.py
+++ b/skills/aaif-triage-intake/scripts/test_intake.py
@@ -1,0 +1,44 @@
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(__file__))
+import intake  # noqa: E402
+
+
+def _digest_of(rec):
+    data = {"Organizers": [rec], "Hosts": [], "Speakers": []}
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        intake.text_digest(data)
+    return buf.getvalue()
+
+
+BASE = {"row": 2, "status": "New", "Full name": "Ada", "Email": "ada@x.com"}
+
+
+class TestDigestCity(unittest.TestCase):
+    def test_shows_city_new_when_present(self):
+        out = _digest_of({**BASE, "City (Existing)": "Other", "City (New)": "Berlin"})
+        self.assertIn("Berlin", out)
+        self.assertNotIn("Other", out)
+
+    def test_falls_back_to_city_existing_when_new_blank(self):
+        out = _digest_of({**BASE, "City (Existing)": "Paris", "City (New)": ""})
+        self.assertIn("Paris", out)
+
+    def test_city_not_double_printed_in_detail_block(self):
+        out = _digest_of({**BASE, "City (Existing)": "Paris", "City (New)": ""})
+        self.assertEqual(out.count("Paris"), 1)
+
+
+class TestLegacyAliases(unittest.TestCase):
+    def test_new_headers_map_to_legacy(self):
+        self.assertEqual(intake.LEGACY_ALIASES["City (Existing)"], "City")
+        self.assertEqual(intake.LEGACY_ALIASES["City (New)"], "Resolved City")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Aligns the intake ops skills with the sheet's renamed city columns (**City (Existing)** / **City (New)**), codifies the role-tab provenance colors and the organizer review flow, and adds a new **`aaif-backup`** skill for versioned local snapshots. A self-review pass hardened the color-rule logic and backup safety and added unit tests; a Copilot review pass fixed the color-rule insertion index and promoted **Tentative** to a real Status value. Sheet/Drive-side changes were applied live (see Test Plan).

## Changesets

### 1. `docs: spec for new-city-fixes`
**Files:** `docs/superpowers/specs/2026-07-03-new-city-fixes-design.md`

### 2. `feat: City (Existing)/City (New) schema + provenance colors + review flow`
**Files:** `skills/aaif-clean-data/scripts/clean.py`, `skills/aaif-clean-data/SKILL.md`, `skills/aaif-triage-intake/scripts/intake.py`, `skills/aaif-triage-intake/SKILL.md`
`install-colors` subcommand (violet/amber/green below the bright-red rule); role tabs read City (Existing)/City (New); docs for colors + organizer review flow.

### 3. `feat: add aaif-backup skill for versioned local snapshots`
**Files:** `skills/aaif-backup/SKILL.md`, `skills/aaif-backup/scripts/backup.py`, `.gitignore`, `backups/README.md`, `README.md`
Default backs up the Intake Ops sheet (→ `.xlsx`); optional arg for any Drive fileId or local file; immutable timestamped snapshots; `backups/` git-ignored.

### 4. `fix: address self-review findings`
**Files:** `clean.py`, `intake.py`, `backup.py` + `test_clean.py`, `test_backup.py`, `test_intake.py`
Red-rule detected by 8-bit color (kept error priority); backups verified non-empty; violet-wins docstring; intake legacy-header fallback; header-name guard; collision-proof snapshots; 22 unit tests.

### 5. `fix: address PR review feedback (Copilot)`
**Files:** `clean.py`, `test_clean.py`, `triage-intake/SKILL.md`
- Insertion index computed from the red rule's actual position (not assumed index 0), adjusted for stale deletions; +2 tests (24 total).
- **Tentative** documented as a real Status value (teal): `New → In progress → Tentative → Accepted/Denied`.

## Test Plan
- [x] `python3 -m pytest skills/*/scripts/test_*.py` — 24 pass; pre-commit green.
- [ ] `clean.py install-colors` applies violet/amber/green + City labels to the role tabs (not yet run live).
- [x] `backup.py` writes a non-empty snapshot to `backups/` (219KB `.xlsx`).
- [x] Intake Ops **"How to use"** tab: violet + teal (Tentative) legend, CITY COLORS, ORGANIZER REVIEW FLOW.
- [x] **Tentative** made real on the sheet: added to the Status dropdown on all 3 role tabs, teal whole-row rule, legend entry.
- [x] Luma clone-URL swapped `ia70fwmm → ps5dw7gm` across all 42 Event Trackers (chapter links untouched).

---
Generated with [Claude Code](https://claude.ai/code)