### PR TITLE
fix(sync-chapters): header-driven feed writes + fail-loud write guards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,16 @@ repos:
         language: python
         additional_dependencies: [pyyaml]
         files: 'SKILL\.md$'
+
+  # --- Tooling-rule banner must not drift between its SKILL.md copies ---------
+  # The banner is duplicated on purpose (skills ship downstream without
+  # CLAUDE.md); this catches the copies silently diverging. Runs on the whole
+  # set, not just changed files, since drift is a property of the set.
+  - repo: local
+    hooks:
+      - id: check-tooling-banner
+        name: tooling-rule banner is identical across SKILL.md
+        entry: python3 scripts/check_tooling_banner.py
+        language: python
+        pass_filenames: false
+        files: 'SKILL\.md$'

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ whether a human or an agent runs it.
 > back to byte-level OOXML surgery in Python (`.docx`/`.pptx`/`.xlsx` zip parts)
 > when the file genuinely *is* a stored Office file — a `.docx` round-trip of a
 > native Doc silently strips native features like Tabs. And never use LibreOffice
-> /`soffice` or any desktop office suite, not even to render a local preview: it
-> substitutes local system fonts for the brand fonts. To see a file, render it
-> through the API (`aaif_events.slides_export.render_slide_png` for a slide;
+> /`soffice`, `unoconv`, or any desktop office suite, not even to render a local
+> preview: it substitutes local system fonts for the brand fonts and drops OOXML it
+> doesn't understand, so its output and its renders both misrepresent the real file.
+> To see a file, render it through the API
+> (`aaif_events.slides_export.render_slide_png` for a slide;
 > `gws drive files copy` → `export` to PDF → trash the copy for a doc).
 
 Install `gws` (a Google Workspace command‑line tool), then authenticate with one of:
@@ -170,7 +172,7 @@ events/
 ├── skills/
 │   ├── aaif-announcement-post/SKILL.md
 │   ├── aaif-create-chapter/{SKILL.md, scripts/}
-│   └── …  (12 skills total)
+│   └── …  (17 skills total)
 └── README.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,15 +92,22 @@ These drive Google Drive / Sheets through the `gws` CLI (see below).
 
 ## Google Workspace access (for the ops skills)
 
-The ops skills read and write Google Drive/Sheets. Pick **one** of these ways to
-give your agent access. The bundled scripts call the **`gws` CLI** out of the box;
-the connector and MCP options are alternatives if you'd rather have Claude do the
-Drive/Sheets work through tools (you then follow the skill steps interactively
-instead of running the script).
+The ops skills read and write Google Drive/Sheets through **one** route: the
+**`gws` CLI**, driven from **Python**. There is no connector or MCP alternative —
+every skill, script, and manual step goes through `gws`, so behaviour is the same
+whether a human or an agent runs it.
 
-### Option A — `gws` CLI  *(what the scripts use)*
-The **`gws` CLI** (a Google Workspace command‑line tool) is what the scripts call.
-Install it, then authenticate with one of:
+> **Work in native Google formats wherever possible.** Prefer the Docs, Sheets,
+> and Slides APIs against native `application/vnd.google-apps.*` files. Only fall
+> back to byte-level OOXML surgery in Python (`.docx`/`.pptx`/`.xlsx` zip parts)
+> when the file genuinely *is* a stored Office file — a `.docx` round-trip of a
+> native Doc silently strips native features like Tabs. And never use LibreOffice
+> /`soffice` or any desktop office suite, not even to render a local preview: it
+> substitutes local system fonts for the brand fonts. To see a file, render it
+> through the API (`aaif_events.slides_export.render_slide_png` for a slide;
+> `gws drive files copy` → `export` to PDF → trash the copy for a doc).
+
+Install `gws` (a Google Workspace command‑line tool), then authenticate with one of:
 
 - **Interactive OAuth:** `gws auth login`
 - **Credentials file:** set `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/oauth_credentials.json`
@@ -115,8 +122,7 @@ read-only access passes the verify step below but then fails on the first write
 (form responses are read-only by nature, hence the `.readonly` scope). The
 bundled scripts use only the Sheets and Drive scopes; the Docs, Slides, and Forms
 scopes are for operating on those assets directly — the chapter/series source docs
-and decks, and the intake form (e.g. via Claude's Google connector or an MCP
-server):
+and decks, and the intake form:
 
 - `https://www.googleapis.com/auth/spreadsheets` — read/write the intake sheet *(scripts)*
 - `https://www.googleapis.com/auth/drive` — copy, create, and update Drive files,
@@ -131,24 +137,6 @@ Verify with:
 ```bash
 gws sheets spreadsheets get --params '{"spreadsheetId":"<your-sheet-id>"}'
 ```
-
-### Option B — Claude's Google Drive connector
-claude.ai and Claude Code can connect Google Drive/Sheets natively via
-**Connectors** (Settings → Connectors → Google Drive). Best when you want Claude to
-pull event details from Drive docs or read a sheet conversationally. To use it with
-the ops skills, run the skill's steps and let Claude operate the connected tools
-rather than invoking the `gws` script.
-
-### Option C — Google Workspace MCP server
-Run a Google Workspace **MCP server** and register it with Claude Code:
-
-```bash
-claude mcp add google-workspace -- <command to start the server>
-# or add it to .mcp.json in your project
-```
-
-Claude then reads/writes Sheets and Drive through MCP tools. As with the connector,
-follow the skill instructions interactively (the scripts themselves assume `gws`).
 
 ---
 

--- a/scripts/check_tooling_banner.py
+++ b/scripts/check_tooling_banner.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Assert the "Tooling rule" banner is byte-identical in every SKILL.md that carries it.
+
+The rule (gws + Python only, native Google formats, never LibreOffice) has to be
+duplicated into each SKILL.md because the skills ship downstream on their own —
+CLAUDE.md does not travel with them. Duplication is therefore deliberate, but
+undetected *drift* between the copies is not: a skill whose banner quietly loses
+the `unoconv` ban would let an agent reach for it without violating anything it
+was told.
+
+This does not police which skills carry the banner — that is an editorial call.
+It only enforces that every copy which exists says exactly the same thing.
+
+Usage:  python3 scripts/check_tooling_banner.py [FILE...]
+        (no args = every skills/*/SKILL.md)
+"""
+import glob, os, sys
+
+MARKER = "> **Tooling rule"
+
+
+def extract(path):
+    """Return the banner blockquote, or None when the file doesn't carry one."""
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().split("\n")
+    for i, line in enumerate(lines):
+        if line.startswith(MARKER):
+            block = []
+            for line in lines[i:]:
+                # The banner is one unbroken blockquote; the first non-"> " line ends it.
+                if not line.startswith(">"):
+                    break
+                block.append(line)
+            return "\n".join(block)
+    return None
+
+
+def main(argv):
+    paths = argv[1:] or sorted(glob.glob("skills/*/SKILL.md"))
+    banners = {}
+    for p in paths:
+        b = extract(p)
+        if b is not None:
+            banners.setdefault(b, []).append(p)
+
+    if len(banners) <= 1:
+        n = len(next(iter(banners.values()))) if banners else 0
+        print("check_tooling_banner: %d file(s) carry the banner, all identical." % n)
+        return 0
+
+    # More than one distinct text: report the minority variants against the most
+    # common one, which is almost always the intended wording.
+    canonical, canonical_files = max(banners.items(), key=lambda kv: len(kv[1]))
+    print("ERROR: the tooling-rule banner has drifted between SKILL.md files.\n")
+    print("Canonical (%d file(s)): %s" % (len(canonical_files), ", ".join(canonical_files)))
+    for text, files in banners.items():
+        if text == canonical:
+            continue
+        print("\nDiffers in: %s" % ", ".join(files))
+        want = canonical.split("\n")
+        got = text.split("\n")
+        for i in range(max(len(want), len(got))):
+            w = want[i] if i < len(want) else "(missing)"
+            g = got[i] if i < len(got) else "(missing)"
+            if w != g:
+                print("  line %d\n    canonical: %s\n    here     : %s" % (i + 1, w, g))
+    print("\nMake every copy identical, or remove the banner from the outliers.")
+    return 1
+
+
+if __name__ == "__main__":
+    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+    sys.exit(main(sys.argv))

--- a/skills/aaif-backup/SKILL.md
+++ b/skills/aaif-backup/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: "[driveFileId | ./local/path]"
 
 # Backup AAIF Ops Data
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Snapshot irreplaceable data to **local, versioned files** before risky edits (a bulk
 clean, a schema change, a column move). Every run writes a **new immutable file** —
 nothing is ever overwritten — so the backup folder is a full version history you can

--- a/skills/aaif-carousel-copy/SKILL.md
+++ b/skills/aaif-carousel-copy/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '[event title / paste tracker entry]'
 
 # AAIF LinkedIn Carousel Copy
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Caption text for a **6-slide** LinkedIn carousel built from the AAIF LinkedIn
 Carousel template. Each slide: a **headline (max 7 words)** + one short supporting
 line. **Slide 1 hooks, slide 6 is the CTA.**

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '<City Name> [--slug <lumaslug>] [--lat <deg> --lon <deg>]'
 
 # Create AAIF Chapter
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Spin up a new AAIF city "chapter" by cloning the **TemplateCity** folder in the
 **Chapters** Google Drive and rebranding every Office file from San Francisco to
 the new city. Each chapter folder is the standard template: `Event Tracker.docx`,

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -116,9 +116,7 @@ override (see Verify) and re-run.
    it was moved). If the city is in **East Asia / Oceania** and the dot looks off,
    add a `PIXEL_OVERRIDES` entry in `create_chapter.py` (pixel coords on the
    1123×794 `image18.png`) and re-run. To recalibrate against a render, export
-   slide 5 to PNG via the Slides API (**not LibreOffice** — `soffice` silently
-   substitutes local system fonts for the deck's brand fonts, so a LibreOffice
-   render can look wrong in ways the live file isn't):
+   slide 5 to PNG via the Slides API (see the tooling rule at the top of this file):
    ```bash
    PYTHONPATH=lib python3 -c "
    from aaif_events.slides_export import render_slide_png

--- a/skills/aaif-create-event/SKILL.md
+++ b/skills/aaif-create-event/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '<chapter|series> --title "..." --date "..."'
 
 # AAIF Create Event
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Add a new event to a chapter/series `Event Tracker.docx`: clone the example event
 section, fill the detail block, and compute every phase task's DUE date backward from
 the event date (the template's exact cadence is preserved per task). Mode is implicit —

--- a/skills/aaif-create-event/SKILL.md
+++ b/skills/aaif-create-event/SKILL.md
@@ -91,8 +91,7 @@ keys are per-calendar). The script detects this itself and its dry-run says so:
 
 1. **Prepare the assets**: write the page copy with `aaif-luma-description` and
    save it as markdown; export the event banner to PNG for the cover via the
-   Slides API — **not LibreOffice/`soffice`**, which substitutes local system
-   fonts for the deck's brand fonts and silently produces a wrong-looking export:
+   Slides API (see the tooling rule at the top of this file):
    ```
    PYTHONPATH=lib python3 -c "
    from aaif_events.slides_export import render_slide_png

--- a/skills/aaif-create-online-series/SKILL.md
+++ b/skills/aaif-create-online-series/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '<Series Name> [--slug <lumaslug>]'
 
 # Create AAIF Online Series
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Spin up a new AAIF **online event series** (e.g. a Reading Group, a Paper Club) by
 cloning the **TemplateSeries** folder in the top-level **Online** Google Drive
 folder and rebranding every Office file from San Francisco to the new series. This

--- a/skills/aaif-dayof-slides/SKILL.md
+++ b/skills/aaif-dayof-slides/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '[event title / paste tracker entry]'
 
 # AAIF Day-of Slides (from the tracker)
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Turn an event's tracker entry into the text for the chapter's **"Day of Event"**
 deck (`Event Template/Slides.pptx`). Fill the per-event slides from the tracker and
 **leave the fixed brand slides** (`[FIXED]`: About AAIF, the global-network stats)

--- a/skills/aaif-event-status/SKILL.md
+++ b/skills/aaif-event-status/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '<chapter|series> [event]'
 
 # AAIF Event Status
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Read-only digest of a chapter or online series' `Event Tracker.docx`: for each event,
 the **overdue** and **due-soon** (within 7 days) tasks, grouped by owner.
 

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -54,11 +54,15 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
   accent-insensitively); names already there but absent from intake are left alone
   (manual entries live there). Written values keep original UTF-8 (`Médéric Hurier`
   stays accented).
-- **Near-miss cities** (e.g. intake `Delhi` vs row `Delhi NCR`) are reported, not
-  auto-matched — confirm the right row or fix the intake city, never create a
-  near-duplicate row.
-- **`MLOps Community Organizers` is read-only history — never modified.** (It was
-  headed `Previous MLOps Organizers` until 2026-07-28.) Its spellings can differ
+- **Near-miss cities** are reported, not auto-matched — confirm the right row or
+  fix the intake city, never create a near-duplicate row. A near-miss fires on a
+  substring (intake `Delhi` vs row `Delhi NCR`) **or a shared discriminating word**
+  (`New Delhi` vs `Delhi NCR`). Generic words are excluded — `new`, `san`, `city`,
+  `saint`, `north`… — because a near-miss is never written and has no override
+  flag, so a false positive doesn't cost one confirmation, it blocks the city
+  **permanently**. Without that stoplist `San Diego` matches `San Francisco` and
+  can never be added.
+- **`MLOps Community Organizers` is read-only history — never modified.** Its spellings can differ
   from intake (e.g. "Adam Lite" vs "Adam Liter"); intake wins for `Organizers`.
   San Francisco people are **not** mirrored into the Silicon Valley row —
   `Organizers` follows the intake city; the MLOps column is where the legacy
@@ -71,10 +75,20 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
   removed; same exceptions as `aaif-create-chapter`, e.g. Denver → `aaif-colorado`).
   `Country`, `Generated Geolocation`, `Summary` and `Image` are left **blank for a
   human** — the report names them; the row isn't site-ready until they're filled.
