### PR TITLE
feat(create-chapter): auto-place slide-5 map dot for new cities

### DIFF
--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -30,6 +30,15 @@ not touch it.
 | `SF` abbreviation (`AAIF · SF`, `SF CHAPTER`, `About the AAIF SF Chapter`, `AAIF SF — Attendee CRM`, doc metadata) | full city name | **UPPER** in all-caps contexts, **Title case** in prose |
 | `aaif-sanfrancisco` / `AAIF-SANFRANCISCO` (Luma slug, incl. hyperlink targets) | `aaif-<slug>` / `AAIF-<SLUG>` | see slug rules below |
 
+Beyond text, the script also **repositions the green "you-are-here" dot and its
+`<CITY> · TONIGHT` label** on slide 5 ("THE NETWORK") of `Event Template/Slides.pptx`
+to the new city's real place on the world map. Previously only the label text was
+rebranded and the dot stayed parked at San Francisco — this closes that gap. The
+city's coordinates come from `--lat`/`--lon` if given, otherwise from geocoding the
+city name (Nominatim, keyless). If neither resolves (offline, or a fictional name),
+the dot is left at San Francisco with a clear warning — chapter creation never
+fails over the dot. See **Map dot coordinates** below.
+
 ## Luma slug rules
 
 - Default slug = city lowercased, spaces/accents removed: `New York → newyork`,
