### PR TITLE
docs: update marketplace name to aaif/community-events

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,8 +8,8 @@
     "name": "AAIF",
     "url": "https://github.com/aaif"
   },
-  "homepage": "https://github.com/aaif/events",
-  "repository": "https://github.com/aaif/events",
+  "homepage": "https://github.com/aaif/community-events",
+  "repository": "https://github.com/aaif/community-events",
   "license": "MIT",
   "keywords": ["aaif", "events", "community", "google-workspace", "luma", "linkedin"]
 }

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ also work in claude.ai and the Claude Agent SDK — see [Using in other tools](#
 ## Install (Claude Code)
 
 ```bash
-/plugin marketplace add aaif/events
+/plugin marketplace add aaif/community-events
 /plugin install aaif-events@aaif
 ```
 
-`marketplace add aaif/events` reads `.claude-plugin/marketplace.json` from this
+`marketplace add aaif/community-events` reads `.claude-plugin/marketplace.json` from this
 repo; `@aaif` is the marketplace name. After installing, the skills auto‑activate
 when you describe a matching task (e.g. “draft the announcement post for our July
 event”), or invoke one explicitly with `/aaif-<skill>` (e.g.
@@ -28,10 +28,10 @@ event”), or invoke one explicitly with `/aaif-<skill>` (e.g.
 
 Prefer the guided UI flow? Run these inside Claude Code:
 
-1. **Add the marketplace** (the full git URL is equivalent to the `aaif/events`
+1. **Add the marketplace** (the full git URL is equivalent to the `aaif/community-events`
    shorthand used in [Install](#install-claude-code) above):
    ```bash
-   /plugin marketplace add https://github.com/aaif/events.git#main
+   /plugin marketplace add https://github.com/aaif/community-events.git#main
    ```
 2. **Enable it:** run `/plugin`, tab to **Marketplaces**, and enable the **aaif**
    marketplace.

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -304,7 +304,7 @@ def geocode_city(name, retries=3):
     url = "https://nominatim.openstreetmap.org/search?" + urllib.parse.urlencode(
         {"q": name, "format": "json", "limit": 1})
     req = urllib.request.Request(url, headers={   # Nominatim requires a UA
-        "User-Agent": "aaif-create-chapter/1.0 (AAIF chapter cloner; +https://github.com/aaif/events)"})
+        "User-Agent": "aaif-create-chapter/1.0 (AAIF chapter cloner; +https://github.com/aaif/community-events)"})
     for i in range(retries):
         try:
             with urllib.request.urlopen(req, timeout=15) as r:


### PR DESCRIPTION
Repo was renamed from `aaif/events` to `aaif/community-events`, but the install instructions and metadata still pointed at the old name (`marketplace add aaif/events` fails with *repository not found*).

## Changes
- **README.md** — install commands + quickstart now use `aaif/community-events`
- **.claude-plugin/plugin.json** — `homepage` / `repository` URLs updated

Left the historical CHANGELOG entry untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)