-  The report says whether the Luma page is live — page creation is manual, and a
-  net-new city still needs its Drive folder/assets: run **`aaif-create-chapter`**
-  for it as the follow-up.
+  The report says whether the Luma page is live, and **`--write` refuses to create
+  a row whose page isn't live** (its CTA would point at a 404) unless you pass
+  `--allow-missing-luma`. Page creation is manual, and a net-new city still needs
+  its Drive folder/assets: run **`aaif-create-chapter`** for it as the follow-up.
 - Duplicate intake rows for the same person+city are deduped (first wins, reported).
+  Duplicate **chapter** rows (two rows for one city) are reported too — only the
+  last is ever updated, so merge them by hand.
+- **The run aborts rather than guessing** when: a header is duplicated (reads and
+  writes would resolve to different columns); any written column is missing; a row
+  below the last City row is non-empty (new rows are appended there and would wipe
+  it); a city has no ASCII characters, so its Luma slug would be empty; intake text
+  contains markup or control characters, or exceeds 120 chars; or the sheet changed
+  between building the proposal and writing it (row numbers are snapshot indices,
+  and the per-city Luma checks sit in that window).
 
 ## Verify
 
@@ -97,12 +111,15 @@ After any run (and after editing the engine):
 - Both tabs are read by **header name** (`Status`, `Full name`, `City (Existing)`,
   `City (New)`, `Run events before?`, `Why organize / ties`, `City`, `Organizers`),
   never by fixed column letter — the script aborts loudly if a header disappears.
-  **Writes** are addressed the same way: the chapters tab is read `A:Z` and every
-  write target is derived from the header row's index. The tab was
-  `City | Organizers | Previous MLOps Organizers | Chapter Luma Link` until
-  2026-07-21, when it became an 11-column website feed
-  (`Title | City | Country | Generated Geolocation | Summary | Image | CTA | URL for CTA | Organizers | Chapter Luma Link | MLOps Community Organizers`);
-  the old hardcoded `B`/`A:D` writes are why nothing may be addressed by letter again.
+  **Writes** are addressed the same way: the chapters tab is read `A:AZ` and every
+  write target is derived from the header row's index. Every column a new row
+  writes (`Title`, `City`, `Organizers`, `CTA`, `URL for CTA`, `Chapter Luma Link`)
+  is resolved up front and aborts if missing — a silently skipped one would publish
+  a chapter with no title or a dead CTA. The tab was restructured from
+  `City | Organizers | Previous MLOps Organizers | Chapter Luma Link` into the
+  11-column website feed it is now; the canonical column list lives in `HEADERS` in
+  `scripts/test_sync_chapters.py`, which is executable and therefore can't go stale.
+  The old hardcoded `B`/`A:D` writes are why nothing may be addressed by letter again.
   Note `Chapter Luma Link` is **hidden** in the sheet UI — hidden ≠ absent.
 - Quote the tab name in any manual A1 ranges (`'Chapters & Teams'!I11`) — it
   contains `&` and spaces.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -49,21 +49,28 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
   **unresolved** — reported with its free-text answers quoted (and an inferred
   city when the text explicitly names a chapter city), **never written**. The fix
   is to fill `City (New)` on the intake row (see `aaif-clean-data`), then re-run.
-- **Merge, don't overwrite**: existing `B` is parsed on `;`, intake names are
-  appended only if missing (compared case-, whitespace- and accent-insensitively);
-  names already in `B` but absent from intake are left alone (manual entries live
-  there). Written values keep original UTF-8 (`Médéric Hurier` stays accented).
+- **Merge, don't overwrite**: the existing `Organizers` cell is parsed on `;`,
+  intake names are appended only if missing (compared case-, whitespace- and
+  accent-insensitively); names already there but absent from intake are left alone
+  (manual entries live there). Written values keep original UTF-8 (`Médéric Hurier`
+  stays accented).
 - **Near-miss cities** (e.g. intake `Delhi` vs row `Delhi NCR`) are reported, not
   auto-matched — confirm the right row or fix the intake city, never create a
   near-duplicate row.
-- **Column C (`Previous MLOps Organizers`) is read-only history — never modified.**
-  Its spellings can differ from intake (e.g. "Adam Lite" vs "Adam Liter"); intake
-  wins for column B. San Francisco people are **not** mirrored into the Silicon
-  Valley row — B follows the intake city; C is where the legacy duplication lives.
+- **`MLOps Community Organizers` is read-only history — never modified.** (It was
+  headed `Previous MLOps Organizers` until 2026-07-28.) Its spellings can differ
+  from intake (e.g. "Adam Lite" vs "Adam Liter"); intake wins for `Organizers`.
+  San Francisco people are **not** mirrored into the Silicon Valley row —
+  `Organizers` follows the intake city; the MLOps column is where the legacy
+  duplication lives.
 - **New city rows** are appended after the last non-empty City row (not at the
-  grid bottom): City in A, names joined `"; "` in B, C empty, and
-  `https://luma.com/aaif-SLUG` in D (slug = city lowercased, spaces/accents
+  grid bottom), written across the **full feed width** so nothing lands in the
+  wrong column: `Title` = `AAIF <City> Chapter`, `City`, `Organizers` = names
+  joined `"; "`, `CTA` = `Stay Updated`, and `https://luma.com/aaif-SLUG` in both
+  `URL for CTA` and `Chapter Luma Link` (slug = city lowercased, spaces/accents
   removed; same exceptions as `aaif-create-chapter`, e.g. Denver → `aaif-colorado`).