@@ -41,6 +50,24 @@ not touch it.
   `LU.MA / AAIF-<SLUG>`; keep that — only the slug changes.
 - The script **cannot create the Luma page** (that's done manually at luma.com).
   It checks whether the page is live and warns if not.
+
+## Map dot coordinates
+
+The slide-5 network-map dot is placed from the city's latitude/longitude:
+
+- **Default:** the script geocodes the `--city` name via Nominatim (keyless, no
+  key/setup). The dry run prints the resolved `Coords:` line so you can sanity-check
+  it before creating anything.
+- **Override:** pass `--lat <deg> --lon <deg>` (both required together) to skip
+  geocoding — useful when a city name is ambiguous or geocodes to the wrong place.
+- **Fallback:** if geocoding returns nothing or the service is unreachable and no
+  override was given, the dot is left at San Francisco and a warning is printed. The
+  chapter is still created; just fix slide 5's dot manually (or re-run with `--lat`/`--lon`).
+
+The projection is calibrated to the **current** `image18.png` world map. East-Asia /
+Oceania cities are drawn distorted and use a per-city `PIXEL_OVERRIDES` table in the
+script (seeded with Seoul, Sydney, Melbourne). If a new such city lands off, add an
+override (see Verify) and re-run.
 
 ## Procedure
 
@@ -69,6 +96,15 @@ not touch it.
 
 4. **Verify.** Confirm the run printed no `!! residual` flags and report the new
    folder URL to the user. If the Luma page wasn't live, remind them to create it.
+   Open slide 5 ("THE NETWORK") of `Event Template/Slides.pptx` and confirm the
+   green dot sits on the correct city (the `Slides.pptx` line shows `+map dot` when
+   it was moved). If the city is in **East Asia / Oceania** and the dot looks off,
+   add a `PIXEL_OVERRIDES` entry in `create_chapter.py` (pixel coords on the
+   1123×794 `image18.png`) and re-run. To recalibrate against a render:
+   ```bash
+   # macOS: /Applications/LibreOffice.app/Contents/MacOS/soffice
+   soffice --headless --convert-to pdf --outdir . Slides.pptx   # check page 5
+   ```
 
 ## How it works / maintenance
 
@@ -78,12 +114,23 @@ robust to OOXML run-splitting. The `SF`-abbreviation casing is decided by the
 surrounding words. The Drive layer uses `gws` (`files.copy`, `create`, `get`,
 `update`).
 
+The slide-5 map dot is placed by `reposition_map_marker` using a lat/lon →
+pixel projection (`lon2x` linear; `lat2y` piecewise-linear via `LAT_ANCHORS`;
+`PIXEL_OVERRIDES` for the distorted western Pacific). The anchors are calibrated
+to the current `image18.png`; **if the template's map image changes, recalibrate**
+by rendering slide 5 to PDF (see Verify) and adjusting `LAT_ANCHORS` / `lon2x` /
+overrides until candidate dots sit on the coastlines. `scripts/test_create_chapter.py`
+covers the San Francisco self-check, the label offset, the override table, and the
+2-shapes-or-raise guard.
+
 To validate the engine after any edit, rebrand a throwaway copy of the template
 and diff it against an existing chapter (the canonical end-state):
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/create_chapter.py \
-    --city "Los Angeles" --rebrand-local /path/to/template-copy
-# then compare paragraph text against the real Los Angeles chapter
+    --city "Los Angeles" --lat 34.05 --lon -118.24 --rebrand-local /path/to/template-copy
+# then compare paragraph text against the real Los Angeles chapter, and open
+# slide 5 of the rebranded Slides.pptx to confirm the dot moved (+map dot).
+python3 ${CLAUDE_SKILL_DIR}/scripts/test_create_chapter.py   # unit tests
 ```
 
 Constants (Chapters parent id, TemplateCity id) live at the top of the script.

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-create-chapter
 description: Create a new AAIF city chapter in the "Chapters" Google Drive by cloning TemplateCity and rebranding all assets. Use when asked to add/launch/set up a new AAIF city, chapter, or location.
-argument-hint: '<City Name> [--slug <lumaslug>]'
+argument-hint: '<City Name> [--slug <lumaslug>] [--lat <deg> --lon <deg>]'
 ---
 
 # Create AAIF Chapter

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -24,7 +24,7 @@ Usage:
   # Test the text engine on a local folder of .pptx/.docx/.xlsx (no Drive):
   python create_chapter.py --city "Los Angeles" --rebrand-local ./somedir
 """
-import argparse, html, json, os, re, subprocess, sys, time, unicodedata, urllib.error, urllib.request, zipfile
+import argparse, html, json, os, re, subprocess, sys, time, unicodedata, urllib.error, urllib.parse, urllib.request, zipfile
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
 TEMPLATE_FOLDER = "1PHvEgqnHo0RrsFyA47O9iRJGaKehC8Eg"   # the "TemplateCity" folder
@@ -159,6 +159,157 @@ def residual_tokens(path):
     return hits
 
 # ----------------------------------------------------------------------------
+# Network-map marker placement (slide 5 "THE NETWORK" of Event Template/Slides.pptx)
+#
+# The template's world map (ppt/media/image18.png, 1123x794 px) carries a green
+# "you-are-here" dot + a "<CITY> · TONIGHT" label, both parked at San Francisco.
+# rebrand_file fixes the label *text*; this moves the green shapes to the new city.
+# The projection anchors/overrides below are calibrated to the *current* image18.png
+# — if the template's map image changes, recalibrate (see SKILL.md "Verify").
+# ----------------------------------------------------------------------------
+SLIDE5 = "ppt/slides/slide5.xml"
+GREEN = "14964A"                       # AAIF green fill on both marker shapes
+DOT_SIZE = 155448                      # dot ext cx=cy, EMU
+MAP_OFF = (3246120, 1234440)           # world-map picture off, EMU
+MAP_EXT = (5394960, 3814424)           # world-map picture ext, EMU
+MAP_PX = (1123, 794)                   # world-map picture size, px
+LABEL_DX, LABEL_DY = -425196, 224028   # label-corner minus dot-corner (SF template)
+# The dot is the small square green shape; the label is the wide text box. The dot
+# carries an EMPTY <a:t></a:t>, so text presence can't tell them apart — discriminate
+# by the dot's 155448x155448 ext (its signature).
+DOT_EXT_RE = re.compile(r'<a:ext cx="%d" cy="%d"\s*/>' % (DOT_SIZE, DOT_SIZE))
+
+# Longitude: linear (verified on SF, London, Gibraltar, Tokyo).
+def lon2x(lon):
+    return 2.676 * lon + 516.3
+
+# Latitude: NONLINEAR (the map compresses toward the poles) — piecewise-linear.
+LAT_ANCHORS = [(64.8, 205), (51.5, 253), (37.77, 311), (25.1, 345),
+               (0.0, 398), (-34.8, 525), (-55.9, 597)]
+
+def lat2y(lat):
+    a = LAT_ANCHORS
+    if lat >= a[0][0]:
+        (l0, y0), (l1, y1) = a[0], a[1]
+    elif lat <= a[-1][0]:
+        (l0, y0), (l1, y1) = a[-2], a[-1]
+    else:
+        for i in range(len(a) - 1):
+            if a[i][0] >= lat >= a[i + 1][0]:
+                (l0, y0), (l1, y1) = a[i], a[i + 1]
+                break
+    return y0 + (lat - l0) / (l1 - l0) * (y1 - y0)
+
+# The western Pacific is drawn distorted (Tokyo ~140°E and Sydney ~151°E land at
+# nearly the same x), so a separable projection can't place East-Asia/Oceania by
+# formula. Keep a per-city pixel override table, seeded with the known cases.
+PIXEL_OVERRIDES = {"Seoul": (822, 305), "Sydney": (870, 512), "Melbourne": (836, 543)}
+
+def project_city(name, lat, lon):
+    """Map a city to (x, y) pixels on image18.png (override table first)."""
+    if name in PIXEL_OVERRIDES:
+        return PIXEL_OVERRIDES[name]
+    return lon2x(lon), lat2y(lat)
+
+def marker_offsets(name, lat, lon):
+    """Return (dot_off, label_off) in EMU for a city, matching the SF template's
+    relative label placement. Self-check: San Francisco (37.77, -122.42)
+    reproduces the real template/chapter dot off (4074942, 2650779)."""
+    px, py = project_city(name, lat, lon)
+    cx = MAP_OFF[0] + px * (MAP_EXT[0] / MAP_PX[0])   # dot CENTER, EMU
+    cy = MAP_OFF[1] + py * (MAP_EXT[1] / MAP_PX[1])
+    dot_off = (round(cx - DOT_SIZE / 2), round(cy - DOT_SIZE / 2))
+    label_off = (dot_off[0] + LABEL_DX, dot_off[1] + LABEL_DY)
+    return dot_off, label_off
+
+def reposition_map_marker(path, city, lat, lon):
+    """Move the green dot + its label on slide 5 of a .pptx to (lat, lon).
+
+    Returns the number of shapes moved (2 on success) or 0 when there is nothing
+    to move (slide 5 absent, or it has no green marker shapes). Raises if green
+    shapes are present but not exactly 2 can be moved — a template drift the
+    caller should surface loudly, mirroring the residual-token check."""
+    with zipfile.ZipFile(path) as z:
+        if SLIDE5 not in z.namelist():
+            print("      note: %s has no %s; leaving map dot as-is."
+                  % (os.path.basename(path), SLIDE5))
+            return 0
+        xml = z.read(SLIDE5).decode("utf-8")
+
+    dot_off, label_off = marker_offsets(city, lat, lon)
+    off_re = re.compile(r'<a:off x="-?\d+" y="-?\d+"/>')
+    sp_re = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)   # slide 5 shapes are flat
+
+    green = moved = 0
+    def move_sp(m):
+        nonlocal green, moved
+        block = m.group(0)
+        if GREEN not in block:
+            return block
+        green += 1
+        off = dot_off if DOT_EXT_RE.search(block) else label_off
+        block, n = off_re.subn('<a:off x="%d" y="%d"/>' % off, block, count=1)
+        moved += n
+        return block
+
+    new_xml = sp_re.sub(move_sp, xml)
+    if green == 0:
+        print("      note: slide 5 has no green (%s) marker shapes; "
+              "leaving map dot as-is." % GREEN)
+        return 0
+    if moved != 2:
+        raise RuntimeError(
+            "slide 5: expected to move exactly 2 green marker shapes, moved %d "
+            "of %d green shape(s) — template drift? Re-check reposition_map_marker."
+            % (moved, green))
+
+    tmp = path + ".new"
+    with zipfile.ZipFile(path) as zin, \
+            zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
+        for it in zin.infolist():
+            data = new_xml.encode("utf-8") if it.filename == SLIDE5 else zin.read(it.filename)
+            zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
+            zi.compress_type = it.compress_type
+            zi.external_attr = it.external_attr
+            zout.writestr(zi, data)
+    if zipfile.ZipFile(tmp).testzip() is not None:
+        os.remove(tmp); raise RuntimeError("repackaged zip failed validation: " + path)
+    os.replace(tmp, path)
+    return moved
+
+def geocode_city(name, retries=3):
+    """Resolve (lat, lon) for a city name via Nominatim (keyless), or None if it
+    cannot be found or the service is unreachable. Retries transient errors in
+    the same style as the gws helpers."""
+    url = "https://nominatim.openstreetmap.org/search?" + urllib.parse.urlencode(
+        {"q": name, "format": "json", "limit": 1})
+    req = urllib.request.Request(url, headers={   # Nominatim requires a UA
+        "User-Agent": "aaif-create-chapter/1.0 (AAIF chapter cloner; +https://github.com/aaif/meetups)"})
+    for i in range(retries):
+        try:
+            with urllib.request.urlopen(req, timeout=15) as r:
+                data = json.loads(r.read().decode("utf-8"))
+            if data:
+                return float(data[0]["lat"]), float(data[0]["lon"])
+            return None   # empty result -> genuinely un-geocodable (e.g. "Tatooine")
+        except Exception:
+            if i < retries - 1:
+                time.sleep(2 * (i + 1))
+                continue
+            return None
+    return None
+
+def resolve_latlon(name, lat, lon):
+    """Pick coordinates for the map dot: explicit --lat/--lon override first,
+    else geocode the city name. Returns (lat, lon) or None (dot stays at SF)."""
+    if lat is not None and lon is not None:
+        return (lat, lon)
+    if lat is not None or lon is not None:
+        print("WARNING: --lat and --lon must be given together; ignoring the lone "
+              "value and geocoding %r instead." % name)
+    return geocode_city(name)
+
+# ----------------------------------------------------------------------------
 # Drive helpers (via the gws CLI)
 # ----------------------------------------------------------------------------
 _TRANSIENT = ("timed out", "internalError", "HTTP request failed",
@@ -255,13 +406,21 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent=""):
                 tmp = os.path.join(ctx["tmp"], "f" + copy_id + ext)
                 gws_download(copy_id, tmp)
                 n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
-                if n:
+                # Slides.pptx carries the network-map dot on slide 5; move it to
+                # the new city when we have coordinates (rebrand_file only fixed
+                # the label text). Gate the upload on either change.
+                if cname == "Slides.pptx" and ctx.get("latlon"):
+                    moved = reposition_map_marker(tmp, ctx["name"], *ctx["latlon"])
+                else:
+                    moved = 0
+                if n or moved:
                     gws_upload(copy_id, tmp, MIME_BY_EXT[ext])
                 left = residual_tokens(tmp)
                 if left:
                     ctx["residuals"].append((cname, left))
                 flag = "  !! residual %s" % left if left else ""
-                print("%s  - %s (%d parts)%s" % (indent, cname, n, flag))
+                dot = " +map dot" if moved else ""
+                print("%s  - %s (%d parts%s)%s" % (indent, cname, n, dot, flag))
                 os.remove(tmp)
             else:
                 print("%s  - %s (copied)" % (indent, cname))
@@ -272,6 +431,8 @@ def main():
     ap.add_argument("--city", required=True, help='Full city name, e.g. "New York"')
     ap.add_argument("--slug", help="Luma slug override (default: city, lowercased, no spaces)")
     ap.add_argument("--dry-run", action="store_true", help="Plan only; create nothing")
+    ap.add_argument("--lat", type=float, help="City latitude (use with --lon) to override geocoding of the map dot")
+    ap.add_argument("--lon", type=float, help="City longitude (use with --lat) to override geocoding of the map dot")
     ap.add_argument("--rebrand-local", metavar="DIR",
                     help="Rebrand .pptx/.docx/.xlsx in a local dir (no Drive); for testing")
     a = ap.parse_args()
@@ -283,6 +444,15 @@ def main():
     print("Upper: %s" % upper)
     print("Slug : aaif-%s  ->  https://luma.com/aaif-%s" % (slug, slug))
 
+    # Coordinates for the slide-5 network-map dot (override -> geocode -> none).
+    latlon = resolve_latlon(name, a.lat, a.lon)
+    if latlon:
+        src = "override" if (a.lat is not None and a.lon is not None) else "geocoded"
+        print("Coords: %.4f, %.4f (%s)" % (latlon[0], latlon[1], src))
+    else:
+        print("Coords: -- could not resolve %r; the slide-5 map dot will stay at "
+              "San Francisco (fix it manually, or re-run with --lat/--lon)." % name)
+
     if a.rebrand_local:
         residual_any = False
         for root, _d, files in os.walk(a.rebrand_local):
@@ -290,10 +460,13 @@ def main():
                 if os.path.splitext(f)[1].lower() in MIME_BY_EXT:
                     p = os.path.join(root, f)
                     n = rebrand_file(p, name, upper, slug)
+                    moved = reposition_map_marker(p, name, *latlon) \
+                        if f == "Slides.pptx" and latlon else 0
                     left = residual_tokens(p)
                     if left:
                         residual_any = True
-                    print("  %s: %d parts%s" % (f, n, ("  !! " + str(left)) if left else ""))
+                    print("  %s: %d parts%s%s" % (f, n, " +map dot" if moved else "",
+                                                  ("  !! " + str(left)) if left else ""))
         if residual_any:
             sys.exit("FAIL: residual source tokens remain after rebrand (see !! above).")
         return
@@ -318,7 +491,7 @@ def main():
             print("[dry-run] NOTE: could not verify the Luma page aaif-%s; check it manually." % slug)
         return
 
-    ctx = {"name": name, "upper": upper, "slug": slug, "residuals": [],
+    ctx = {"name": name, "upper": upper, "slug": slug, "residuals": [], "latlon": latlon,
            "tmp": os.path.join(os.environ.get("TMPDIR", "/tmp"), "aaif_chapter")}
     os.makedirs(ctx["tmp"], exist_ok=True)
     print()

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -125,26 +125,32 @@ def rebrand_part(part_name, data, name, upper, newslug):
         return data
     return xml.encode("utf-8")
 
-def rebrand_file(path, name, upper, newslug):
-    """Rewrite an .pptx/.docx/.xlsx in place. Returns number of parts changed."""
+def _rewrite_zip(path, transform):
+    """Rewrite an OOXML zip in place, mapping each member's bytes through
+    transform(name, data) -> bytes while preserving its ZipInfo, then validating
+    the repackaged zip with testzip(). Returns the number of members whose bytes
+    changed. On a bad repack, removes the temp file and raises (original intact)."""
     tmp = path + ".new"
-    zin = zipfile.ZipFile(path, "r")
-    zout = zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED)
     changed = 0
-    for it in zin.infolist():
-        data = zin.read(it.filename)
-        new = rebrand_part(it.filename, data, name, upper, newslug)
-        if new != data:
-            changed += 1
-        zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
-        zi.compress_type = it.compress_type
-        zi.external_attr = it.external_attr
-        zout.writestr(zi, new)
-    zin.close(); zout.close()
+    with zipfile.ZipFile(path) as zin, \
+            zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
+        for it in zin.infolist():
+            data = zin.read(it.filename)
+            new = transform(it.filename, data)
+            if new != data:
+                changed += 1
+            zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
+            zi.compress_type = it.compress_type
+            zi.external_attr = it.external_attr
+            zout.writestr(zi, new)
     if zipfile.ZipFile(tmp).testzip() is not None:
         os.remove(tmp); raise RuntimeError("repackaged zip failed validation: " + path)
     os.replace(tmp, path)
     return changed
+
+def rebrand_file(path, name, upper, newslug):
+    """Rewrite an .pptx/.docx/.xlsx in place. Returns number of parts changed."""
+    return _rewrite_zip(path, lambda n, d: rebrand_part(n, d, name, upper, newslug))
 
 def residual_tokens(path):
     """List any stale San Francisco / SF / aaif-sf tokens still present."""
@@ -200,13 +206,16 @@ def lat2y(lat):
                 break
     return y0 + (lat - l0) / (l1 - l0) * (y1 - y0)
 
-# The western Pacific is drawn distorted (Tokyo ~140°E and Sydney ~151°E land at
-# nearly the same x), so a separable projection can't place East-Asia/Oceania by
-# formula. Keep a per-city pixel override table, seeded with the known cases.
+# The western Pacific is drawn distorted: Sydney (~151°E) and Melbourne (~145°E)
+# are dragged WEST to nearly Tokyo's x, so a separable lon/lat projection can't
+# place East-Asia/Oceania. (Tokyo itself IS placed correctly by the linear
+# formula and needs no override — it's only the landmark showing how far west the
+# others land.) Keep a per-city pixel override table for the cities that need it.
 PIXEL_OVERRIDES = {"Seoul": (822, 305), "Sydney": (870, 512), "Melbourne": (836, 543)}
 
 def project_city(name, lat, lon):
-    """Map a city to (x, y) pixels on image18.png (override table first)."""
+    """Map a city to (x, y) pixels on image18.png. Overridden cities take their
+    pixel from the table and IGNORE lat/lon (the map is non-separable there)."""
     if name in PIXEL_OVERRIDES:
         return PIXEL_OVERRIDES[name]
     return lon2x(lon), lat2y(lat)
@@ -226,9 +235,11 @@ def reposition_map_marker(path, city, lat, lon):
     """Move the green dot + its label on slide 5 of a .pptx to (lat, lon).
 
     Returns the number of shapes moved (2 on success) or 0 when there is nothing
-    to move (slide 5 absent, or it has no green marker shapes). Raises if green
-    shapes are present but not exactly 2 can be moved — a template drift the
-    caller should surface loudly, mirroring the residual-token check."""
+    to move (slide 5 absent, or it has no green marker shapes). Raises when slide 5
+    does NOT have exactly one green dot and one green label whose offsets both get
+    rewritten — checking *identity* (one of each), not just the move count, so
+    template drift fails loudly instead of silently stacking the two markers. Like
+    rebrand_file, this raises mid-run; callers clean up the temp file in a finally."""
     with zipfile.ZipFile(path) as z:
         if SLIDE5 not in z.namelist():
             print("      note: %s has no %s; leaving map dot as-is."
@@ -237,19 +248,26 @@ def reposition_map_marker(path, city, lat, lon):
         xml = z.read(SLIDE5).decode("utf-8")
 
     dot_off, label_off = marker_offsets(city, lat, lon)
-    off_re = re.compile(r'<a:off x="-?\d+" y="-?\d+"/>')
-    sp_re = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)   # slide 5 shapes are flat
+    off_re = re.compile(r'<a:off x="-?\d+" y="-?\d+"\s*/>')   # tolerate a re-saved " />"
+    sp_re = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)      # slide 5 shapes are flat
 
-    green = moved = 0
+    green = 0
+    dot_moved = label_moved = 0
     def move_sp(m):
-        nonlocal green, moved
+        nonlocal green, dot_moved, label_moved
         block = m.group(0)
         if GREEN not in block:
             return block
         green += 1
-        off = dot_off if DOT_EXT_RE.search(block) else label_off
-        block, n = off_re.subn('<a:off x="%d" y="%d"/>' % off, block, count=1)
-        moved += n
+        # The dot is the small square shape; the label is the wide text box.
+        is_dot = bool(DOT_EXT_RE.search(block))
+        block, n = off_re.subn(
+            '<a:off x="%d" y="%d"/>' % (dot_off if is_dot else label_off),
+            block, count=1)
+        if is_dot:
+            dot_moved += n
+        else:
+            label_moved += n
         return block
 
     new_xml = sp_re.sub(move_sp, xml)
@@ -257,30 +275,23 @@ def reposition_map_marker(path, city, lat, lon):
         print("      note: slide 5 has no green (%s) marker shapes; "
               "leaving map dot as-is." % GREEN)
         return 0
-    if moved != 2:
+    if dot_moved != 1 or label_moved != 1:
         raise RuntimeError(
-            "slide 5: expected to move exactly 2 green marker shapes, moved %d "
-            "of %d green shape(s) — template drift? Re-check reposition_map_marker."
-            % (moved, green))
+            "slide 5: expected exactly one green dot and one green label to move, "
+            "but moved %d dot + %d label of %d green shape(s) — template drift? "
+            "Re-check reposition_map_marker / DOT_EXT_RE."
+            % (dot_moved, label_moved, green))
 
-    tmp = path + ".new"
-    with zipfile.ZipFile(path) as zin, \
-            zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
-        for it in zin.infolist():
-            data = new_xml.encode("utf-8") if it.filename == SLIDE5 else zin.read(it.filename)
-            zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
-            zi.compress_type = it.compress_type
-            zi.external_attr = it.external_attr
-            zout.writestr(zi, data)
-    if zipfile.ZipFile(tmp).testzip() is not None:
-        os.remove(tmp); raise RuntimeError("repackaged zip failed validation: " + path)
-    os.replace(tmp, path)
-    return moved
+    _rewrite_zip(path, lambda n, d: new_xml.encode("utf-8") if n == SLIDE5 else d)
+    return dot_moved + label_moved
 
 def geocode_city(name, retries=3):
-    """Resolve (lat, lon) for a city name via Nominatim (keyless), or None if it
-    cannot be found or the service is unreachable. Retries transient errors in
-    the same style as the gws helpers."""
+    """Resolve (lat, lon) for a city name via Nominatim (keyless), or None if the
+    city can't be found or the service is unreachable. Retries ONLY transient
+    network errors; an empty result is treated as un-geocodable, and an
+    unexpected response shape (API change / captcha page) is reported distinctly
+    rather than masked as a missing city. Either way the caller leaves the dot at
+    San Francisco — geocoding never fails chapter creation."""
     url = "https://nominatim.openstreetmap.org/search?" + urllib.parse.urlencode(
         {"q": name, "format": "json", "limit": 1})
     req = urllib.request.Request(url, headers={   # Nominatim requires a UA
@@ -288,14 +299,27 @@ def geocode_city(name, retries=3):
     for i in range(retries):
         try:
             with urllib.request.urlopen(req, timeout=15) as r:
-                data = json.loads(r.read().decode("utf-8"))
-            if data:
-                return float(data[0]["lat"]), float(data[0]["lon"])
-            return None   # empty result -> genuinely un-geocodable (e.g. "Tatooine")
-        except Exception:
+                body = r.read().decode("utf-8")
+        except (urllib.error.URLError, TimeoutError) as e:   # transient: retry, then give up
             if i < retries - 1:
                 time.sleep(2 * (i + 1))
                 continue
+            print("WARNING: geocoding %r unreachable (%s); map dot stays at "
+                  "San Francisco." % (name, e))
+            return None
+        try:
+            data = json.loads(body)
+        except ValueError as e:   # includes json.JSONDecodeError; deterministic, don't retry
+            print("WARNING: geocoder returned non-JSON for %r (%s); map dot stays "
+                  "at San Francisco — check the Nominatim API." % (name, e))
+            return None
+        if not data:
+            return None   # empty result -> genuinely un-geocodable (e.g. "Tatooine")
+        try:
+            return float(data[0]["lat"]), float(data[0]["lon"])
+        except (KeyError, IndexError, ValueError, TypeError) as e:
+            print("WARNING: geocoder response for %r is missing lat/lon (%s); map "
+                  "dot stays at San Francisco — check the Nominatim API." % (name, e))
             return None
     return None
 
@@ -404,24 +428,27 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent=""):
             ext = os.path.splitext(cname)[1].lower()
             if ext in MIME_BY_EXT:
                 tmp = os.path.join(ctx["tmp"], "f" + copy_id + ext)
-                gws_download(copy_id, tmp)
-                n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
-                # Slides.pptx carries the network-map dot on slide 5; move it to
-                # the new city when we have coordinates (rebrand_file only fixed
-                # the label text). Gate the upload on either change.
-                if cname == "Slides.pptx" and ctx.get("latlon"):
-                    moved = reposition_map_marker(tmp, ctx["name"], *ctx["latlon"])
-                else:
-                    moved = 0
-                if n or moved:
-                    gws_upload(copy_id, tmp, MIME_BY_EXT[ext])
-                left = residual_tokens(tmp)
-                if left:
-                    ctx["residuals"].append((cname, left))
-                flag = "  !! residual %s" % left if left else ""
-                dot = " +map dot" if moved else ""
-                print("%s  - %s (%d parts%s)%s" % (indent, cname, n, dot, flag))
-                os.remove(tmp)
+                try:
+                    gws_download(copy_id, tmp)
+                    n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
+                    # Slides.pptx carries the network-map dot on slide 5; move it to
+                    # the new city when we have coordinates (rebrand_file only fixed
+                    # the label text). Gate the upload on either change.
+                    if cname == "Slides.pptx" and ctx.get("latlon"):
+                        moved = reposition_map_marker(tmp, ctx["name"], *ctx["latlon"])
+                    else:
+                        moved = 0
+                    if n or moved:
+                        gws_upload(copy_id, tmp, MIME_BY_EXT[ext])
+                    left = residual_tokens(tmp)
+                    if left:
+                        ctx["residuals"].append((cname, left))
+                    flag = "  !! residual %s" % left if left else ""
+                    dot = " +map dot" if moved else ""
+                    print("%s  - %s (%d parts%s)%s" % (indent, cname, n, dot, flag))
+                finally:
+                    if os.path.exists(tmp):
+                        os.remove(tmp)
             else:
                 print("%s  - %s (copied)" % (indent, cname))
     return new_id
@@ -450,8 +477,10 @@ def main():
         src = "override" if (a.lat is not None and a.lon is not None) else "geocoded"
         print("Coords: %.4f, %.4f (%s)" % (latlon[0], latlon[1], src))
     else:
-        print("Coords: -- could not resolve %r; the slide-5 map dot will stay at "
-              "San Francisco (fix it manually, or re-run with --lat/--lon)." % name)
+        print("Coords: --")
+        print("WARNING: could not resolve coordinates for %r; the slide-5 map dot "
+              "will stay at San Francisco (fix it manually, or re-run with "
+              "--lat/--lon)." % name)
 
     if a.rebrand_local:
         residual_any = False

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -132,20 +132,25 @@ def _rewrite_zip(path, transform):
     changed. On a bad repack, removes the temp file and raises (original intact)."""
     tmp = path + ".new"
     changed = 0
-    with zipfile.ZipFile(path) as zin, \
-            zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
-        for it in zin.infolist():
-            data = zin.read(it.filename)
-            new = transform(it.filename, data)
-            if new != data:
-                changed += 1
-            zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
-            zi.compress_type = it.compress_type
-            zi.external_attr = it.external_attr
-            zout.writestr(zi, new)
-    if zipfile.ZipFile(tmp).testzip() is not None:
-        os.remove(tmp); raise RuntimeError("repackaged zip failed validation: " + path)
-    os.replace(tmp, path)
+    try:
+        with zipfile.ZipFile(path) as zin, \
+                zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
+            for it in zin.infolist():
+                data = zin.read(it.filename)
+                new = transform(it.filename, data)
+                if new != data:
+                    changed += 1
+                zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
+                zi.compress_type = it.compress_type
+                zi.external_attr = it.external_attr
+                zout.writestr(zi, new)
+        with zipfile.ZipFile(tmp) as zt:   # close the handle before os.replace
+            if zt.testzip() is not None:
+                raise RuntimeError("repackaged zip failed validation: " + path)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):   # cleared on success by os.replace; else a leftover
+            os.remove(tmp)
     return changed
 
 def rebrand_file(path, name, upper, newslug):

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -1,0 +1,162 @@
+"""Unit tests for the network-map marker placement in create_chapter.py.
+
+Run: python3 skills/aaif-create-chapter/scripts/test_create_chapter.py
+"""
+import os
+import re
+import sys
+import tempfile
+import unittest
+import zipfile
+
+sys.path.insert(0, os.path.dirname(__file__))
+import create_chapter as cc  # noqa: E402
+
+A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+P = 'xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"'
+
+# Slide-5 shape templates, mirroring the real deck. The DOT is the square
+# 155448x155448 shape and carries an EMPTY <a:t></a:t> (so text presence can NOT
+# distinguish it from the label). The LABEL is a wide text box whose <a:t> carries
+# xml:space="preserve" the way rebrand_file leaves it. Discrimination is by ext.
+DOT_SP = (
+    '<p:sp><p:spPr><a:xfrm><a:off x="4074942" y="2650779"/>'
+    '<a:ext cx="155448" cy="155448"/></a:xfrm>'
+    '<a:solidFill><a:srgbClr val="14964A"/></a:solidFill></p:spPr>'
+    '<p:txBody><a:p><a:r><a:t></a:t></a:r></a:p></p:txBody></p:sp>'
+)
+LABEL_SP = (
+    '<p:sp><p:spPr><a:xfrm><a:off x="3649553" y="2875998"/>'
+    '<a:ext cx="2000000" cy="300000"/></a:xfrm>'
+    '<a:solidFill><a:srgbClr val="14964A"/></a:solidFill></p:spPr>'
+    '<p:txBody><a:p><a:r>'
+    '<a:t xml:space="preserve">SAN FRANCISCO · TONIGHT</a:t>'
+    '</a:r></a:p></p:txBody></p:sp>'
+)
+# A non-green decorative shape that must never move.
+OTHER_SP = (
+    '<p:sp><p:spPr><a:xfrm><a:off x="111111" y="222222"/>'
+    '<a:ext cx="500000" cy="500000"/></a:xfrm>'
+    '<a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></p:spPr></p:sp>'
+)
+
+
+def slide5(*shapes):
+    return ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<p:sld %s %s><p:cSld><p:spTree>%s</p:spTree></p:cSld></p:sld>'
+            % (P, A, "".join(shapes)))
+
+
+def make_pptx(path, slide_xml=None):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", "<Types/>")
+        if slide_xml is not None:
+            z.writestr(cc.SLIDE5, slide_xml)
+
+
+def offsets_by_shape(path):
+    """Return {'dot': (x, y), 'label': (x, y), 'other': (x, y)} from slide 5."""
+    with zipfile.ZipFile(path) as z:
+        xml = z.read(cc.SLIDE5).decode("utf-8")
+    out = {}
+    for block in re.findall(r"<p:sp\b[^>]*>.*?</p:sp>", xml, re.S):
+        m = re.search(r'<a:off x="(-?\d+)" y="(-?\d+)"/>', block)
+        xy = (int(m.group(1)), int(m.group(2)))
+        if "14964A" not in block:
+            out["other"] = xy
+        elif cc.DOT_EXT_RE.search(block):
+            out["dot"] = xy
+        else:
+            out["label"] = xy
+    return out
+
+
+class TestProjection(unittest.TestCase):
+    def test_sf_selfcheck_matches_real_deck(self):
+        # Ground truth: the real San Francisco chapter deck's dot sits at exactly
+        # this offset. The projection must reproduce it (this is the calibration
+        # reference — do NOT replace it with a guessed value).
+        dot_off, _ = cc.marker_offsets("San Francisco", 37.77, -122.42)
+        self.assertEqual(dot_off, (4074942, 2650779))
+
+    def test_label_keeps_template_offset_from_dot(self):
+        dot_off, label_off = cc.marker_offsets("New York", 40.71, -74.01)
+        self.assertEqual(label_off[0] - dot_off[0], cc.LABEL_DX)
+        self.assertEqual(label_off[1] - dot_off[1], cc.LABEL_DY)
+
+    def test_pixel_override_wins_over_formula(self):
+        # Overridden cities ignore lat/lon entirely.
+        self.assertEqual(cc.project_city("Seoul", 0.0, 0.0), (822, 305))
+        self.assertEqual(cc.project_city("Sydney", 99.0, 99.0), (870, 512))
+
+
+class TestReposition(unittest.TestCase):
+    def test_moves_both_shapes_to_new_city(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, slide5(DOT_SP, LABEL_SP, OTHER_SP))
+            moved = cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+            self.assertEqual(moved, 2)
+            self.assertIsNone(zipfile.ZipFile(p).testzip())
+
+            dot_off, label_off = cc.marker_offsets("New York", 40.71, -74.01)
+            got = offsets_by_shape(p)
+            self.assertEqual(got["dot"], dot_off)
+            self.assertEqual(got["label"], label_off)      # label detected despite xml:space
+            self.assertEqual(got["other"], (111111, 222222))  # untouched
+
+    def test_uses_pixel_override_when_present(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, slide5(DOT_SP, LABEL_SP))
+            # Seoul's lat/lon are deliberately wrong; the override must win.
+            cc.reposition_map_marker(p, "Seoul", 0.0, 0.0)
+            expected_dot, _ = cc.marker_offsets("Seoul", 0.0, 0.0)
+            self.assertEqual(offsets_by_shape(p)["dot"], expected_dot)
+
+    def test_absent_slide5_returns_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, slide_xml=None)  # no slide 5 at all
+            self.assertEqual(cc.reposition_map_marker(p, "New York", 40.71, -74.01), 0)
+
+    def test_no_green_shapes_returns_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, slide5(OTHER_SP))  # shapes present, none green
+            self.assertEqual(cc.reposition_map_marker(p, "New York", 40.71, -74.01), 0)
+
+    def test_guard_raises_when_not_exactly_two_green(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, slide5(DOT_SP, OTHER_SP))  # only 1 green shape
+            with self.assertRaises(RuntimeError):
+                cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+
+
+class TestResolveLatlon(unittest.TestCase):
+    def test_override_bypasses_geocoding(self):
+        # Both values given -> returned verbatim, no network.
+        self.assertEqual(cc.resolve_latlon("Anywhere", 12.34, 56.78), (12.34, 56.78))
+
+    def test_lone_value_falls_through_to_geocode(self):
+        calls = []
+        orig = cc.geocode_city
+        cc.geocode_city = lambda name, **kw: calls.append(name) or (1.0, 2.0)
+        try:
+            self.assertEqual(cc.resolve_latlon("Paris", 48.85, None), (1.0, 2.0))
+            self.assertEqual(calls, ["Paris"])
+        finally:
+            cc.geocode_city = orig
+
+    def test_ungeocodable_returns_none(self):
+        orig = cc.geocode_city
+        cc.geocode_city = lambda name, **kw: None
+        try:
+            self.assertIsNone(cc.resolve_latlon("Tatooine", None, None))
+        finally:
+            cc.geocode_city = orig
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -41,17 +41,30 @@ OTHER_SP = (
 )
 
 
+def green_sp(off, ext, text=None, off_selfclose="/>"):
+    """A green shape with a chosen off/ext, optional text run, and control over
+    the <a:off .../> self-close spacing (to exercise re-saved ' />' output)."""
+    body = ("<p:txBody><a:p><a:r><a:t>%s</a:t></a:r></a:p></p:txBody>" % text
+            if text is not None else "")
+    return ('<p:sp><p:spPr><a:xfrm><a:off x="%d" y="%d"%s'
+            '<a:ext cx="%d" cy="%d"/></a:xfrm>'
+            '<a:solidFill><a:srgbClr val="14964A"/></a:solidFill></p:spPr>%s</p:sp>'
+            % (off[0], off[1], off_selfclose, ext[0], ext[1], body))
+
+
 def slide5(*shapes):
     return ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
             '<p:sld %s %s><p:cSld><p:spTree>%s</p:spTree></p:cSld></p:sld>'
             % (P, A, "".join(shapes)))
 
 
-def make_pptx(path, slide_xml=None):
+def make_pptx(path, slide_xml=None, extra=None):
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
         z.writestr("[Content_Types].xml", "<Types/>")
         if slide_xml is not None:
             z.writestr(cc.SLIDE5, slide_xml)
+        for member_name, data in (extra or {}).items():
+            z.writestr(member_name, data)
 
 
 def offsets_by_shape(path):
@@ -88,6 +101,22 @@ class TestProjection(unittest.TestCase):
         # Overridden cities ignore lat/lon entirely.
         self.assertEqual(cc.project_city("Seoul", 0.0, 0.0), (822, 305))
         self.assertEqual(cc.project_city("Sydney", 99.0, 99.0), (870, 512))
+
+    def test_lat2y_hits_every_anchor_exactly(self):
+        for lat, y in cc.LAT_ANCHORS:
+            self.assertAlmostEqual(cc.lat2y(lat), y, places=6, msg="anchor %s" % lat)
+
+    def test_lat2y_interpolates_and_covers_southern_hemisphere(self):
+        # Midpoint of the (0.0, 398) -> (-34.8, 525) segment (a formula-driven
+        # southern city like Cape Town lands here; SH is otherwise all overrides).
+        self.assertAlmostEqual(cc.lat2y(-17.4), (398 + 525) / 2, places=3)
+        self.assertTrue(398 < cc.lat2y(-33.9) < 525)  # Cape Town, interpolated
+
+    def test_lat2y_extrapolates_past_the_end_anchors(self):
+        # Beyond the anchor range it extrapolates (does NOT clamp): a far-north
+        # city projects above the top anchor's y, a far-south one below the last.
+        self.assertLess(cc.lat2y(70.0), cc.LAT_ANCHORS[0][1])
+        self.assertGreater(cc.lat2y(-60.0), cc.LAT_ANCHORS[-1][1])
 
 
 class TestReposition(unittest.TestCase):
@@ -133,6 +162,49 @@ class TestReposition(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 cc.reposition_map_marker(p, "New York", 40.71, -74.01)
 
+    def test_guard_raises_when_both_green_match_dot_ext(self):
+        # Identity, not count: two square green shapes -> both classified as dot,
+        # zero labels -> must raise even though moved == 2 (would otherwise stack
+        # the markers silently).
+        two_dots = slide5(green_sp((1, 2), (155448, 155448)),
+                          green_sp((3, 4), (155448, 155448), text="X"))
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, two_dots)
+            with self.assertRaises(RuntimeError):
+                cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+
+    def test_guard_raises_when_neither_green_matches_dot_ext(self):
+        # Both green shapes are wide -> both classified as label, zero dots -> raise.
+        two_labels = slide5(green_sp((1, 2), (999999, 111111)),
+                            green_sp((3, 4), (888888, 222222), text="X"))
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, two_labels)
+            with self.assertRaises(RuntimeError):
+                cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+
+    def test_off_regex_tolerates_respaced_selfclose(self):
+        # A deck re-saved as '<a:off ... />' (space before />) must still move.
+        respaced = slide5(green_sp((1, 2), (155448, 155448), off_selfclose=" />"),
+                         green_sp((3, 4), (2011680, 201168), text="SF", off_selfclose=" />"))
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, respaced)
+            self.assertEqual(cc.reposition_map_marker(p, "New York", 40.71, -74.01), 2)
+
+    def test_rewrite_preserves_other_zip_members(self):
+        # A non-slide5 binary member (like image18.png) must round-trip byte-identical.
+        blob = bytes(range(256)) * 8
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "Slides.pptx")
+            make_pptx(p, slide5(DOT_SP, LABEL_SP),
+                      extra={"ppt/media/image18.png": blob})
+            cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+            with zipfile.ZipFile(p) as z:
+                self.assertEqual(z.read("ppt/media/image18.png"), blob)
+                self.assertIn("[Content_Types].xml", z.namelist())
+
 
 class TestResolveLatlon(unittest.TestCase):
     def test_override_bypasses_geocoding(self):
@@ -156,6 +228,64 @@ class TestResolveLatlon(unittest.TestCase):
             self.assertIsNone(cc.resolve_latlon("Tatooine", None, None))
         finally:
             cc.geocode_city = orig
+
+
+class _FakeResp:
+    def __init__(self, body):
+        self._body = body.encode("utf-8") if isinstance(body, str) else body
+    def read(self):
+        return self._body
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+class TestGeocodeCity(unittest.TestCase):
+    """geocode_city with urlopen stubbed — no network. Patches time.sleep so the
+    retry path doesn't actually back off."""
+
+    def _patch(self, urlopen):
+        self._orig_open = cc.urllib.request.urlopen
+        self._orig_sleep = cc.time.sleep
+        cc.urllib.request.urlopen = urlopen
+        cc.time.sleep = lambda *_a: None
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        cc.urllib.request.urlopen = self._orig_open
+        cc.time.sleep = self._orig_sleep
+
+    def test_success_parses_lat_lon(self):
+        self._patch(lambda req, timeout=0: _FakeResp('[{"lat":"40.71","lon":"-74.01"}]'))
+        self.assertEqual(cc.geocode_city("New York"), (40.71, -74.01))
+
+    def test_empty_result_is_none(self):
+        self._patch(lambda req, timeout=0: _FakeResp("[]"))
+        self.assertIsNone(cc.geocode_city("Nowhereville"))
+
+    def test_network_error_retries_then_none(self):
+        import urllib.error
+        calls = []
+        def boom(req, timeout=0):
+            calls.append(1)
+            raise urllib.error.URLError("unreachable")
+        self._patch(boom)
+        self.assertIsNone(cc.geocode_city("Paris", retries=3))
+        self.assertEqual(len(calls), 3)  # retried all attempts
+
+    def test_non_json_response_is_none_without_retry(self):
+        calls = []
+        def html(req, timeout=0):
+            calls.append(1)
+            return _FakeResp("<html>captcha</html>")
+        self._patch(html)
+        self.assertIsNone(cc.geocode_city("Paris", retries=3))
+        self.assertEqual(len(calls), 1)  # deterministic -> not retried
+
+    def test_missing_lat_lon_fields_is_none(self):
+        self._patch(lambda req, timeout=0: _FakeResp('[{"name":"somewhere"}]'))
+        self.assertIsNone(cc.geocode_city("Paris"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
When a new AAIF chapter is cloned from `TemplateCity`, the cloner rebranded only *text*, so the green "you-are-here" marker on slide 5 ("THE NETWORK") of `Event Template/Slides.pptx` stayed parked at San Francisco while the label read `<CITY> · TONIGHT`. This closes that gap: the dot **and** its label are repositioned to the new city's real location on the world map, computed from a calibrated lat/lon→pixel projection and unit-tested against the real San Francisco deck.

## Changesets

### 1. `feat(create-chapter): auto-place slide-5 map dot for new cities` (`9919328`)
**Files:** `skills/aaif-create-chapter/scripts/create_chapter.py`, `skills/aaif-create-chapter/scripts/test_create_chapter.py` (new), `skills/aaif-create-chapter/SKILL.md`

- **Projection + placement.** Calibrated lat/lon → pixel projection for `image18.png` (linear longitude, piecewise-linear latitude, `PIXEL_OVERRIDES` for the distorted western Pacific). `reposition_map_marker()` rewrites the two green shapes' `<a:off>` in `slide5.xml` (ZipInfo-preserving, `testzip`-validated).
- **Dot vs. label discrimination by ext.** The real dot shape carries an *empty* `<a:t></a:t>`, so text presence can't tell it apart from the label — the code keys on the dot's `155448×155448` ext instead.
- **Coordinates.** New `--lat`/`--lon` flags override; otherwise the city name is geocoded via Nominatim (keyless). If neither resolves, the dot is left at SF with a warning — **chapter creation never fails over the dot.**
- **Wiring.** Hooked into `clone_and_rebrand` (upload gated on text OR dot change) and the `--rebrand-local` test path; prints a `Coords:` line and a `+map dot` marker. `SKILL.md` documents behavior, flags, fallback, and recalibration.

### 2. `fix: address self-review findings on map-dot placement` (`8c80aa8`)
**Files:** `skills/aaif-create-chapter/scripts/create_chapter.py`, `skills/aaif-create-chapter/scripts/test_create_chapter.py`

- **Identity guard.** `reposition_map_marker` now requires exactly one green dot **and** one green label to be rewritten (not just a move-count of 2), so template drift can't silently stack the two markers.
- **Precise geocode error handling.** Retries only transient network errors; reports an unexpected Nominatim response shape distinctly rather than masking it as a missing city.
- **Robustness/cleanup.** `try/finally` temp-file cleanup on mid-clone raise; extracted a shared `_rewrite_zip` helper; `off_re` tolerates a re-saved `<a:off ... />`; corrected docstrings/comments; unresolved-coords prints a real `WARNING:`.

## Test Plan
- [x] `python3 skills/aaif-create-chapter/scripts/test_create_chapter.py` → **23/23 pass** (SF self-check pinned to the real deck offset `(4074942, 2650779)`; empty-`<a:t>` dot classification; identity guard both-dot/neither-dot; `off_re` whitespace; non-slide5 member round-trip; direct `geocode_city` success/empty/network-retry/non-JSON/missing-fields; `lat2y` anchors/interp/extrapolation)
- [x] End-to-end on a **local copy of the real SF deck** repositioned to New York — dot + label land correctly; `image18.png` byte-identical; `testzip` clean
- [x] Self-review by five pr-review-toolkit agents; all findings applied
- [ ] Create a throwaway chapter for a well-known city and eyeball slide 5's dot on the live deck (needs a real `gws` chapter creation)
- [ ] First East-Asia/Oceania city: confirm the dot sits right; add a `PIXEL_OVERRIDES` entry if off

## Related Issues
Delivered via `hero-skills:one-shot` from an implementation brief (no tracked issue).

---
Generated with [Claude Code](https://claude.ai/code)