+  `Country`, `Generated Geolocation`, `Summary` and `Image` are left **blank for a
+  human** — the report names them; the row isn't site-ready until they're filled.
   The report says whether the Luma page is live — page creation is manual, and a
   net-new city still needs its Drive folder/assets: run **`aaif-create-chapter`**
   for it as the follow-up.
@@ -77,8 +84,9 @@ After any run (and after editing the engine):
   column; a delta means status strings drifted.
 - After `--write`, the built-in re-verify must print
   "Verified: a fresh run proposes zero changes."
-- Spot-check one touched row in the sheet: B merged correctly, C and D untouched,
-  and the version history shows a single edit for the whole sync.
+- Spot-check one touched row in the sheet: `Organizers` merged correctly, the
+  MLOps and Luma columns untouched, and the version history shows a single edit
+  for the whole sync.
 - Unit tests for the pure merge/slug/near-miss logic:
   ```bash
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_chapters.py
@@ -89,7 +97,14 @@ After any run (and after editing the engine):
 - Both tabs are read by **header name** (`Status`, `Full name`, `City (Existing)`,
   `City (New)`, `Run events before?`, `Why organize / ties`, `City`, `Organizers`),
   never by fixed column letter — the script aborts loudly if a header disappears.
-- Quote the tab name in any manual A1 ranges (`'Chapters & Teams'!B11`) — it
+  **Writes** are addressed the same way: the chapters tab is read `A:Z` and every
+  write target is derived from the header row's index. The tab was
+  `City | Organizers | Previous MLOps Organizers | Chapter Luma Link` until
+  2026-07-21, when it became an 11-column website feed
+  (`Title | City | Country | Generated Geolocation | Summary | Image | CTA | URL for CTA | Organizers | Chapter Luma Link | MLOps Community Organizers`);
+  the old hardcoded `B`/`A:D` writes are why nothing may be addressed by letter again.
+  Note `Chapter Luma Link` is **hidden** in the sheet UI — hidden ≠ absent.
+- Quote the tab name in any manual A1 ranges (`'Chapters & Teams'!I11`) — it
   contains `&` and spaces.
 - Unresolved rows already hand-placed on the chapters list are flagged
   "no action needed" so they don't nag every run.

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -17,6 +17,7 @@ sheets are already in sync. --write recomputes the proposal from a fresh read,
 applies it atomically, then re-reads and verifies the diff is empty.
 """
 import argparse, json, re, subprocess, sys, time, unicodedata, urllib.error, urllib.request
+from collections import namedtuple
 
 INTAKE_ID = "1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o"
 INTAKE_TAB = "Organizers"
@@ -29,6 +30,9 @@ SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
 # Folded city -> Luma slug, for cities whose page doesn't follow the default
 # slug rule (same exceptions as aaif-create-chapter).
 SLUG_OVERRIDES = {"denver": "colorado"}
+
+# Feed columns a new row can't derive from the intake — left blank for a human.
+EDITORIAL_COLUMNS = ("Country", "Generated Geolocation", "Summary", "Image")
 
 # ----------------------------------------------------------------------------
 # gws helpers (same retry/JSON pattern as aaif-create-chapter)
@@ -80,6 +84,18 @@ def fold(s):
     s = "".join(c for c in s if not unicodedata.combining(c))
     return re.sub(r"\s+", " ", s).strip().casefold()
 
+def fold_city(s):
+    """City comparison key: fold(), with punctuation flattened to spaces.
+
+    'Washington, DC' and 'Washington DC' are one city; without this they compare
+    unequal AND fail the substring near-miss test, so the sync would append a
+    duplicate row for a city already on the list.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", fold(s))).strip()
+
+def city_tokens(s):
+    return set(fold_city(s).split())
+
 def slugify(city):
     s = unicodedata.normalize("NFKD", city).encode("ascii", "ignore").decode()
     return SLUG_OVERRIDES.get(fold(city), re.sub(r"[^a-z0-9]", "", s.lower()))
@@ -94,6 +110,16 @@ def header_index(headers, sheet, *names):
             sys.exit("ABORT: column %r not found on %s — sheet layout changed?" % (n, sheet))
         idx.append(headers.index(n))
     return idx
+
+def col_letter(i):
+    """0-based column index -> A1 letter. Every write target is derived from the
+    header row through this, so a column reorder moves the writes with it."""
+    s = ""
+    i += 1
+    while i:
+        i, r = divmod(i - 1, 26)
+        s = chr(ord("A") + r) + s
+    return s
 
 def luma_status(slug):
     """'live' (200) / 'absent' (404) / 'unknown' (couldn't verify)."""
@@ -150,11 +176,18 @@ def read_intake():
     return entries, unresolved, counts, dupes
 
 def read_chapters():
-    """Return (chapters, last_row). chapters = [{row, city, organizers_raw}]."""
-    rows = get_values(CHAPTERS_ID, "'%s'!A:D" % CHAPTERS_TAB)
+    """Return (chapters, last_row, layout). chapters = [{row, city, organizers_raw}].
+
+    layout = {headers, index: {name -> 0-based col}} — the tab is a website feed
+    whose columns have moved before (it was City|Organizers|MLOps|Luma until
+    2026-07-21), so read the whole width and resolve every column by header name.
+    """
+    rows = get_values(CHAPTERS_ID, "'%s'!A:Z" % CHAPTERS_TAB)
     if not rows:
         sys.exit("ABORT: chapters tab %r came back empty." % CHAPTERS_TAB)
-    i_city, i_org = header_index(rows[0], CHAPTERS_TAB, "City", "Organizers")
+    headers = [h.strip() for h in rows[0]]
+    i_city, i_org = header_index(headers, CHAPTERS_TAB, "City", "Organizers")
+    layout = {"headers": headers, "index": {h: i for i, h in enumerate(headers) if h}}
 
     chapters, last_row = [], 1
     for rownum, row in enumerate(rows[1:], start=2):
@@ -163,7 +196,7 @@ def read_chapters():
             continue   # never append into a gap; find the true last City row
         chapters.append({"row": rownum, "city": city, "organizers_raw": cell(row, i_org)})
         last_row = rownum
-    return chapters, last_row
+    return chapters, last_row, layout
 
 # ----------------------------------------------------------------------------
 # Diff
@@ -174,15 +207,18 @@ def parse_organizers(raw):
 def build_proposal(entries, chapters, last_row):
     """Return (adds, new_rows, near_misses).
 
-    adds       = [{row, city, names, new_value}]   merge into an existing B cell
+    adds       = [{row, city, names, new_value}]   merge into an Organizers cell
     new_rows   = [{row, city, names, slug}]        append after last_row
     near_misses= [{city, names, candidates}]       no exact row; never written
     """
     by_city = {}          # folded intake city -> {city, names[]}   (intake order)
     for e in entries:
-        by_city.setdefault(fold(e["city"]), {"city": e["city"], "names": []})["names"].append(e["name"])
+        by_city.setdefault(fold_city(e["city"]), {"city": e["city"], "names": []})["names"].append(e["name"])
 
-    chap_by_fold = {fold(c["city"]): c for c in chapters}
+    # Fold each chapter city once: the near-miss scan below is O(intake x chapters)
+    # and fold_city() is regex + unicode normalization.
+    folded = [(c, fold_city(c["city"])) for c in chapters]
+    chap_by_fold = {f: c for c, f in folded}
     adds, new_rows, near_misses = [], [], []
     next_row = last_row + 1
     for fc, grp in by_city.items():
@@ -190,14 +226,20 @@ def build_proposal(entries, chapters, last_row):
         if chap:
             existing = parse_organizers(chap["organizers_raw"])
             present = {fold(n) for n in existing}
-            # Merge, don't overwrite: keep every name already in B (manual
-            # entries included), append only the intake names missing from it.
+            # Merge, don't overwrite: keep every name already in Organizers
+            # (manual entries included), append only the intake names missing.
             missing = [n for n in grp["names"] if fold(n) not in present]
             if missing:
                 adds.append({"row": chap["row"], "city": chap["city"], "names": missing,
                              "new_value": "; ".join(existing + missing)})
             continue
-        cands = [c for c in chapters if fc in fold(c["city"]) or fold(c["city"]) in fc]
+        # Near-miss on substring OR any shared token: 'New Delhi' vs 'Delhi NCR'
+        # overlaps on neither substring test but is the same chapter. Over-
+        # reporting only costs a human confirmation; under-reporting silently
+        # forks a city into two rows.
+        toks = city_tokens(grp["city"])
+        cands = [c for c, cf in folded
+                 if fc in cf or cf in fc or (toks & set(cf.split()))]
         if cands:
             near_misses.append({"city": grp["city"], "names": grp["names"],
                                 "candidates": [(c["city"], c["row"]) for c in cands]})
@@ -222,7 +264,8 @@ def annotate_unresolved(unresolved, chapters):
 # Report
 # ----------------------------------------------------------------------------
 def print_report(entries, unresolved, counts, dupes, chapters, last_row,
-                 adds, new_rows, near_misses):
+                 adds, new_rows, near_misses, layout):
+    org_col = col_letter(layout["index"]["Organizers"])
     qual = " + ".join("%d %s" % (counts[s], s) for s in SYNC_STATUSES)
     print("Intake  : %d qualifying organizers (%s) across %d cities; %d unresolved; %d duplicate row(s)."
           % (len(entries), qual, len({fold(e["city"]) for e in entries}), len(unresolved), len(dupes)))
@@ -232,9 +275,13 @@ def print_report(entries, unresolved, counts, dupes, chapters, last_row,
         print("\nProposed adds to existing rows:")
         for a in adds:
             print("  %s (row %d): + %s" % (a["city"], a["row"], "; ".join(a["names"])))
-            print("      B%d -> %r" % (a["row"], a["new_value"]))
+            print("      %s%d -> %r" % (org_col, a["row"], a["new_value"]))
     if new_rows:
         print("\nProposed NEW city rows (appended after row %d):" % last_row)
+        blanks = [c for c in EDITORIAL_COLUMNS if c in layout["index"]]
+        if blanks:
+            print("  (%s left blank on new rows — fill them before the row goes live on the site)"
+                  % ", ".join(blanks))
         for n in new_rows:
             status = luma_status(n["slug"])
             note = {"live": "Luma page live",
@@ -269,19 +316,50 @@ def print_report(entries, unresolved, counts, dupes, chapters, last_row,
         print("\nNo changes needed — the chapters list is in sync with the intake.")
 
 # ----------------------------------------------------------------------------
+# Named, not a bare tuple: print_report() takes the whole thing positionally and
+# main() picks fields out of it, so a new field used to mean editing every
+# unpack site by hand (that's how `layout` landed).
+State = namedtuple("State", "entries unresolved counts dupes chapters last_row "
+                            "adds new_rows near_misses layout")
+
 def compute():
     entries, unresolved, counts, dupes = read_intake()
-    chapters, last_row = read_chapters()
+    chapters, last_row, layout = read_chapters()
     adds, new_rows, near_misses = build_proposal(entries, chapters, last_row)
     annotate_unresolved(unresolved, chapters)
-    return entries, unresolved, counts, dupes, chapters, last_row, adds, new_rows, near_misses
+    return State(entries, unresolved, counts, dupes, chapters, last_row,
+                 adds, new_rows, near_misses, layout)
 
-def apply_changes(adds, new_rows):
-    data = [{"range": "'%s'!B%d" % (CHAPTERS_TAB, a["row"]), "values": [[a["new_value"]]]}
+def new_row_values(n, layout):
+    """Full-width feed row for a brand-new city.
+
+    Only the columns derivable from the intake are filled; the editorial ones
+    (Country, Generated Geolocation, Summary, Image) are left blank for a human
+    — the report says so. Writing the whole width, rather than A:D, is what
+    keeps names out of Title/Country after the 2026-07 restructure.
+    """
+    luma = "https://luma.com/aaif-" + n["slug"]
+    derived = {"Title": "AAIF %s Chapter" % n["city"],
+               "City": n["city"],
+               "Organizers": "; ".join(n["names"]),
+               "CTA": "Stay Updated",
+               "URL for CTA": luma,
+               "Chapter Luma Link": luma}
+    vals = [""] * len(layout["headers"])
+    for name, v in derived.items():
+        i = layout["index"].get(name)
+        if i is not None:
+            vals[i] = v
+    return vals
+
+def apply_changes(adds, new_rows, layout):
+    org_col = col_letter(layout["index"]["Organizers"])
+    last_col = col_letter(len(layout["headers"]) - 1)
+    data = [{"range": "'%s'!%s%d" % (CHAPTERS_TAB, org_col, a["row"]),
+             "values": [[a["new_value"]]]}
             for a in adds]
-    data += [{"range": "'%s'!A%d:D%d" % (CHAPTERS_TAB, n["row"], n["row"]),
-              "values": [[n["city"], "; ".join(n["names"]), "",
-                          "https://luma.com/aaif-" + n["slug"]]]}
+    data += [{"range": "'%s'!A%d:%s%d" % (CHAPTERS_TAB, n["row"], last_col, n["row"]),
+              "values": [new_row_values(n, layout)]}
              for n in new_rows]
     # One batchUpdate for everything, so a partial failure can't half-sync the
     # sheet. RAW, not USER_ENTERED: a name starting with = + - @ must stay text,
@@ -300,22 +378,21 @@ def main():
     # --write recomputes from a fresh read here — a stale proposal is never applied.
     state = compute()
     print_report(*state)
-    adds, new_rows = state[6], state[7]
-    if not a.write or (not adds and not new_rows):
+    if not a.write or (not state.adds and not state.new_rows):
         return
 
     print("\nApplying %d cell update(s) + %d new row(s) in one batchUpdate..."
-          % (len(adds), len(new_rows)))
-    n = apply_changes(adds, new_rows)
+          % (len(state.adds), len(state.new_rows)))
+    n = apply_changes(state.adds, state.new_rows, state.layout)
     print("Wrote %d range(s)." % n)
 
     print("\nRe-verifying...")
-    _, _, _, _, _, _, adds2, new_rows2, _ = compute()
-    if adds2 or new_rows2:
+    after = compute()
+    if after.adds or after.new_rows:
         print("VERIFY FAILED — still out of sync after write:")
-        for x in adds2:
+        for x in after.adds:
             print("  row %d %s: + %s" % (x["row"], x["city"], "; ".join(x["names"])))
-        for x in new_rows2:
+        for x in after.new_rows:
             print("  new row %s: %s" % (x["city"], "; ".join(x["names"])))
         sys.exit(1)
     print("Verified: a fresh run proposes zero changes.")

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -31,15 +31,43 @@ SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
 # slug rule (same exceptions as aaif-create-chapter).
 SLUG_OVERRIDES = {"denver": "colorado"}
 
-# Feed columns a new row can't derive from the intake — left blank for a human.
+# Blank-on-new-row columns a human must fill before the row goes live on the site.
 EDITORIAL_COLUMNS = ("Country", "Generated Geolocation", "Summary", "Image")
+
+# Also blank on new rows, but read-only legacy history — never backfilled, so the
+# report must not tell an operator to fill it.
+NEVER_FILLED = ("MLOps Community Organizers",)
+
+# Every column a new row writes. All must resolve, or we refuse to write at all:
+# these are the columns the old hardcoded A:D write got wrong, and a silently
+# skipped one publishes a chapter row with no title or no CTA link.
+DERIVED_COLUMNS = ("Title", "City", "Organizers", "CTA", "URL for CTA", "Chapter Luma Link")
+
+# Tokens too generic to imply the same chapter. A near-miss is never written and
+# has no override, so a false positive blocks the city permanently — without this
+# stoplist "San Diego" is reported against "San Francisco" and can never be added.
+GENERIC_CITY_TOKENS = frozenset(
+    "new san santa saint st city los las el la de del di da du "
+    "north south east west upper lower grand port cape lake fort mount".split())
+
+# Free text from the PUBLIC intake form is republished to the website feed, so it
+# is length- and charset-checked before it can reach a cell.
+MAX_PUBLIC_TEXT = 120
+_UNSAFE_PUBLIC_TEXT = re.compile(r"[\x00-\x1f\x7f<>]")
 
 # ----------------------------------------------------------------------------
 # gws helpers (same retry/JSON pattern as aaif-create-chapter)
 # ----------------------------------------------------------------------------
 _TRANSIENT = ("timed out", "internalError", "HTTP request failed",
-              "Connection", "temporarily", "rateLimit", "userRateLimit",
-              "backendError", "503", "500", "502")
+              "Connection reset", "Connection refused", "Connection aborted",
+              "temporarily", "rateLimit", "userRateLimit", "backendError")
+# Bare "500"/"502"/"503" as substrings match any range or quota id that happens to
+# contain those digits ("A500:K500 exceeds grid limits"), so a permanent error
+# would burn the full backoff. Match them only as standalone HTTP statuses.
+_TRANSIENT_STATUS = re.compile(r"(?<![0-9])(?:429|500|502|503|504)(?![0-9])")
+
+def _transient(msg):
+    return any(k in msg for k in _TRANSIENT) or bool(_TRANSIENT_STATUS.search(msg))
 
 def _gws(cmd, retries=5):
     for i in range(max(1, retries)):   # retries<=0 must raise below, not return None
@@ -47,7 +75,11 @@ def _gws(cmd, retries=5):
         if r.returncode == 0:
             return r.stdout
         msg = (r.stderr or "") + (r.stdout or "")
-        if i < max(1, retries) - 1 and any(k in msg for k in _TRANSIENT):
+        if i < max(1, retries) - 1 and _transient(msg):
+            # Announce it: a silent 30s backoff looks like a hang, and a run that
+            # succeeds on attempt 4 should still leave a trace that the API was sick.
+            print("  gws call failed (attempt %d/%d), retrying in %ds: %s"
+                  % (i + 1, max(1, retries), 2 * (i + 1), msg.strip()[:120]), file=sys.stderr)
             time.sleep(2 * (i + 1))
             continue
         raise RuntimeError("gws failed (%s): %s" % (r.returncode, msg.strip()[:400]))
@@ -88,13 +120,32 @@ def fold_city(s):
     """City comparison key: fold(), with punctuation flattened to spaces.
 
     'Washington, DC' and 'Washington DC' are one city; without this they compare
-    unequal AND fail the substring near-miss test, so the sync would append a
-    duplicate row for a city already on the list.
+    unequal and get reported as a near-miss every run instead of merging cleanly.
+
+    `\\W` is Unicode-aware, and that is load-bearing: an ASCII allowlist
+    (`[^a-z0-9]`) folds every non-Latin city — 'Москва', '東京' — to "", which
+    collides them all onto one key and merges organizers into the WRONG row.
+    The `or fold(s)` fallback covers a name that is punctuation all the way down.
     """
-    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", fold(s))).strip()
+    return re.sub(r"\s+", " ", re.sub(r"[\W_]+", " ", fold(s))).strip() or fold(s)
 
 def city_tokens(s):
-    return set(fold_city(s).split())
+    """Discriminating tokens only — see GENERIC_CITY_TOKENS."""
+    return set(fold_city(s).split()) - GENERIC_CITY_TOKENS
+
+def check_public_text(kind, s, row):
+    """Reject intake free-text that must not reach the public website feed.
+
+    The intake sheet is fed by a public Google Form, and this script is the last
+    controlled point before a name or city is republished. RAW input mode already
+    stops formula injection; this stops markup and control characters.
+    """
+    if _UNSAFE_PUBLIC_TEXT.search(s):
+        sys.exit("ABORT: intake row %d %s %r contains control characters or angle "
+                 "brackets, which must never reach the public feed." % (row, kind, s))
+    if len(s) > MAX_PUBLIC_TEXT:
+        sys.exit("ABORT: intake row %d %s is %d characters (max %d)."
+                 % (row, kind, len(s), MAX_PUBLIC_TEXT))
 
 def slugify(city):
     s = unicodedata.normalize("NFKD", city).encode("ascii", "ignore").decode()
@@ -114,6 +165,8 @@ def header_index(headers, sheet, *names):
 def col_letter(i):
     """0-based column index -> A1 letter. Every write target is derived from the
     header row through this, so a column reorder moves the writes with it."""
+    if i < 0:
+        raise ValueError("col_letter: negative column index %d" % i)
     s = ""
     i += 1
     while i:
@@ -139,8 +192,9 @@ def luma_status(slug):
 def read_intake():
     """Return (entries, unresolved, status_counts, dupes).
 
-    entries    = [{row, name, city, status}]           city resolved, deduped
-    unresolved = [{row, name, status, g, h, events, why}]  needs a human
+    entries    = [{row, name, city, status}]                        city resolved, deduped
+    unresolved = [{row, name, status, g, h, events, why,
+                   placed, inferred}]                               needs a human
     """
     rows = get_values(INTAKE_ID, "%s!A:U" % INTAKE_TAB)
     if not rows:
@@ -163,10 +217,16 @@ def read_intake():
         # "Other..." placeholder; else the row needs a human.
         city = h or (g if g and not fold(g).startswith("other") else "")
         if not name or not city:
+            # placed/inferred are filled by annotate_unresolved but initialised
+            # here, so the record is never half-built and print_report is safe
+            # regardless of call order.
             unresolved.append({"row": rownum, "name": name, "status": status,
                                "g": g, "h": h,
-                               "events": cell(row, i_events), "why": cell(row, i_why)})
+                               "events": cell(row, i_events), "why": cell(row, i_why),
+                               "placed": [], "inferred": []})
             continue
+        check_public_text("name", name, rownum)
+        check_public_text("city", city, rownum)
         key = (fold(name), fold(city))
         if key in seen:
             dupes.append({"row": rownum, "name": name, "city": city})
@@ -179,15 +239,30 @@ def read_chapters():
     """Return (chapters, last_row, layout). chapters = [{row, city, organizers_raw}].
 
     layout = {headers, index: {name -> 0-based col}} — the tab is a website feed
-    whose columns have moved before (it was City|Organizers|MLOps|Luma until
-    2026-07-21), so read the whole width and resolve every column by header name.
+    whose columns have moved before, so read well past the current width and
+    resolve every column by header name.
     """
-    rows = get_values(CHAPTERS_ID, "'%s'!A:Z" % CHAPTERS_TAB)
+    rows = get_values(CHAPTERS_ID, "'%s'!A:AZ" % CHAPTERS_TAB)
     if not rows:
         sys.exit("ABORT: chapters tab %r came back empty." % CHAPTERS_TAB)
     headers = [h.strip() for h in rows[0]]
-    i_city, i_org = header_index(headers, CHAPTERS_TAB, "City", "Organizers")
+
+    # A duplicated header would resolve differently for reads and writes:
+    # header_index() takes the FIRST match, a dict comprehension keeps the LAST.
+    # The script would then read organizers from one column and write the merged
+    # value over another, clobbering it. Refuse rather than pick a winner.
+    dups = sorted({h for h in headers if h and headers.count(h) > 1})
+    if dups:
+        sys.exit("ABORT: duplicate column header(s) %s on %s — reads and writes "
+                 "would resolve to different columns."
+                 % (", ".join(map(repr, dups)), CHAPTERS_TAB))
+
+    # Every column we write must exist, not just the two we read. Resolving them
+    # all here is what lets new_row_values index directly instead of silently
+    # skipping a renamed column and publishing a row with no title or CTA link.
+    header_index(headers, CHAPTERS_TAB, *DERIVED_COLUMNS)
     layout = {"headers": headers, "index": {h: i for i, h in enumerate(headers) if h}}
+    i_city, i_org = layout["index"]["City"], layout["index"]["Organizers"]
 
     chapters, last_row = [], 1
     for rownum, row in enumerate(rows[1:], start=2):
@@ -196,6 +271,18 @@ def read_chapters():
             continue   # never append into a gap; find the true last City row
         chapters.append({"row": rownum, "city": city, "organizers_raw": cell(row, i_org)})
         last_row = rownum
+
+    # New rows are appended at last_row+1 and written FULL WIDTH, which clears
+    # every column we don't derive. A half-drafted row below the table (Summary
+    # written, City not filled in yet) is invisible to the loop above and would
+    # be silently wiped, so refuse to run while one exists.
+    for rownum, row in enumerate(rows[1:], start=2):
+        if rownum > last_row and any(str(v).strip() for v in row):
+            occupied = [headers[i] for i, v in enumerate(row)
+                        if i < len(headers) and headers[i] and str(v).strip()]
+            sys.exit("ABORT: row %d sits below the last City row (%d) but is not empty "
+                     "(%s).\nNew chapters are appended there and would overwrite it. "
+                     "Give it a City or clear it." % (rownum, last_row, ", ".join(occupied)))
     return chapters, last_row, layout
 
 # ----------------------------------------------------------------------------
@@ -233,19 +320,26 @@ def build_proposal(entries, chapters, last_row):
                 adds.append({"row": chap["row"], "city": chap["city"], "names": missing,
                              "new_value": "; ".join(existing + missing)})
             continue
-        # Near-miss on substring OR any shared token: 'New Delhi' vs 'Delhi NCR'
-        # overlaps on neither substring test but is the same chapter. Over-
-        # reporting only costs a human confirmation; under-reporting silently
-        # forks a city into two rows.
+        # Near-miss on substring OR a shared DISCRIMINATING token: 'New Delhi' vs
+        # 'Delhi NCR' overlaps on neither substring test but is the same chapter.
+        # Generic tokens are excluded (see GENERIC_CITY_TOKENS) because a
+        # near-miss is never written and has no override — a false positive
+        # doesn't cost a confirmation, it blocks the city permanently.
         toks = city_tokens(grp["city"])
         cands = [c for c, cf in folded
-                 if fc in cf or cf in fc or (toks & set(cf.split()))]
+                 if (fc and cf and (fc in cf or cf in fc)) or (toks & set(cf.split()))]
         if cands:
             near_misses.append({"city": grp["city"], "names": grp["names"],
                                 "candidates": [(c["city"], c["row"]) for c in cands]})
             continue
+        slug = slugify(grp["city"])
+        if not slug:
+            sys.exit("ABORT: city %r has no ASCII letters or digits, so its Luma slug "
+                     "would be empty and the row would publish a link to "
+                     "https://luma.com/aaif-.\nAdd a SLUG_OVERRIDES entry for it."
+                     % grp["city"])
         new_rows.append({"row": next_row, "city": grp["city"], "names": grp["names"],
-                         "slug": slugify(grp["city"])})
+                         "slug": slug})
         next_row += 1
     return adds, new_rows, near_misses
 
@@ -255,7 +349,7 @@ def annotate_unresolved(unresolved, chapters):
     for u in unresolved:
         u["placed"] = [(c["city"], c["row"]) for c in chapters
                        if fold(u["name"]) in {fold(n) for n in parse_organizers(c["organizers_raw"])}
-                       ] if u["name"] else []
+                       ] if u["name"] else []   # keys pre-initialised in read_intake
         text = fold(u["events"] + " " + u["why"])
         u["inferred"] = [c["city"] for c in chapters
                          if re.search(r"(?<![a-z0-9])%s(?![a-z0-9])" % re.escape(fold(c["city"])), text)]
@@ -263,12 +357,21 @@ def annotate_unresolved(unresolved, chapters):
 # ----------------------------------------------------------------------------
 # Report
 # ----------------------------------------------------------------------------
-def print_report(entries, unresolved, counts, dupes, chapters, last_row,
-                 adds, new_rows, near_misses, layout):
+def print_report(st):
+    """Print the proposal. Takes the whole State by name — the fields are read
+    by attribute, so adding one can't silently rebind a positional parameter.
+
+    Side effect: caches each new row's Luma status on the record as `luma`, so
+    main() can gate --write on it without a second round of HTTP calls.
+    """
+    entries, unresolved, counts, dupes = st.entries, st.unresolved, st.counts, st.dupes
+    chapters, last_row, layout = st.chapters, st.last_row, st.layout
+    adds, new_rows, near_misses = st.adds, st.new_rows, st.near_misses
     org_col = col_letter(layout["index"]["Organizers"])
     qual = " + ".join("%d %s" % (counts[s], s) for s in SYNC_STATUSES)
     print("Intake  : %d qualifying organizers (%s) across %d cities; %d unresolved; %d duplicate row(s)."
-          % (len(entries), qual, len({fold(e["city"]) for e in entries}), len(unresolved), len(dupes)))
+          % (len(entries), qual, len({fold_city(e["city"]) for e in entries}),
+             len(unresolved), len(dupes)))
     print("Chapters: %d city rows (2-%d)." % (len(chapters), last_row))
 
     if adds:
@@ -278,12 +381,15 @@ def print_report(entries, unresolved, counts, dupes, chapters, last_row,
             print("      %s%d -> %r" % (org_col, a["row"], a["new_value"]))
     if new_rows:
         print("\nProposed NEW city rows (appended after row %d):" % last_row)
-        blanks = [c for c in EDITORIAL_COLUMNS if c in layout["index"]]
+        # Derived from the header row, not from EDITORIAL_COLUMNS: a twelfth feed
+        # column added tomorrow is written blank, so it must be reported blank too.
+        blanks = [h for h in layout["headers"]
+                  if h and h not in DERIVED_COLUMNS and h not in NEVER_FILLED]
         if blanks:
             print("  (%s left blank on new rows — fill them before the row goes live on the site)"
                   % ", ".join(blanks))
         for n in new_rows:
-            status = luma_status(n["slug"])
+            status = n["luma"] = luma_status(n["slug"])
             note = {"live": "Luma page live",
                     "absent": "Luma page NOT LIVE yet — create it manually; run aaif-create-chapter for the assets",
                     "unknown": "could not verify the Luma page — check it manually"}[status]
@@ -312,13 +418,25 @@ def print_report(entries, unresolved, counts, dupes, chapters, last_row,
         for d in dupes:
             print("  intake row %d: %s / %s" % (d["row"], d["name"], d["city"]))
 
+    # The chapters side has its own duplicate problem, and only the intake side
+    # was ever reported. chap_by_fold is last-wins, so an earlier duplicate row
+    # is never updated and its organizers stay invisible to every future run.
+    by_fold = {}
+    for c in chapters:
+        by_fold.setdefault(fold_city(c["city"]), []).append((c["city"], c["row"]))
+    collisions = [v for v in by_fold.values() if len(v) > 1]
+    if collisions:
+        print("\nDuplicate chapter rows (only the LAST is ever updated — merge them):")
+        for v in collisions:
+            print("  %s" % ", ".join("%r (row %d)" % p for p in v))
+
     if not adds and not new_rows:
         print("\nNo changes needed — the chapters list is in sync with the intake.")
 
 # ----------------------------------------------------------------------------
-# Named, not a bare tuple: print_report() takes the whole thing positionally and
-# main() picks fields out of it, so a new field used to mean editing every
-# unpack site by hand (that's how `layout` landed).
+# Named, not a bare tuple: every consumer reads fields by attribute (print_report
+# takes the State itself, not *state), so adding a field can't silently rebind a
+# positional parameter the way it did when `layout` landed.
 State = namedtuple("State", "entries unresolved counts dupes chapters last_row "
                             "adds new_rows near_misses layout")
 
@@ -335,8 +453,13 @@ def new_row_values(n, layout):
 
     Only the columns derivable from the intake are filled; the editorial ones
     (Country, Generated Geolocation, Summary, Image) are left blank for a human
-    — the report says so. Writing the whole width, rather than A:D, is what
-    keeps names out of Title/Country after the 2026-07 restructure.
+    — the report names them. Writing the whole width, rather than A:D, is what
+    keeps the city out of `Title`, the organizer names out of `City`, and the
+    Luma URL out of `Generated Geolocation` after the 2026-07 restructure.
+
+    Every DERIVED_COLUMNS name is indexed directly, not via .get(): read_chapters
+    has already aborted if one is missing, so a renamed column can no longer be
+    skipped into a blank cell that the report claims was written.
     """
     luma = "https://luma.com/aaif-" + n["slug"]
     derived = {"Title": "AAIF %s Chapter" % n["city"],
@@ -347,12 +470,35 @@ def new_row_values(n, layout):
                "Chapter Luma Link": luma}
     vals = [""] * len(layout["headers"])
     for name, v in derived.items():
-        i = layout["index"].get(name)
-        if i is not None:
-            vals[i] = v
+        vals[layout["index"][name]] = v
     return vals
 
+def assert_rows_unchanged(adds, new_rows, layout):
+    """Re-read the City column and confirm the proposal's row numbers still mean
+    what they meant when it was computed.
+
+    Row numbers are indices into a snapshot. print_report() sits between that read
+    and this write, spending up to 15s per new city checking Luma, so a human
+    inserting a row in that window would shift every target — silently putting an
+    organizer on the wrong city's row.
+    """
+    c = col_letter(layout["index"]["City"])
+    rows = get_values(CHAPTERS_ID, "'%s'!%s:%s" % (CHAPTERS_TAB, c, c))
+    def at(r):
+        return cell(rows[r - 1], 0) if 0 < r <= len(rows) else ""
+    for a in adds:
+        if fold_city(at(a["row"])) != fold_city(a["city"]):
+            sys.exit("ABORT: row %d now reads %r, expected %r — the sheet changed while "
+                     "the proposal was being built. Nothing was written; re-run."
+                     % (a["row"], at(a["row"]), a["city"]))
+    for n in new_rows:
+        if at(n["row"]):
+            sys.exit("ABORT: row %d is no longer empty (now %r) — the sheet changed while "
+                     "the proposal was being built. Nothing was written; re-run."
+                     % (n["row"], at(n["row"])))
+
 def apply_changes(adds, new_rows, layout):
+    assert_rows_unchanged(adds, new_rows, layout)
     org_col = col_letter(layout["index"]["Organizers"])
     last_col = col_letter(len(layout["headers"]) - 1)
     data = [{"range": "'%s'!%s%d" % (CHAPTERS_TAB, org_col, a["row"]),
@@ -373,13 +519,26 @@ def main():
     ap = argparse.ArgumentParser(description="Sync intake organizer decisions into the chapters list.")
     ap.add_argument("--write", action="store_true",
                     help="apply the proposed changes (default: report only)")
+    ap.add_argument("--allow-missing-luma", action="store_true",
+                    help="write new rows even if their Luma page isn't live yet "
+                         "(their CTA will point at a 404 until it is created)")
     a = ap.parse_args()
 
     # --write recomputes from a fresh read here — a stale proposal is never applied.
     state = compute()
-    print_report(*state)
+    print_report(state)
     if not a.write or (not state.adds and not state.new_rows):
         return
+
+    # Luma page creation is manual, so "absent" is the NORMAL state for a net-new
+    # city — without this gate the common path publishes a "Stay Updated" button
+    # pointing at a 404, and the only warning is one line of per-city output.
+    stale = [n for n in state.new_rows if n.get("luma") != "live"]
+    if stale and not a.allow_missing_luma:
+        sys.exit("ABORT: %d new row(s) have no live Luma page: %s.\nTheir CTA would "
+                 "point at a 404. Create the pages first, or re-run with "
+                 "--allow-missing-luma if that's intended."
+                 % (len(stale), ", ".join(n["city"] for n in stale)))
 
     print("\nApplying %d cell update(s) + %d new row(s) in one batchUpdate..."
           % (len(state.adds), len(state.new_rows)))
@@ -387,7 +546,13 @@ def main():
     print("Wrote %d range(s)." % n)
 
     print("\nRe-verifying...")
-    after = compute()
+    # The write has already landed. A bare traceback here would leave the operator
+    # unable to tell whether the sheet was modified, so say so explicitly.
+    try:
+        after = compute()
+    except (Exception, SystemExit) as e:
+        sys.exit("WRITE WAS APPLIED (%d range(s)) but verification could not run: %s\n"
+                 "Re-run without --write to confirm the sheet state." % (n, e))
     if after.adds or after.new_rows:
         print("VERIFY FAILED — still out of sync after write:")
         for x in after.adds:

--- a/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
@@ -7,11 +7,10 @@ import sync_chapters
 from sync_chapters import (fold, fold_city, slugify, parse_organizers, build_proposal,
                            col_letter)
 
-# The live feed layout as of 2026-07-22 — writes are resolved through it by name.
+# The live feed layout — writes are resolved through it by name.
 HEADERS = ["Title", "City", "Country", "Generated Geolocation", "Summary", "Image",
            "CTA", "URL for CTA", "Organizers", "Chapter Luma Link",
            "MLOps Community Organizers"]
-LAYOUT = {"headers": HEADERS, "index": {h: i for i, h in enumerate(HEADERS)}}
 
 def chap(row, city, orgs):
     return {"row": row, "city": city, "organizers_raw": orgs}
@@ -27,6 +26,30 @@ def check(label, got, want):
     print("%s %s" % ("ok  " if ok else "FAIL", label))
     if not ok:
         print("      got : %r\n      want: %r" % (got, want))
+
+def read_chapters_over(rows):
+    """Drive the real read_chapters() over a fixture grid.
+
+    Building LAYOUT by hand would let read_chapters' output shape drift away from
+    what every write path consumes while all the tests still passed, so the layout
+    under test is always the one production actually produces.
+    """
+    with mock.patch.object(sync_chapters, "get_values", return_value=rows):
+        return sync_chapters.read_chapters()
+
+def aborts(fn):
+    """True if fn() calls sys.exit — the script's only refusal mechanism."""
+    try:
+        fn()
+    except SystemExit:
+        return True
+    return False
+
+ROW2 = ["AAIF Boston Chapter", "Boston", "USA", "42,-71", "blurb", "img",
+        "Stay Updated", "u", "Kranthi Manchikanti", "luma", ""]
+_chapters, _last, LAYOUT = read_chapters_over([HEADERS, ROW2])
+check("read_chapters resolves the real layout", LAYOUT["index"]["Organizers"], 8)
+check("read_chapters finds the last City row", _last, 2)
 
 # --- fold: case, whitespace, accents (compare folded, write original) --------
 check("fold trims/collapses/casefolds", fold("  Chandana  Srinivasa "), "chandana srinivasa")
@@ -105,8 +128,69 @@ check("empty Organizers populated", adds[0]["new_value"], "A B")
 check("col_letter A/I/K", [col_letter(0), col_letter(8), col_letter(10)], ["A", "I", "K"])
 check("col_letter past Z", [col_letter(25), col_letter(26)], ["Z", "AA"])
 
+# --- non-Latin city names must survive folding --------------------------------
+# An ASCII allowlist folded these to "", which collides every non-Latin city onto
+# one key and merges organizers into the wrong row.
+check("fold_city keeps non-latin text", bool(fold_city("Москва")) and bool(fold_city("東京")), True)
+check("fold_city keeps non-latin cities distinct", fold_city("Москва") == fold_city("東京"), False)
+adds, new_rows, near = build_proposal(
+    [entry(2, "New Person", "Pune")], [chap(2, "Boston", "K"), chap(3, "東京", "")], 3)
+check("a non-latin chapter row does not block new cities",
+      ([n["city"] for n in new_rows], near), (["Pune"], []))
+adds, _, _ = build_proposal([entry(2, "X Y", "東京")],
+                            [chap(2, "東京", ""), chap(3, "Москва", "")], 3)
+check("non-latin city merges into its OWN row", [(a["row"], a["city"]) for a in adds],
+      [(2, "東京")])
+
+# --- generic tokens must not block a legitimate new city ------------------------
+# A near-miss is never written and has no override, so over-matching here blocks
+# the city permanently rather than costing one confirmation.
+GENERIC = [chap(2, "San Francisco", ""), chap(3, "New York", ""), chap(4, "Mexico City", "")]
+for city in ["San Diego", "New Orleans", "Kansas City", "Salt Lake City"]:
+    _, nr, nm = build_proposal([entry(2, "P Q", city)], GENERIC, 4)
+    check("%r is added, not blocked by a generic token" % city,
+          ([n["city"] for n in nr], nm), ([city], []))
+_, nr, nm = build_proposal([entry(2, "P Q", "New Delhi")], [chap(2, "Delhi NCR", "")], 2)
+check("a discriminating shared token still blocks", ([n["city"] for n in nr],
+      [c[0] for c in nm[0]["candidates"]]), ([], ["Delhi NCR"]))
+
+# --- empty slug must abort, never publish https://luma.com/aaif- ----------------
+check("city with no ascii aborts rather than writing an empty slug",
+      aborts(lambda: build_proposal([entry(2, "X Y", "東京")], [chap(2, "Boston", "")], 2)), True)
+
+# --- read_chapters refuses layouts it cannot address safely ---------------------
+check("duplicate header aborts",
+      aborts(lambda: read_chapters_over([HEADERS + ["Organizers"], ROW2 + [""]])), True)
+check("missing derived column aborts",
+      aborts(lambda: read_chapters_over([[h for h in HEADERS if h != "CTA"], ROW2[:6] + ROW2[7:]])),
+      True)
+check("non-empty row below the last City row aborts",
+      aborts(lambda: read_chapters_over(
+          [HEADERS, ROW2, ["", "", "France", "", "half-written summary", "", "", "", "", "", ""]])),
+      True)
+check("blank trailing rows are fine", read_chapters_over([HEADERS, ROW2, [""] * 11])[1], 2)
+
+# --- col_letter rejects a negative index instead of returning "" ----------------
+try:
+    col_letter(-1); raised = False
+except ValueError:
+    raised = True
+check("col_letter(-1) raises", raised, True)
+
+# --- public-form text is charset/length checked before it can reach the feed ----
+check("markup in a name aborts",
+      aborts(lambda: sync_chapters.check_public_text("name", "<img src=x onerror=1>", 5)), True)
+check("control characters abort",
+      aborts(lambda: sync_chapters.check_public_text("city", "Bo\x00ston", 5)), True)
+check("over-long text aborts",
+      aborts(lambda: sync_chapters.check_public_text("name", "A" * 200, 5)), True)
+check("an ordinary accented name passes",
+      aborts(lambda: sync_chapters.check_public_text("name", "Médéric Hurier", 5)), False)
+
 # --- apply_changes: exact ranges, column order, RAW (gws mocked, no network) -----
-with mock.patch.object(sync_chapters, "gws_json") as gj:
+CITY_COL = [["City"], ["Boston"]]        # row 2 = Boston, row 6 still empty
+with mock.patch.object(sync_chapters, "gws_json") as gj, \
+     mock.patch.object(sync_chapters, "get_values", return_value=CITY_COL):
     n = sync_chapters.apply_changes(
         [{"row": 2, "city": "Boston", "names": ["New Person"],
           "new_value": "Kranthi Manchikanti; New Person"}],
@@ -123,12 +207,29 @@ check("apply_changes ranges and column order", body["data"],
                     "https://luma.com/aaif-pune", "Imran Bagwan",
                     "https://luma.com/aaif-pune", ""]]}])
 
+# --- the sheet moving under us must abort BEFORE the write ----------------------
+with mock.patch.object(sync_chapters, "gws_json") as gj, \
+     mock.patch.object(sync_chapters, "get_values", return_value=[["City"], ["Lisbon"]]):
+    shifted = aborts(lambda: sync_chapters.apply_changes(
+        [{"row": 2, "city": "Boston", "names": ["X"], "new_value": "X"}], [], LAYOUT))
+check("a shifted row aborts", shifted, True)
+check("a shifted row writes nothing", gj.called, False)
+
+with mock.patch.object(sync_chapters, "gws_json") as gj, \
+     mock.patch.object(sync_chapters, "get_values",
+                       return_value=[["City"], ["Boston"], ["Someone Else"]]):
+    taken = aborts(lambda: sync_chapters.apply_changes(
+        [], [{"row": 3, "city": "Pune", "names": ["I B"], "slug": "pune"}], LAYOUT))
+check("an occupied target row aborts", taken, True)
+check("an occupied target row writes nothing", gj.called, False)
+
 # --- a column reorder must move the writes, not corrupt neighbours ---------------
 SWAPPED = ["City", "Organizers", "MLOps Community Organizers", "Chapter Luma Link"]
-with mock.patch.object(sync_chapters, "gws_json") as gj:
+SWAPPED_LAYOUT = {"headers": SWAPPED, "index": {h: i for i, h in enumerate(SWAPPED)}}
+with mock.patch.object(sync_chapters, "gws_json") as gj, \
+     mock.patch.object(sync_chapters, "get_values", return_value=[["City"], ["Boston"]]):
     sync_chapters.apply_changes(
-        [{"row": 2, "city": "Boston", "names": ["X"], "new_value": "X"}], [],
-        {"headers": SWAPPED, "index": {h: i for i, h in enumerate(SWAPPED)}})
+        [{"row": 2, "city": "Boston", "names": ["X"], "new_value": "X"}], [], SWAPPED_LAYOUT)
     check("adds follow the Organizers header", gj.call_args.kwargs["body"]["data"][0]["range"],
           "'%s'!B2" % sync_chapters.CHAPTERS_TAB)
 

--- a/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
@@ -4,7 +4,14 @@ import sys, os
 from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import sync_chapters
-from sync_chapters import fold, slugify, parse_organizers, build_proposal
+from sync_chapters import (fold, fold_city, slugify, parse_organizers, build_proposal,
+                           col_letter)
+
+# The live feed layout as of 2026-07-22 — writes are resolved through it by name.
+HEADERS = ["Title", "City", "Country", "Generated Geolocation", "Summary", "Image",
+           "CTA", "URL for CTA", "Organizers", "Chapter Luma Link",
+           "MLOps Community Organizers"]
+LAYOUT = {"headers": HEADERS, "index": {h: i for i, h in enumerate(HEADERS)}}
 
 def chap(row, city, orgs):
     return {"row": row, "city": city, "organizers_raw": orgs}
@@ -31,8 +38,8 @@ check("slug accents", slugify("Montréal"), "montreal")
 check("slug Denver override", slugify("Denver"), "colorado")
 
 # --- parse_organizers ----------------------------------------------------------
-check("parse B", parse_organizers(" Gleb Lukicov;  Alex Jones ; "), ["Gleb Lukicov", "Alex Jones"])
-check("parse empty B", parse_organizers(""), [])
+check("parse Organizers cell", parse_organizers(" Gleb Lukicov;  Alex Jones ; "), ["Gleb Lukicov", "Alex Jones"])
+check("parse empty Organizers cell", parse_organizers(""), [])
 
 CHAPTERS = [chap(2, "Boston", "Kranthi Manchikanti"),
             chap(3, "Delhi NCR", ""),
@@ -61,6 +68,20 @@ check("near-miss candidates", near,
       [{"city": "Delhi", "names": ["Kritika Parmar"],
         "candidates": [("Delhi NCR", 3)]}])
 
+# --- punctuation-only differences are the SAME city, not a new row ---------------
+check("fold_city flattens punctuation", fold_city("Washington, DC"), fold_city("Washington DC"))
+DC = [chap(2, "Washington DC", "Sushant Kumar")]
+adds, new_rows, near = build_proposal([entry(2, "Donte Small", "Washington, DC")], DC, 2)
+check("comma variant merges into the existing row", (adds[0]["row"], adds[0]["new_value"]),
+      (2, "Sushant Kumar; Donte Small"))
+check("comma variant creates no row", (new_rows, near), ([], []))
+
+# --- shared-token near-miss: 'New Delhi' must not fork 'Delhi NCR' ---------------
+adds, new_rows, near = build_proposal([entry(2, "Satyam Soni", "New Delhi")], CHAPTERS, 5)
+check("shared-token near-miss writes nothing", (adds, new_rows), ([], []))
+check("shared-token near-miss names the candidate",
+      [c[0] for c in near[0]["candidates"]], ["Delhi NCR"])
+
 # --- SF is NOT mirrored into Silicon Valley -------------------------------------
 adds, new_rows, near = build_proposal([entry(2, "Leo Walker", "San Francisco")], CHAPTERS, 5)
 check("SF row only, SV untouched", [a["row"] for a in adds], [4])
@@ -75,25 +96,49 @@ check("new rows numbered from last+1",
       [(6, "Pune", ["Imran Bagwan", "Someone Else"], "pune"),
        (7, "Montréal", ["Jaime Vélez"], "montreal")])
 
-# --- empty B everywhere (first-ever run) ----------------------------------------
+# --- empty Organizers everywhere (first-ever run) ----------------------------------------
 adds, _, _ = build_proposal([entry(2, "A B", "Delhi NCR")],
                             [chap(2, "Delhi NCR", "")], 2)
-check("empty B populated", adds[0]["new_value"], "A B")
+check("empty Organizers populated", adds[0]["new_value"], "A B")
+
+# --- col_letter: writes are addressed by index, not by hand ----------------------
+check("col_letter A/I/K", [col_letter(0), col_letter(8), col_letter(10)], ["A", "I", "K"])
+check("col_letter past Z", [col_letter(25), col_letter(26)], ["Z", "AA"])
 
 # --- apply_changes: exact ranges, column order, RAW (gws mocked, no network) -----
 with mock.patch.object(sync_chapters, "gws_json") as gj:
     n = sync_chapters.apply_changes(
         [{"row": 2, "city": "Boston", "names": ["New Person"],
           "new_value": "Kranthi Manchikanti; New Person"}],
-        [{"row": 6, "city": "Pune", "names": ["Imran Bagwan"], "slug": "pune"}])
+        [{"row": 6, "city": "Pune", "names": ["Imran Bagwan"], "slug": "pune"}],
+        LAYOUT)
     body = gj.call_args.kwargs["body"]
 check("apply_changes writes both changes", n, 2)
 check("apply_changes uses RAW (no formula injection)", body["valueInputOption"], "RAW")
 check("apply_changes ranges and column order", body["data"],
-      [{"range": "'%s'!B2" % sync_chapters.CHAPTERS_TAB,
+      [{"range": "'%s'!I2" % sync_chapters.CHAPTERS_TAB,
         "values": [["Kranthi Manchikanti; New Person"]]},
-       {"range": "'%s'!A6:D6" % sync_chapters.CHAPTERS_TAB,
-        "values": [["Pune", "Imran Bagwan", "", "https://luma.com/aaif-pune"]]}])
+       {"range": "'%s'!A6:K6" % sync_chapters.CHAPTERS_TAB,
+        "values": [["AAIF Pune Chapter", "Pune", "", "", "", "", "Stay Updated",
+                    "https://luma.com/aaif-pune", "Imran Bagwan",
+                    "https://luma.com/aaif-pune", ""]]}])
+
+# --- a column reorder must move the writes, not corrupt neighbours ---------------
+SWAPPED = ["City", "Organizers", "MLOps Community Organizers", "Chapter Luma Link"]
+with mock.patch.object(sync_chapters, "gws_json") as gj:
+    sync_chapters.apply_changes(
+        [{"row": 2, "city": "Boston", "names": ["X"], "new_value": "X"}], [],
+        {"headers": SWAPPED, "index": {h: i for i, h in enumerate(SWAPPED)}})
+    check("adds follow the Organizers header", gj.call_args.kwargs["body"]["data"][0]["range"],
+          "'%s'!B2" % sync_chapters.CHAPTERS_TAB)
+
+# --- new rows never write into the editorial columns -----------------------------
+vals = sync_chapters.new_row_values(
+    {"row": 6, "city": "Pune", "names": ["Imran Bagwan"], "slug": "pune"}, LAYOUT)
+check("new row is full feed width", len(vals), len(HEADERS))
+check("editorial columns left blank",
+      [vals[LAYOUT["index"][c]] for c in sync_chapters.EDITORIAL_COLUMNS], ["", "", "", ""])
+check("MLOps history untouched on new rows", vals[LAYOUT["index"]["MLOps Community Organizers"]], "")
 
 # --- gws_json survives U+2028 inside JSON string values (the splitlines() bug) ---
 raw = '{"a": "line1\u2028line2"}\n'

--- a/skills/aaif-update-event/SKILL.md
+++ b/skills/aaif-update-event/SKILL.md
@@ -6,6 +6,21 @@ argument-hint: '<chapter|series> <event> [--set "LABEL=value"] [--date "..."]'
 
 # AAIF Update Event
 
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
 Change-driven editor for one event in a chapter/series `Event Tracker.docx`. State the
 change; the script edits the right detail fields. If you move the date, every phase task
 DUE date is recomputed (clock-time day-of tasks are left alone). It reports which


### PR DESCRIPTION
## Summary

The chapters sync was addressing a restructured sheet by hardcoded column letter and would have written organizer names into the wrong columns on its next run. This fixes that, then hardens the write path so the remaining ways it could silently write wrong data now abort instead. Separately, the "`gws` + Python only, never LibreOffice" tooling rule is stated in the SKILL.md bodies that ship downstream, with a CI guard against the copies drifting.

Note: `origin/main` already carries this branch's two earliest commits (squash-merged as #13), so the net diff is the four changesets below.

## Changesets

### 1. `docs: mandate gws + Python as the only Drive route, ban LibreOffice`
**Files:** `README.md` + 8 `SKILL.md` (+137 −29)

The rule lives in the skill bodies because the skills ship downstream and `CLAUDE.md` doesn't travel with them: prefer the native Docs/Sheets/Slides APIs (a `.docx` round-trip of a native Doc strips native features like Tabs); byte-level OOXML surgery only for genuinely stored Office files; never LibreOffice/`soffice`/`unoconv`, not even for a preview render, because it substitutes system fonts for brand fonts. README drops the connector and MCP alternatives so a human and an agent behave identically.

### 2. `fix(sync-chapters): address the chapters feed by header, not column letter`
**Files:** `aaif-sync-chapters/{SKILL.md, scripts/sync_chapters.py, scripts/test_sync_chapters.py}` (+186 −49)

The tab became an 11-column website feed; the script still read `A:D` and wrote a hardcoded `B`/`A:D`, which would have put organizer names in `Title` and the city in `City`. Now reads the full width, builds a `{header -> index}` layout, and derives every write target from it. New rows are written full width so nothing lands in a neighbouring column; the four editorial columns are left blank for a human and the report names them.

### 3. `chore: guard the tooling banner against drift, fix stale docs`
**Files:** `.pre-commit-config.yaml`, `scripts/check_tooling_banner.py` (new), `README.md`, 2 `SKILL.md` (+94 −9)

The banner is duplicated on purpose; drift between copies is not. New check asserts every copy that exists is byte-identical (it doesn't police *which* skills carry one). Also restores the `unoconv` ban to the README, removes two in-file restatements of the same rule, and corrects the skill count.

### 4. `fix(sync-chapters): address self-review findings`
**Files:** `aaif-sync-chapters/{SKILL.md, scripts/sync_chapters.py, scripts/test_sync_chapters.py}` (+340 −57)

Six review agents; 22 findings, all reproduced before being fixed. Three were regressions changeset 2 introduced:

- **`fold_city()` erased non-Latin scripts.** An ASCII allowlist folded `Москва`/`東京`/`—` to `""`. One such row made every unmatched city a near-miss (sync silently stops adding); two collided and merged an organizer into the **wrong city's row**.
- **Generic shared tokens blocked cities permanently.** A near-miss is never written and has no override, so this wasn't "one extra confirmation" — against the current sheet, `San Diego`, `San Jose`, `New Orleans`, `New Haven`, `Kansas City` and `Salt Lake City` could never be added.
- **The full-width write blanked a half-drafted row** below the table. Widening `A:D` → `A:K` took the blast radius from 4 columns to 11.

Plus: duplicate headers, silently-dropped write columns, empty Luma slugs, a `--write` that published CTAs pointing at 404s, unguarded row-number staleness, unvalidated public-form text, unreported duplicate chapter rows, and a post-write verify that could traceback — all now abort with a named reason.

**Behavior changes worth flagging:** a new `--allow-missing-luma` flag (without it, `--write` refuses rows whose Luma page isn't live), and several new abort conditions that will stop runs that previously proceeded. Both are deliberate — every one of them was a path to silently wrong data in a sheet that feeds a public website.

## Test Plan

- [x] `test_sync_chapters.py` — 55 checks pass (was 30)
- [x] All 10 skill test suites pass
- [x] `pre-commit run --all-files` — 15 hooks pass, including the new banner guard
- [x] Banner guard verified to *fail* on a one-word change, then restored
- [x] `--write` Luma gate verified: aborts and writes nothing without the flag; proceeds with it
- [x] `assert_rows_unchanged` verified to write nothing on a shifted row and on an occupied target row
- [x] Live report-only run against the production sheet: 97 organizers / 52 cities / 80 chapter rows, in sync, no guard fired
- [ ] Next `--write` against the live sheet: confirm the proposal addresses column `I` for Organizers and `A:K` for new rows, and that the re-verify prints "Verified: a fresh run proposes zero changes."

_Generated using hero-skills._