### PR TITLE
fix(clean-data): header-driven columns + idempotent install-colors

### DIFF
--- a/skills/aaif-clean-data/SKILL.md
+++ b/skills/aaif-clean-data/SKILL.md
@@ -55,13 +55,25 @@ by **header name**, never column letter.
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/clean.py install-colors
    ```
-   Labels col G **`City (Existing)`** / col H **`City (New)`** and installs three
-   rules just **under** the bright-red error rule (so errors keep top priority):
-   **violet** whole-row when `Status = "Existing (from MLOps)"`, **amber** on
-   `City (New)` when it has a value (a net-new resolved city), and **green** on
-   `City (Existing)` when it holds a real city (non-empty, not "Other"). Idempotent —
-   it matches and refreshes its own rules by formula, safe to re-run after a column
-   move. `install-flags` now also runs this, so one command does the full setup.
+   Labels the adjacent `City` / `Resolved City` pair the role-tab array formula
+   emits — **`City (Existing)`** / **`City (New)`**, at H/I today — and installs
+   three rules just **under** the bright-red error rule (so errors keep top
+   priority): **violet** whole-row when `Status = "Existing (from MLOps)"`,
+   **amber** on `City (New)` when it has a value (a net-new resolved city), and
+   **green** on `City (Existing)` when it holds a real city (non-empty, not
+   "Other").
+
+   The pair is located **by header name at run time**, never by a fixed letter —
+   it started at G/H and moved to H/I when a column was inserted upstream, which
+   made the hardcoded version abort every run. Idempotent across that move too:
+   the rules it owns are matched by formula *shape* (any column) plus one of its
+   three colors, so a refresh replaces them instead of stacking a second set at
+   the new position. Two traps that made the "safe to re-run" claim false before:
+   colors must be compared with a ±1 tolerance (Sheets floors the float→8-bit
+   conversion, so its own colors read back one unit low), and the bright-red
+   error rule is found by the `Issues` column it references, not by its color —
+   that red has been re-picked in the UI and no longer matches the constant.
+   `install-flags` now also runs this, so one command does the full setup.
 
 ## Procedure
 

--- a/skills/aaif-clean-data/SKILL.md
+++ b/skills/aaif-clean-data/SKILL.md
@@ -35,8 +35,17 @@ by **header name**, never column letter.
    python3 ${CLAUDE_SKILL_DIR}/scripts/clean.py apply changes.json
    ```
    `changes.json` is `[{"row": <source row>, "header": "<column>", "value": "<new>"}]`.
-   Writes those cells in `Form Responses` and notes what changed per row in the
-   `Autofixes` column.
+   Writes those cells in `Form Responses` and appends a note per row to the
+   `Autofixes` column, formatted **`<phrase> -> <new value>`** (`;` joins phrases
+   within one run, `|` joins runs). The value is carried so a second edit to the
+   same field isn't deduped away as a repeat of the first; separators are stripped
+   out of it, because a phrase that can't be split back out re-appends every run.
+
+   `row` must be a data row (2..last); row 1 is the header and is refused. Values
+   are written **RAW**, never `USER_ENTERED` — the form is public, and the
+   normalizers will happily re-case `=IMPORTXML(...)` into a still-valid formula
+   that would otherwise go live on write. If no requested header matches a column,
+   the run aborts rather than reporting "No changes to apply".
 
 3. **Install-flags (maintenance)** — add/refresh the live error flag:
    ```bash
@@ -48,8 +57,10 @@ by **header name**, never column letter.
    auto-clears once fixed, and is distinct from the light-red "Denied" status.
    `City="Other"` is deliberately **NOT** an error (it's a normalization to resolve,
    surfaced by `scan`), so it never turns a row red. Already installed — re-run to
-   re-point the `Issues` formula after a column move; the existing red rule is
-   **kept** as-is (the run reports it as `kept`), not rewritten.
+   re-point the `Issues` formula after a column move. An existing red rule is not
+   duplicated: its **range** is re-pointed in place (reported as `range re-pointed`)
+   while its colour is left alone, since the red has been re-picked in the UI and
+   that choice is the operator's.
 
 4. **Install-colors (maintenance)** — label the two city columns and provenance-color
    the role tabs:
@@ -64,28 +75,41 @@ by **header name**, never column letter.
    value (a net-new resolved city), and **green** on `City (Existing)` when it
    holds a real city (non-empty, not "Other").
 
-   The pair is located **by header name at run time**, never by a fixed letter —
-   it started at G/H and moved to H/I when a column was inserted upstream, which
-   made the hardcoded version abort every run. It **aborts before writing
-   anything** if a tab has no such pair, more than one, or a half-labelled one
-   (evidence a previous run died mid-way); all three role tabs are validated up
-   front, so a failure on one never leaves another half-applied.
+   Every column it touches — the city pair **and** `Status` for the violet rule —
+   is located **by header name at run time**, never by a fixed letter. The pair
+   started at G/H and moved to H/I when a column was inserted upstream, which made
+   the hardcoded version abort every run.
+
+   `install-colors` **validates all three role tabs before writing to any of
+   them**, and aborts if a tab has no city pair, more than one, a half-labelled
+   one, no `Status` column, or a sheetId missing from the spreadsheet. That covers
+   *validation* failures only — a mid-run API error can still leave one tab
+   written and the next not, since tabs are written one at a time. Note that
+   invoking this via `install-flags` writes the `Issues` columns to all three tabs
+   **first**, so an abort there is not "before writing anything".
 
    Idempotent across a column move: the rules it owns are matched by formula
    *shape* (any column) plus one of its three colors, so a refresh replaces them
-   instead of stacking a second set. Three traps that made the "safe to re-run"
+   instead of stacking a second set. Four traps that made the "safe to re-run"
    claim false before:
 
    - colors must be compared with a **±1 tolerance** — Sheets floors the
      float→8-bit conversion, so its own colors read back one unit low. This
      applies to the bright-red rule too, not just the three provenance colors;
-   - the bright-red error rule is found by the **`Issues` column it references**,
-     not by its color — that red has been re-picked in the UI and no longer
-     matches the constant. If it cannot be located at all, the run warns on
-     stderr rather than silently installing above it;
-   - every pattern must accept **any column**, including violet's — Sheets
-     rewrites stored rule formulas when a column is inserted, so a pattern
-     pinned to a letter stops matching exactly when it is needed most.
+   - the bright-red error rule is found by the **`Issues` column it references**
+     *and* verified to actually be red — that red has been re-picked in the UI and
+     no longer matches the constant, and matching on formula text alone put the
+     provenance rules above an operator's own rule on the same column. If it
+     cannot be located, the run warns on stderr and installs at index 0 anyway —
+     **above** any error highlighting;
+   - patterns must accept **any column** — Sheets rewrites stored rule formulas
+     when a column is inserted, so a pattern pinned to a letter stops matching
+     exactly when it is needed most. But a pattern must still bind one rule to
+     one column: the green ones backreference, so a rule painting H while testing
+     Z is not recognised as ours;
+   - matching a rule is not the same as rebuilding it correctly. Widening the
+     violet pattern only fixed *recognition*; `Status` had to be discovered by
+     header too, or a rule deleted at `$B2` would be reinstalled at `$A2`.
 
    `install-flags` now also runs this, so one command does the full setup.
 

--- a/skills/aaif-clean-data/SKILL.md
+++ b/skills/aaif-clean-data/SKILL.md
@@ -47,32 +47,46 @@ by **header name**, never column letter.
    there's a genuine error — **missing/invalid email or a broken LinkedIn URL**. It
    auto-clears once fixed, and is distinct from the light-red "Denied" status.
    `City="Other"` is deliberately **NOT** an error (it's a normalization to resolve,
-   surfaced by `scan`), so it never turns a row red. Already installed — re-run only
-   to refresh after a column move.
+   surfaced by `scan`), so it never turns a row red. Already installed — re-run to
+   re-point the `Issues` formula after a column move; the existing red rule is
+   **kept** as-is (the run reports it as `kept`), not rewritten.
 
 4. **Install-colors (maintenance)** — label the two city columns and provenance-color
    the role tabs:
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/clean.py install-colors
    ```
-   Labels the adjacent `City` / `Resolved City` pair the role-tab array formula
-   emits — **`City (Existing)`** / **`City (New)`**, at H/I today — and installs
-   three rules just **under** the bright-red error rule (so errors keep top
-   priority): **violet** whole-row when `Status = "Existing (from MLOps)"`,
-   **amber** on `City (New)` when it has a value (a net-new resolved city), and
-   **green** on `City (Existing)` when it holds a real city (non-empty, not
-   "Other").
+   **Overwrites the two header cells** of the adjacent `City` / `Resolved City`
+   pair the role-tab array formula emits, relabelling them **`City (Existing)`** /
+   **`City (New)`**, and installs three rules just **under** the bright-red error
+   rule (so errors keep top priority): **violet** whole-row when
+   `Status = "Existing (from MLOps)"`, **amber** on `City (New)` when it has a
+   value (a net-new resolved city), and **green** on `City (Existing)` when it
+   holds a real city (non-empty, not "Other").
 
    The pair is located **by header name at run time**, never by a fixed letter —
    it started at G/H and moved to H/I when a column was inserted upstream, which
-   made the hardcoded version abort every run. Idempotent across that move too:
-   the rules it owns are matched by formula *shape* (any column) plus one of its
-   three colors, so a refresh replaces them instead of stacking a second set at
-   the new position. Two traps that made the "safe to re-run" claim false before:
-   colors must be compared with a ±1 tolerance (Sheets floors the float→8-bit
-   conversion, so its own colors read back one unit low), and the bright-red
-   error rule is found by the `Issues` column it references, not by its color —
-   that red has been re-picked in the UI and no longer matches the constant.
+   made the hardcoded version abort every run. It **aborts before writing
+   anything** if a tab has no such pair, more than one, or a half-labelled one
+   (evidence a previous run died mid-way); all three role tabs are validated up
+   front, so a failure on one never leaves another half-applied.
+
+   Idempotent across a column move: the rules it owns are matched by formula
+   *shape* (any column) plus one of its three colors, so a refresh replaces them
+   instead of stacking a second set. Three traps that made the "safe to re-run"
+   claim false before:
+
+   - colors must be compared with a **±1 tolerance** — Sheets floors the
+     float→8-bit conversion, so its own colors read back one unit low. This
+     applies to the bright-red rule too, not just the three provenance colors;
+   - the bright-red error rule is found by the **`Issues` column it references**,
+     not by its color — that red has been re-picked in the UI and no longer
+     matches the constant. If it cannot be located at all, the run warns on
+     stderr rather than silently installing above it;
+   - every pattern must accept **any column**, including violet's — Sheets
+     rewrites stored rule formulas when a column is inserted, so a pattern
+     pinned to a letter stops matching exactly when it is needed most.
+
    `install-flags` now also runs this, so one command does the full setup.
 
 ## Procedure
@@ -83,8 +97,8 @@ by **header name**, never column letter.
    `City="Other"` row, read that person's free-text in `Form Responses` (their
    "Why organize / ties", "Have you helped run events before?", LinkedIn, etc.) and
    infer the real city — e.g. Bangalore, Frankfurt, Luxembourg. Write the inferred
-   value into the **`Resolved City`** source column (now at `CF`; shown in the role
-   tabs as **`City (New)`**), **never overwrite the submitted `City` dropdown**
+   value into the **`Resolved City`** source column (found by header name — shown in
+   the role tabs as **`City (New)`**), **never overwrite the submitted `City` dropdown**
    (shown as **`City (Existing)`**) — that's the non-destructive rule. `City (New)`
    holds **only net-new cities** (rows where `City = "Other"`); existing form cities
    stay in `City (Existing)` and must **not** be copied across. A row stops being

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -45,16 +45,18 @@ def gws(args):
     return json.loads(txt[i:]) if i >= 0 else {}
 
 
-def read_tab(tab, rng=None):
-    """Read a whole tab. The range is the bare tab name by default so the read
-    window can never fall behind the sheet: a hardcoded bound (this used to be
-    "A1:CJ") silently truncates the moment a column is appended, and the column
-    it drops first is the newest one — which is how `Autofixes` (at CK) fell
-    outside the window and made apply() overwrite prior notes instead of
-    appending them. Sheets trims trailing empty rows/columns for us."""
-    rangespec = f"{tab}!{rng}" if rng else tab
+def read_tab(tab):
+    """Read a whole tab. The range is the bare tab name — deliberately NOT a
+    bounded one, and there is no parameter to make it bounded again: a hardcoded
+    window (this used to be "A1:CJ") silently truncates the moment a column is
+    appended, and the column it drops first is the newest one — which is how
+    `Autofixes` (at CK) fell outside the window and made apply() overwrite prior
+    notes instead of appending them. Measured against the live sheet: the bare
+    name returns 89 columns where "A1:CJ" returned 88. Sheets trims trailing
+    empty rows/columns for us, and quotes the name itself when echoing the
+    resolved range, so a tab name containing spaces needs no quoting here."""
     d = gws(["sheets", "spreadsheets", "values", "get", "--params",
-             json.dumps({"spreadsheetId": SHEET_ID, "range": rangespec,
+             json.dumps({"spreadsheetId": SHEET_ID, "range": tab,
                          "majorDimension": "ROWS"}), "--format", "json"])
     vals = d.get("values", [])
     if not vals:
@@ -76,16 +78,23 @@ def colletter(n):  # 1-based -> A1 letter
 # City (Existing) = the submitted dropdown; City (New) = the resolved "Other"
 # city. They are the adjacent City,Resolved City pair the role-tab array formula
 # emits, but their POSITION moves whenever a column is inserted upstream — they
-# started at G/H and are at H/I today. So they are located by header name at run
-# time (find_city_cols) and never hardcoded; a fixed letter here is exactly the
-# bug that made install_colors abort after the pair shifted by one.
+# started at G/H and were observed at H/I in 2026-07. So they are located by
+# header name at run time (find_city_cols) and never hardcoded; a fixed letter
+# here is exactly the bug that made install_colors abort after the pair shifted.
 VIOLET = {"red": 0.60, "green": 0.20, "blue": 0.90}   # Status = Existing (from MLOps)
 AMBER  = {"red": 0.99, "green": 0.76, "blue": 0.30}   # net-new resolved city
 GREEN  = {"red": 0.72, "green": 0.88, "blue": 0.70}   # existing form city
-# The two source-column headers marking the pair, before (or after) labeling.
+# Accepted role-tab header names for each half of the pair: pre-label
+# ("City"/"Resolved City") and post-label ("City (Existing)"/"City (New)"), so
+# discovery works both before and after install_colors renames them.
 CITY_SRC_HEADERS = ({"City", "City (Existing)"}, {"Resolved City", "City (New)"})
 
-VIOLET_FORMULA = '=$A2="Existing (from MLOps)"'      # column-independent
+# Pinned to column A because Status is written there by the role-tab array
+# formula, not discovered by header like the city pair. Sheets REWRITES stored
+# conditional-format formulas when a column is inserted, so an insert left of
+# Status turns this into "=$B2=..."; STALE_PATTERNS therefore matches any column
+# (see below) even though we only ever install at A.
+VIOLET_FORMULA = '=$A2="Existing (from MLOps)"'
 
 
 def amber_formula(new_col):
@@ -104,32 +113,57 @@ def green_formula(existing_col):
 def find_city_cols(hdr, tab):
     """1-based (City (Existing), City (New)) located by header name.
 
-    Returns the first ADJACENT pair, which is what the role-tab array formula
-    emits. Aborts loudly rather than guessing: recoloring the wrong columns
-    would paint provenance onto unrelated data."""
-    for i in range(len(hdr) - 1):
-        if hdr[i] in CITY_SRC_HEADERS[0] and hdr[i + 1] in CITY_SRC_HEADERS[1]:
-            return i + 1, i + 2
-    sys.exit(f"ABORT: {tab} has no adjacent City / Resolved City pair in its "
-             f"header row — columns moved or renamed? Headers: {hdr}")
+    Requires EXACTLY ONE adjacent pair, which is what the role-tab array formula
+    emits. Aborts loudly rather than guessing in every ambiguous case, because
+    the write target is a formula-driven role tab where a stray literal #REF!s
+    the whole sheet, and recoloring the wrong columns would paint provenance
+    onto unrelated data:
+
+    - zero pairs   -> the columns moved or were renamed;
+    - two+ pairs   -> a migration left a stale block next to the live one, and
+                      taking the leftmost would style the stale one;
+    - half-labeled -> "City (Existing)" beside "Resolved City" can only arise
+                      from an earlier run that died between the two header
+                      writes, so it is evidence of a problem, not a state to
+                      silently absorb."""
+    hits = [(i + 1, i + 2) for i in range(len(hdr) - 1)
+            if hdr[i] in CITY_SRC_HEADERS[0] and hdr[i + 1] in CITY_SRC_HEADERS[1]]
+    if len(hits) != 1:
+        sys.exit(f"ABORT: {tab} has {len(hits)} adjacent City / Resolved City pair(s) "
+                 f"at {hits}; expected exactly 1. Headers: {hdr}")
+    existing, new = hits[0]
+    if (hdr[existing - 1] == "City (Existing)") != (hdr[new - 1] == "City (New)"):
+        sys.exit(f"ABORT: {tab} city pair is half-labeled "
+                 f"({hdr[existing - 1]!r} / {hdr[new - 1]!r}) — a previous "
+                 f"install-colors run did not finish. Fix before recoloring.")
+    return existing, new
 
 
 # Our own rules are recognised by SHAPE (any column) + one of our three colors,
 # not by exact formula text. Text-matching pinned to a column letter stops
-# recognising rules the moment the pair moves, so a refresh stacks a duplicate
-# next to the old rule instead of replacing it. The color test is what keeps the
-# broad amber pattern from also matching the bright-red Issues rule (=$W2<>"").
+# recognising rules the moment Sheets rewrites them for a column insert, so a
+# refresh stacks a duplicate next to the old rule instead of replacing it — the
+# violet pattern must therefore accept any column even though we only ever
+# install at A. The color test plus the err_formula exclusion in is_ours are what
+# keep the broad amber shape from also matching the bright-red Issues rule, whose
+# formula has the identical shape. Enforcement that these stay in sync with the
+# builders above is test_recognises_installed_rules_at_any_column — there is no
+# longer a construction-time guarantee, so do not edit a builder without it.
+# The green patterns backreference their column: one rule never tests two.
 STALE_PATTERNS = (
-    re.compile(r'^=\$A2="Existing \(from MLOps\)"$'),                     # violet
-    re.compile(r'^=\$[A-Z]+2<>""$'),                                      # amber
-    re.compile(r'^=AND\(\$[A-Z]+2<>"",LEFT\(\$[A-Z]+2,5\)<>"Other"\)$'),  # green
-    re.compile(r'^=AND\(\$[A-Z]+2<>"",\$[A-Z]+2<>"Other"\)$'),            # legacy green
+    re.compile(r'^=\$[A-Z]+2="Existing \(from MLOps\)"$'),                     # violet
+    re.compile(r'^=\$[A-Z]+2<>""$'),                                           # amber
+    re.compile(r'^=AND\((?P<c>\$[A-Z]+)2<>"",LEFT\((?P=c)2,5\)<>"Other"\)$'),  # green
+    re.compile(r'^=AND\((?P<c>\$[A-Z]+)2<>"",(?P=c)2<>"Other"\)$'),            # legacy green
 )
 
 
 def _rgb8(c):
-    """Quantize a color dict to 8-bit ints — Sheets round-trips colors at 8-bit,
-    so compare with this, never with exact float equality."""
+    """Quantize a color dict to 8-bit ints — Sheets round-trips colors at 8-bit.
+    NOT sufficient for equality on its own: Sheets floors where round() rounds,
+    so use `_color_eq`, never `_rgb8(a) == _rgb8(b)` and never float equality.
+    The `.get(k, 0)` default is load-bearing, not defensive padding — the Sheets
+    Color proto OMITS zero-valued channels, so pure red arrives as {"red": 1.0}."""
     return tuple(round(c.get(k, 0) * 255) for k in ("red", "green", "blue"))
 
 
@@ -154,6 +188,28 @@ def error_rule_formula(hdr):
     return f'=${colletter(hdr.index("Issues") + 1)}2<>""' if "Issues" in hdr else None
 
 
+def autofix_note(prior, phrases):
+    """New text for a row's Autofixes cell, or None when it already says it all.
+
+    Appends rather than overwrites, and dedupes against what the cell ALREADY
+    holds — not just within one run — so re-applying a change list cannot
+    accumulate "city resolved | city resolved | ...". `prior` is split on both
+    separators this column has used historically (";" from within one run, "|"
+    between runs); a hand-typed separator won't be recognised, which costs at
+    most one duplicate phrase.
+
+    Pure so it is testable without touching Sheets, matching color_rule_plan."""
+    seen = {p.strip() for p in re.split(r"[|;]", prior) if p.strip()}
+    uniq = []
+    for p in phrases:
+        if p not in uniq and p not in seen:
+            uniq.append(p)
+    if not uniq:
+        return None
+    note = "; ".join(uniq)
+    return f"{prior} | {note}" if prior.strip() else note
+
+
 def formula_of(cf):
     """The CUSTOM_FORMULA text of a conditional-format rule, or None."""
     c = cf.get("booleanRule", {}).get("condition", {})
@@ -162,28 +218,37 @@ def formula_of(cf):
 
 
 def _is_red(cf):
-    """True if this rule is the bright-red error rule (matched by 8-bit color)."""
+    """True if this rule is the bright-red error rule, matched by color.
+
+    Uses `_color_eq`, NOT exact `_rgb8` equality: BRIGHT_RED comes back from
+    Sheets floored to (232,66,53) while _rgb8 computes (232,66,54), so an exact
+    compare never recognises the rule this module itself wrote. That made
+    color_rule_plan fall through to base=0 and install the provenance rules
+    ABOVE the error rule — the whole-row violet then hid error highlighting on
+    exactly the rows most likely to have errors."""
     bg = cf.get("booleanRule", {}).get("format", {}).get("backgroundColor")
-    return bool(bg) and _rgb8(bg) == _rgb8(BRIGHT_RED)
+    return bg is not None and _color_eq(bg, BRIGHT_RED)
 
 
-def is_ours(cf, err_formula=None):
+def is_ours(cf, err_formula):
     """True if this rule is one of the three provenance rules we install, at ANY
     column position. Requires BOTH a matching formula shape and one of our three
     background colors — the amber shape (=$X2<>"") alone also matches the
     bright-red Issues rule, and deleting that would drop error highlighting.
     `err_formula` names that rule explicitly so it is never claimed even if its
-    color has drifted to something near ours."""
+    color has drifted to something near ours; it is REQUIRED rather than
+    defaulted because omitting it silently disables that guard, and `None` (no
+    Issues column yet) stays a legitimate value to pass."""
     f = formula_of(cf)
     if not f or (err_formula and f == err_formula):
         return False
     if not any(p.match(f) for p in STALE_PATTERNS):
         return False
     bg = cf.get("booleanRule", {}).get("format", {}).get("backgroundColor")
-    return bool(bg) and any(_color_eq(bg, c) for c in (VIOLET, AMBER, GREEN))
+    return bg is not None and any(_color_eq(bg, c) for c in (VIOLET, AMBER, GREEN))
 
 
-def color_rule_plan(cfs, err_formula=None):
+def color_rule_plan(cfs, err_formula):
     """Pure planner for install_colors: given a tab's conditionalFormats, return
     (stale_indices_desc, base_index). stale = our own color rules to delete
     (matched by `is_ours`: formula SHAPE plus one of our colors, so they are
@@ -199,7 +264,17 @@ def color_rule_plan(cfs, err_formula=None):
                 if err_formula and formula_of(cf) == err_formula), None)
     if red is None:
         red = next((i for i, cf in enumerate(cfs) if _is_red(cf)), None)
+        if red is not None and err_formula:
+            print(f"WARNING: no rule references the Issues column ({err_formula}); "
+                  f"located the error rule by color instead.", file=sys.stderr)
     if red is None:
+        # Not the same fact as "the error rule is at index 0" — say so, because
+        # base=0 installs our rules at the TOP and there is no way to tell from
+        # the success message whether error priority was preserved.
+        if cfs:
+            print(f"WARNING: no bright-red error rule found among {len(cfs)} existing "
+                  f"rule(s); installing at index 0. Run install-flags first if error "
+                  f"highlighting should outrank provenance colors.", file=sys.stderr)
         base = 0
     else:
         base = red - sum(1 for s in stale if s < red) + 1
@@ -352,35 +427,35 @@ def apply(path):
             print(f"  skip: no column named {header!r}", file=sys.stderr)
             continue
         data.append({"range": f"{SOURCE}!{colletter(ci + 1)}{rn}", "values": [[new]]})
-        notes.setdefault(rn, []).append(AUTOFIX_PHRASE.get(header, f"{header} updated"))
+        # Carry the new value in the phrase. The phrase alone is per-HEADER, so
+        # a second genuine edit to the same field ("Zurich" -> "Zürich") would
+        # dedupe against the first and silently record nothing, even though the
+        # value write above already happened.
+        notes.setdefault(rn, []).append(
+            f"{AUTOFIX_PHRASE.get(header, f'{header} updated')} -> {new}")
     if not data:
         print("No changes to apply.")
         return
     gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
          json.dumps({"spreadsheetId": SHEET_ID}), "--json",
          json.dumps({"valueInputOption": "USER_ENTERED", "data": data}), "--format", "json"])
-    # annotate each touched row's Autofixes cell (append, preserving prior notes)
-    fix = []
-    for rn, phrases in notes.items():
-        prior = rows[rn - 2][ai] if (rn - 2 < len(rows) and ai < len(rows[rn - 2])) else ""
-        # Dedupe against what the cell ALREADY says, not just within this run —
-        # re-resolving a row that was resolved before would otherwise accumulate
-        # "city resolved | city resolved | ...". Split on both separators this
-        # column has ever used.
-        seen = {p.strip() for p in re.split(r"[|;]", prior) if p.strip()}
-        uniq = []
-        for p in phrases:
-            if p not in uniq and p not in seen:
-                uniq.append(p)
-        if not uniq:
-            continue                      # nothing new to say; leave the cell alone
-        note = "; ".join(uniq)
-        combined = f"{prior} | {note}" if prior.strip() else note
-        fix.append({"range": f"{SOURCE}!{colletter(ai + 1)}{rn}", "values": [[combined]]})
-    gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
-         json.dumps({"spreadsheetId": SHEET_ID}), "--json",
-         json.dumps({"valueInputOption": "RAW", "data": fix}), "--format", "json"])
-    print(f"Applied {len(data)} change(s); annotated 'Autofixes' on {len(notes)} row(s).")
+    # annotate every touched row whose note is genuinely new (see autofix_note)
+    fix = [{"range": f"{SOURCE}!{colletter(ai + 1)}{rn}", "values": [[combined]]}
+           for rn, phrases in notes.items()
+           for combined in [autofix_note(
+               rows[rn - 2][ai] if (rn - 2 < len(rows) and ai < len(rows[rn - 2])) else "",
+               phrases)]
+           if combined is not None]
+    # `fix` can now legitimately be empty (every phrase already recorded), and an
+    # empty `data` list is exactly the shape gws drops — guard it rather than
+    # firing a write whose no-op is indistinguishable from a success.
+    if fix:
+        gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
+             json.dumps({"spreadsheetId": SHEET_ID}), "--json",
+             json.dumps({"valueInputOption": "RAW", "data": fix}), "--format", "json"])
+    skipped = len(notes) - len(fix)
+    print(f"Applied {len(data)} change(s); annotated 'Autofixes' on {len(fix)} row(s)"
+          + (f" ({skipped} row(s) already noted)." if skipped else "."))
 
 
 # ---------- install live Issues flag + bright-red rule ----------
@@ -416,7 +491,9 @@ def install_flags():
                  {"range": f"{tab}!{ilet}2", "values": [[formula]]}]}), "--format", "json"])
         # add the bright-red rule only if not already installed (Issues was absent)
         if "Issues" not in hdr:
-            rng = {"sheetId": sid, "startRowIndex": 1, "endRowIndex": 1000,
+            # endRowIndex omitted: a fixed bound stops highlighting on the newest
+            # rows once the tab grows past it (see _color_rule).
+            rng = {"sheetId": sid, "startRowIndex": 1,
                    "startColumnIndex": 0, "endColumnIndex": icol}
             req = {"addConditionalFormatRule": {"index": 0, "rule": {"ranges": [rng], "booleanRule": {
                 "condition": {"type": "CUSTOM_FORMULA",
@@ -448,15 +525,30 @@ def _all_conditional_formats():
 
 
 def _color_rule(sid, index, c0, c1, formula, bg, white=False):
-    """One addConditionalFormatRule request over 0-based half-open columns."""
+    """One addConditionalFormatRule request over 0-based half-open columns.
+
+    endRowIndex is deliberately OMITTED (= to the end of the sheet). It used to
+    be a hardcoded 1000, which is the same anti-pattern read_tab just lost: past
+    that row the coloring silently stops, and the rows it stops on are the newest
+    submissions. The role tabs are already ~998 rows."""
     fmt = {"backgroundColor": bg}
     if white:
         fmt["textFormat"] = {"foregroundColor": {"red": 1, "green": 1, "blue": 1}, "bold": True}
     return {"addConditionalFormatRule": {"index": index, "rule": {
-        "ranges": [{"sheetId": sid, "startRowIndex": 1, "endRowIndex": 1000,
+        "ranges": [{"sheetId": sid, "startRowIndex": 1,
                     "startColumnIndex": c0, "endColumnIndex": c1}],
         "booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
                         "values": [{"userEnteredValue": formula}]}, "format": fmt}}}}
+
+
+def _city_rule(sid, index, col, formula_fn, bg):
+    """A one-column provenance rule. The painted range and the tested formula
+    both derive from `col` here, so they cannot drift apart — previously each
+    call site named its column three times (0-based start, 1-based end, and
+    again inside the builder), and updating two of the three yields a rule that
+    paints one column while testing another: valid to Sheets, silent, and still
+    recognised by is_ours on the next run."""
+    return _color_rule(sid, index, col - 1, col, formula_fn(col), bg)
 
 
 def install_colors():
@@ -470,15 +562,21 @@ def install_colors():
     they overlap.
     """
     all_cfs = _all_conditional_formats()
+    # Pre-flight: validate EVERY tab before writing to any of them. The loop
+    # below mutates tab-by-tab, so a find_city_cols abort on the second tab used
+    # to leave the first relabeled and re-ruled, the third untouched, and the
+    # error message describing only the tab that failed.
+    plans = {}
     for tab, sid in ROLE_TABS.items():
         hdr, _ = read_tab(tab)
+        if all_cfs.get(sid) is None:
+            sys.exit(f"ABORT: sheetId {sid} ({tab}) not found in the spreadsheet. "
+                     f"No tab modified.")
+        plans[tab] = (hdr, find_city_cols(hdr, tab))
+
+    for tab, sid in ROLE_TABS.items():
+        hdr, (city_existing_col, city_new_col) = plans[tab]
         lastcol = len(hdr)
-        # Locate the pair by header name rather than assuming a letter, so a
-        # column inserted upstream shifts the rules instead of aborting the run.
-        city_existing_col, city_new_col = find_city_cols(hdr, tab)
-        cfs = all_cfs.get(sid)
-        if cfs is None:
-            sys.exit(f"ABORT: sheetId {sid} ({tab}) not found in the spreadsheet.")
         gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",
              json.dumps({"valueInputOption": "USER_ENTERED", "data": [
@@ -486,15 +584,13 @@ def install_colors():
                   "values": [["City (Existing)"]]},
                  {"range": f"{tab}!{colletter(city_new_col)}1",
                   "values": [["City (New)"]]}]}), "--format", "json"])
-        stale, base = color_rule_plan(cfs, error_rule_formula(hdr))
+        stale, base = color_rule_plan(all_cfs[sid], error_rule_formula(hdr))
         dels = [{"deleteConditionalFormatRule": {"sheetId": sid, "index": i}}
                 for i in stale]
         adds = [
             _color_rule(sid, base + 0, 0, lastcol, VIOLET_FORMULA, VIOLET, white=True),
-            _color_rule(sid, base + 1, city_new_col - 1, city_new_col,
-                        amber_formula(city_new_col), AMBER),
-            _color_rule(sid, base + 2, city_existing_col - 1, city_existing_col,
-                        green_formula(city_existing_col), GREEN),
+            _city_rule(sid, base + 1, city_new_col, amber_formula, AMBER),
+            _city_rule(sid, base + 2, city_existing_col, green_formula, GREEN),
         ]
         gws(["sheets", "spreadsheets", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -29,10 +29,17 @@ H_NAME, H_EMAIL, H_LINKEDIN, H_CITY = "Full name", "Email", "LinkedIn URL", "Cit
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 # Per-row provenance for applied edits is recorded in this Form Responses column
-# (not a separate log tab). Phrases keep cells short; falls back to "<field> updated".
+# (not a separate log tab). Each note is written as "<phrase> -> <new value>": the
+# value is carried so a second edit to the SAME field is not deduped away as a
+# repeat of the first (see apply()). Falls back to "<field> updated -> <value>".
 AUTOFIX_COL = "Autofixes"
 AUTOFIX_PHRASE = {"LinkedIn URL": "LinkedIn normalized", "Email": "email normalized",
                   "Full name": "name normalized", "Resolved City": "city resolved"}
+# The Autofixes cell is a delimited list: ";" joins phrases within one run, "|"
+# joins runs. A phrase therefore may NOT contain either character — autofix_note
+# strips them out of the embedded value, because a phrase that cannot be split
+# back out never matches `seen` and re-appends on every single run.
+NOTE_SEPARATORS = re.compile(r"[|;]")
 
 
 # ---------- gws helpers ----------
@@ -51,10 +58,11 @@ def read_tab(tab):
     window (this used to be "A1:CJ") silently truncates the moment a column is
     appended, and the column it drops first is the newest one — which is how
     `Autofixes` (at CK) fell outside the window and made apply() overwrite prior
-    notes instead of appending them. Measured against the live sheet: the bare
-    name returns 89 columns where "A1:CJ" returned 88. Sheets trims trailing
-    empty rows/columns for us, and quotes the name itself when echoing the
-    resolved range, so a tab name containing spaces needs no quoting here."""
+    notes instead of appending them. Sheets trims trailing empty rows/columns.
+
+    The range string is ONLY a sheet title, so there is no "!" to disambiguate
+    and `Form Responses` needs no quoting — unlike an "A1"-style range, where a
+    name containing spaces must be quoted before the "!"."""
     d = gws(["sheets", "spreadsheets", "values", "get", "--params",
              json.dumps({"spreadsheetId": SHEET_ID, "range": tab,
                          "majorDimension": "ROWS"}), "--format", "json"])
@@ -84,17 +92,36 @@ def colletter(n):  # 1-based -> A1 letter
 VIOLET = {"red": 0.60, "green": 0.20, "blue": 0.90}   # Status = Existing (from MLOps)
 AMBER  = {"red": 0.99, "green": 0.76, "blue": 0.30}   # net-new resolved city
 GREEN  = {"red": 0.72, "green": 0.88, "blue": 0.70}   # existing form city
+# The labels install_colors WRITES, named once so a rename cannot update the
+# write sites while leaving the read side (CITY_SRC_HEADERS) unable to recognise
+# what was just written.
+CITY_LABELS = ("City (Existing)", "City (New)")
 # Accepted role-tab header names for each half of the pair: pre-label
-# ("City"/"Resolved City") and post-label ("City (Existing)"/"City (New)"), so
-# discovery works both before and after install_colors renames them.
-CITY_SRC_HEADERS = ({"City", "City (Existing)"}, {"Resolved City", "City (New)"})
+# ("City"/"Resolved City") and post-label, so discovery works both before and
+# after install_colors renames them.
+CITY_SRC_HEADERS = ({"City", CITY_LABELS[0]}, {"Resolved City", CITY_LABELS[1]})
 
-# Pinned to column A because Status is written there by the role-tab array
-# formula, not discovered by header like the city pair. Sheets REWRITES stored
-# conditional-format formulas when a column is inserted, so an insert left of
-# Status turns this into "=$B2=..."; STALE_PATTERNS therefore matches any column
-# (see below) even though we only ever install at A.
-VIOLET_FORMULA = '=$A2="Existing (from MLOps)"'
+STATUS_HEADER = "Status"
+
+
+def violet_formula(status_col):
+    """Violet: this row came across from the MLOps community rather than the form.
+
+    Built from the DISCOVERED Status column, not a hardcoded "$A2". Widening
+    STALE_PATTERNS to any column only fixed *recognition* — after a column is
+    inserted left of Status, Sheets rewrites the stored rule to "=$B2=..." and we
+    correctly delete it, but a pinned builder would then reinstall a rule testing
+    column A, which is no longer Status. Recognition and correctness are separate
+    problems and this is the one that mattered."""
+    return f'=${colletter(status_col)}2="Existing (from MLOps)"'
+
+
+def find_status_col(hdr, tab):
+    """1-based Status column, by header name. Aborts rather than assuming A."""
+    if STATUS_HEADER not in hdr:
+        sys.exit(f"ABORT: {tab} has no {STATUS_HEADER!r} column; the violet "
+                 f"provenance rule has nothing to test. Headers: {hdr}")
+    return hdr.index(STATUS_HEADER) + 1
 
 
 def amber_formula(new_col):
@@ -122,34 +149,38 @@ def find_city_cols(hdr, tab):
     - zero pairs   -> the columns moved or were renamed;
     - two+ pairs   -> a migration left a stale block next to the live one, and
                       taking the leftmost would style the stale one;
-    - half-labeled -> "City (Existing)" beside "Resolved City" can only arise
-                      from an earlier run that died between the two header
-                      writes, so it is evidence of a problem, not a state to
-                      silently absorb."""
+    - half-labeled -> usually a header renamed by hand, or an upstream change;
+                      an interrupted run is unlikely to produce it, since both
+                      labels go out in a single values.batchUpdate. Either way
+                      it means the two halves disagree about which generation of
+                      naming is in force, so say what is expected rather than
+                      guessing which one to keep."""
     hits = [(i + 1, i + 2) for i in range(len(hdr) - 1)
             if hdr[i] in CITY_SRC_HEADERS[0] and hdr[i + 1] in CITY_SRC_HEADERS[1]]
     if len(hits) != 1:
         sys.exit(f"ABORT: {tab} has {len(hits)} adjacent City / Resolved City pair(s) "
                  f"at {hits}; expected exactly 1. Headers: {hdr}")
     existing, new = hits[0]
-    if (hdr[existing - 1] == "City (Existing)") != (hdr[new - 1] == "City (New)"):
+    if (hdr[existing - 1] == CITY_LABELS[0]) != (hdr[new - 1] == CITY_LABELS[1]):
         sys.exit(f"ABORT: {tab} city pair is half-labeled "
-                 f"({hdr[existing - 1]!r} / {hdr[new - 1]!r}) — a previous "
-                 f"install-colors run did not finish. Fix before recoloring.")
+                 f"({hdr[existing - 1]!r} / {hdr[new - 1]!r}). Set the two headers to "
+                 f"either {CITY_LABELS[0]!r}/{CITY_LABELS[1]!r} or "
+                 f"'City'/'Resolved City', then re-run.")
     return existing, new
 
 
 # Our own rules are recognised by SHAPE (any column) + one of our three colors,
-# not by exact formula text. Text-matching pinned to a column letter stops
-# recognising rules the moment Sheets rewrites them for a column insert, so a
-# refresh stacks a duplicate next to the old rule instead of replacing it — the
-# violet pattern must therefore accept any column even though we only ever
-# install at A. The color test plus the err_formula exclusion in is_ours are what
-# keep the broad amber shape from also matching the bright-red Issues rule, whose
-# formula has the identical shape. Enforcement that these stay in sync with the
-# builders above is test_recognises_installed_rules_at_any_column — there is no
-# longer a construction-time guarantee, so do not edit a builder without it.
-# The green patterns backreference their column: one rule never tests two.
+# not by exact formula text: text pinned to a column letter stops matching the
+# moment Sheets rewrites a rule for a column insert, so a refresh stacks a
+# duplicate instead of replacing it. The color test plus the err_formula
+# exclusion in is_ours are what keep the broad amber shape from also matching the
+# bright-red Issues rule, whose formula has the identical shape. The green
+# patterns backreference their column, so a rule painting H while testing Z is
+# NOT ours. These regexes are hand-written and nothing checks them against the
+# builders above — an earlier release derived both from one set of constants;
+# that construction-time guarantee is gone, and
+# test_recognises_installed_rules_at_any_column is now the only thing that
+# catches drift. Do not edit a builder without running it.
 STALE_PATTERNS = (
     re.compile(r'^=\$[A-Z]+2="Existing \(from MLOps\)"$'),                     # violet
     re.compile(r'^=\$[A-Z]+2<>""$'),                                           # amber
@@ -193,16 +224,23 @@ def autofix_note(prior, phrases):
 
     Appends rather than overwrites, and dedupes against what the cell ALREADY
     holds — not just within one run — so re-applying a change list cannot
-    accumulate "city resolved | city resolved | ...". `prior` is split on both
-    separators this column has used historically (";" from within one run, "|"
-    between runs); a hand-typed separator won't be recognised, which costs at
-    most one duplicate phrase.
+    accumulate "city resolved | city resolved | ...".
 
-    Pure so it is testable without touching Sheets, matching color_rule_plan."""
-    seen = {p.strip() for p in re.split(r"[|;]", prior) if p.strip()}
+    Separators are stripped OUT of each incoming phrase first. `prior` is parsed
+    by splitting on them, so a phrase containing one cannot be split back out,
+    never matches `seen`, and re-appends on EVERY run — unbounded growth, the
+    exact bug this function exists to prevent. That became reachable when apply()
+    started embedding a free-text value in the phrase: `Frankfurt; Germany` and
+    `Washington, DC | DC` are ordinary values for a hand-filled Resolved City.
+    Both ends are stripped too, since `seen` is stripped and a trailing space
+    would otherwise read as a different phrase.
+
+    Pure — no I/O — so it is testable without touching Sheets."""
+    phrases = [NOTE_SEPARATORS.sub(",", p).strip() for p in phrases]
+    seen = {p.strip() for p in NOTE_SEPARATORS.split(prior) if p.strip()}
     uniq = []
     for p in phrases:
-        if p not in uniq and p not in seen:
+        if p and p not in uniq and p not in seen:
             uniq.append(p)
     if not uniq:
         return None
@@ -249,32 +287,57 @@ def is_ours(cf, err_formula):
 
 
 def color_rule_plan(cfs, err_formula):
-    """Pure planner for install_colors: given a tab's conditionalFormats, return
+    """Planner for install_colors: given a tab's conditionalFormats, return
     (stale_indices_desc, base_index). stale = our own color rules to delete
     (matched by `is_ours`: formula SHAPE plus one of our colors, so they are
     still recognised after the city pair moves); base = insert index just BELOW
-    the bright-red error rule so it keeps top priority — identified by
-    `err_formula` when given, else by color — computed from its ACTUAL position
-    (not assumed to be index 0), adjusted for the stale rules deleted above it,
-    since deletes and adds run in one batch. Testable without touching Sheets."""
+    the bright-red error rule so it keeps top priority — located by `err_formula`
+    when that is not None and the matched rule is actually red, else by color —
+    computed from its ACTUAL position (not assumed to be index 0), adjusted for
+    the stale rules deleted above it, since deletes and adds run in one batch.
+
+    Returns base=0 when no error rule can be found at all, which installs ABOVE
+    everything; that case warns on stderr. Does no I/O beyond those warnings, so
+    it stays testable without touching Sheets."""
+    def warn(msg):
+        print("WARNING: " + msg, file=sys.stderr)
+
     stale = [i for i, cf in enumerate(cfs) if is_ours(cf, err_formula)]
-    # Prefer identifying the error rule by formula; fall back to its color for
-    # sheets where install_flags has not run and no Issues column exists yet.
-    red = next((i for i, cf in enumerate(cfs)
-                if err_formula and formula_of(cf) == err_formula), None)
-    if red is None:
+    # Identify the error rule by formula, but VERIFY the colour: matching on
+    # formula text alone and taking the first hit put our rules above the real
+    # red rule whenever an operator had their own rule on the Issues column
+    # sitting higher — silently, because the only warnings were on the fallback
+    # branch, which never ran in that case.
+    hits = [i for i, cf in enumerate(cfs) if err_formula and formula_of(cf) == err_formula]
+    reds = [i for i in hits if _is_red(cfs[i])]
+    if len(hits) > 1:
+        warn(f"{len(hits)} rules reference the Issues column ({err_formula}) at {hits}; "
+             f"using {reds[0] if reds else hits[0]}. Delete the duplicates.")
+    if reds:
+        red = reds[0]
+    elif hits:
+        red = hits[0]
+        warn(f"the rule referencing {err_formula} at index {red} is not bright red; "
+             f"treating it as the error rule anyway.")
+    else:
         red = next((i for i, cf in enumerate(cfs) if _is_red(cf)), None)
-        if red is not None and err_formula:
-            print(f"WARNING: no rule references the Issues column ({err_formula}); "
-                  f"located the error rule by color instead.", file=sys.stderr)
+        if red is not None:
+            # Unconditional: err_formula being None means the Issues header was
+            # deleted or renamed, which is the state MOST worth reporting, and it
+            # also silently disables the err_formula exclusion inside is_ours.
+            warn(f"no rule references the Issues column "
+                 f"({err_formula or 'no Issues header found'}); located the error "
+                 f"rule by color instead.")
     if red is None:
         # Not the same fact as "the error rule is at index 0" — say so, because
-        # base=0 installs our rules at the TOP and there is no way to tell from
-        # the success message whether error priority was preserved.
-        if cfs:
-            print(f"WARNING: no bright-red error rule found among {len(cfs)} existing "
-                  f"rule(s); installing at index 0. Run install-flags first if error "
-                  f"highlighting should outrank provenance colors.", file=sys.stderr)
+        # base=0 installs our rules at the TOP and nothing in the success message
+        # reveals whether error priority was preserved. Warn even when cfs is
+        # empty but an Issues column exists: that means the red rule was deleted
+        # wholesale, not that this is a fresh tab.
+        if cfs or err_formula:
+            warn(f"no bright-red error rule found among {len(cfs)} existing rule(s); "
+                 f"installing at index 0, ABOVE any error highlighting. Run "
+                 f"install-flags first if that is not what you want.")
         base = 0
     else:
         base = red - sum(1 for s in stale if s < red) + 1
@@ -419,12 +482,19 @@ def apply(path):
              json.dumps({"spreadsheetId": SHEET_ID,
                          "range": f"{SOURCE}!{colletter(ai + 1)}1", "valueInputOption": "RAW"}),
              "--json", json.dumps({"values": [[AUTOFIX_COL]]}), "--format", "json"])
-    data, notes = [], {}
+    data, notes, dropped = [], {}, 0
     for ch in wanted:
         rn, header, new = ch["row"], ch["header"], ch["value"]
+        # Row 1 is the header. Without a LOWER bound, rn=1 gives rows[-1] below —
+        # seeding the note from the last data row — and writes over the header
+        # cell that this module's entire header-driven design is anchored to.
+        if not isinstance(rn, int) or not 2 <= rn <= len(rows) + 1:
+            sys.exit(f"ABORT: row {rn!r} is outside the data rows (2..{len(rows) + 1}). "
+                     f"Row 1 is the header; nothing written.")
         ci = idx(hdr, header)
         if ci is None:
             print(f"  skip: no column named {header!r}", file=sys.stderr)
+            dropped += 1
             continue
         data.append({"range": f"{SOURCE}!{colletter(ci + 1)}{rn}", "values": [[new]]})
         # Carry the new value in the phrase. The phrase alone is per-HEADER, so
@@ -434,19 +504,28 @@ def apply(path):
         notes.setdefault(rn, []).append(
             f"{AUTOFIX_PHRASE.get(header, f'{header} updated')} -> {new}")
     if not data:
+        # "already clean" and "every header in the change list was renamed away"
+        # are different facts; the second is a failure and must not exit 0.
+        if dropped:
+            sys.exit(f"ABORT: none of the {dropped} requested change(s) matched a column "
+                     f"in {SOURCE!r} — the change list is stale. Nothing written.")
         print("No changes to apply.")
         return
     gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
          json.dumps({"spreadsheetId": SHEET_ID}), "--json",
-         json.dumps({"valueInputOption": "USER_ENTERED", "data": data}), "--format", "json"])
-    # annotate every touched row whose note is genuinely new (see autofix_note)
-    fix = [{"range": f"{SOURCE}!{colletter(ai + 1)}{rn}", "values": [[combined]]}
-           for rn, phrases in notes.items()
-           for combined in [autofix_note(
-               rows[rn - 2][ai] if (rn - 2 < len(rows) and ai < len(rows[rn - 2])) else "",
-               phrases)]
-           if combined is not None]
-    # `fix` can now legitimately be empty (every phrase already recorded), and an
+         # RAW, never USER_ENTERED: these values come from a PUBLIC form, and the
+         # normalizers happily re-case "=IMPORTXML(...)" into a still-valid
+         # formula, so a submission can look like a routine capitalisation fix in
+         # scan and become a live formula here — able to exfiltrate the row. RAW
+         # keeps it inert text. Leading "=", "+", "-" and "@" are all covered.
+         json.dumps({"valueInputOption": "RAW", "data": data}), "--format", "json"])
+    # one entry per touched row, or None when the cell already says it all
+    merged = {rn: autofix_note(
+                  rows[rn - 2][ai] if ai < len(rows[rn - 2]) else "", phrases)
+              for rn, phrases in notes.items()}
+    fix = [{"range": f"{SOURCE}!{colletter(ai + 1)}{rn}", "values": [[c]]}
+           for rn, c in merged.items() if c]
+    # `fix` can legitimately be empty (every phrase already recorded), and an
     # empty `data` list is exactly the shape gws drops — guard it rather than
     # firing a write whose no-op is indistinguishable from a success.
     if fix:
@@ -489,28 +568,54 @@ def install_flags():
              json.dumps({"valueInputOption": "USER_ENTERED", "data": [
                  {"range": f"{tab}!{ilet}1", "values": [["Issues"]]},
                  {"range": f"{tab}!{ilet}2", "values": [[formula]]}]}), "--format", "json"])
-        # add the bright-red rule only if not already installed (Issues was absent)
-        if "Issues" not in hdr:
-            # endRowIndex omitted: a fixed bound stops highlighting on the newest
-            # rows once the tab grows past it (see _color_rule).
-            rng = {"sheetId": sid, "startRowIndex": 1,
-                   "startColumnIndex": 0, "endColumnIndex": icol}
+        # endRowIndex omitted: a fixed bound stops highlighting on the newest
+        # rows once the tab grows past it (see _color_rule).
+        rng = {"sheetId": sid, "startRowIndex": 1,
+               "startColumnIndex": 0, "endColumnIndex": icol}
+        if "Issues" in hdr:
+            # The rule already exists, so ADDING one would duplicate it — but
+            # leaving it alone was how the endRowIndex fix failed to reach the
+            # live sheet: every role tab's red rule was installed with the old
+            # hardcoded 1000 and nothing ever rewrote it, so the one rule that
+            # flags broken emails stayed bounded while the provenance colors
+            # became unbounded. Re-point its RANGE in place, preserving whatever
+            # color the rule currently has (the red has been re-picked in the UI
+            # and that choice is the operator's, not ours).
+            existing = _all_conditional_formats().get(sid, [])
+            err = f'=${ilet}2<>""'
+            at = next((i for i, cf in enumerate(existing) if formula_of(cf) == err), None)
+            if at is None:
+                print(f"  {tab}: no rule references {err}; leaving conditional "
+                      f"formats alone.", file=sys.stderr)
+                req = None
+            else:
+                rule = dict(existing[at])
+                rule["ranges"] = [rng]
+                req = {"updateConditionalFormatRule": {"sheetId": sid, "index": at,
+                                                       "rule": rule}}
+        else:
             req = {"addConditionalFormatRule": {"index": 0, "rule": {"ranges": [rng], "booleanRule": {
                 "condition": {"type": "CUSTOM_FORMULA",
                               "values": [{"userEnteredValue": f'=${ilet}2<>""'}]},
                 "format": {"backgroundColor": BRIGHT_RED,
                            "textFormat": {"foregroundColor": {"red": 1, "green": 1, "blue": 1}, "bold": True}}}}}}
+        reqs = [req] if req else []
+        if "Issues" not in hdr:
             # bold header for the new column too
-            hdrfmt = {"repeatCell": {"range": {"sheetId": sid, "startRowIndex": 0, "endRowIndex": 1,
-                      "startColumnIndex": icol - 1, "endColumnIndex": icol},
-                      "cell": {"userEnteredFormat": {"textFormat": {"bold": True},
-                               "backgroundColor": {"red": 0.85, "green": 0.85, "blue": 0.85}}},
-                      "fields": "userEnteredFormat.textFormat.bold,userEnteredFormat.backgroundColor"}}
+            reqs.append({"repeatCell": {"range": {"sheetId": sid, "startRowIndex": 0, "endRowIndex": 1,
+                        "startColumnIndex": icol - 1, "endColumnIndex": icol},
+                        "cell": {"userEnteredFormat": {"textFormat": {"bold": True},
+                                 "backgroundColor": {"red": 0.85, "green": 0.85, "blue": 0.85}}},
+                        "fields": "userEnteredFormat.textFormat.bold,userEnteredFormat.backgroundColor"}})
+        if reqs:
             gws(["sheets", "spreadsheets", "batchUpdate", "--params",
                  json.dumps({"spreadsheetId": SHEET_ID}), "--json",
-                 json.dumps({"requests": [req, hdrfmt]}), "--format", "json"])
-        print(f"{tab}: Issues column at {ilet}, bright-red rule "
-              f"{'kept' if 'Issues' in hdr else 'added'}.")
+                 json.dumps({"requests": reqs}), "--format", "json"])
+        if "Issues" in hdr:
+            action = "range re-pointed" if req else "left alone (not found)"
+        else:
+            action = "added"
+        print(f"{tab}: Issues column at {ilet}, bright-red rule {action}.")
     install_colors()
 
 
@@ -541,13 +646,19 @@ def _color_rule(sid, index, c0, c1, formula, bg, white=False):
                         "values": [{"userEnteredValue": formula}]}, "format": fmt}}}}
 
 
-def _city_rule(sid, index, col, formula_fn, bg):
+# (builder, color) travel together. A loose `bg` argument was silently
+# unconstrained: installing a rule in a color is_ours does not know makes it
+# invisible to every later run, so each run stacks a fresh duplicate — the exact
+# bug this module exists to prevent. Pass one of these, never a bare color.
+AMBER_RULE = (amber_formula, AMBER)
+GREEN_RULE = (green_formula, GREEN)
+
+
+def _city_rule(sid, index, col, rule):
     """A one-column provenance rule. The painted range and the tested formula
-    both derive from `col` here, so they cannot drift apart — previously each
-    call site named its column three times (0-based start, 1-based end, and
-    again inside the builder), and updating two of the three yields a rule that
-    paints one column while testing another: valid to Sheets, silent, and still
-    recognised by is_ours on the next run."""
+    both derive from `col`, so a rule can never paint one column while testing
+    another — which Sheets accepts silently and `is_ours` still recognises."""
+    formula_fn, bg = rule
     return _color_rule(sid, index, col - 1, col, formula_fn(col), bg)
 
 
@@ -572,25 +683,27 @@ def install_colors():
         if all_cfs.get(sid) is None:
             sys.exit(f"ABORT: sheetId {sid} ({tab}) not found in the spreadsheet. "
                      f"No tab modified.")
-        plans[tab] = (hdr, find_city_cols(hdr, tab))
+        # sid lives in the plan so the write loop iterates ONE source, not two
+        # that must stay in lockstep.
+        plans[tab] = (sid, hdr, find_status_col(hdr, tab), find_city_cols(hdr, tab))
 
-    for tab, sid in ROLE_TABS.items():
-        hdr, (city_existing_col, city_new_col) = plans[tab]
+    for tab, (sid, hdr, status_col, (city_existing_col, city_new_col)) in plans.items():
         lastcol = len(hdr)
         gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",
              json.dumps({"valueInputOption": "USER_ENTERED", "data": [
                  {"range": f"{tab}!{colletter(city_existing_col)}1",
-                  "values": [["City (Existing)"]]},
+                  "values": [[CITY_LABELS[0]]]},
                  {"range": f"{tab}!{colletter(city_new_col)}1",
-                  "values": [["City (New)"]]}]}), "--format", "json"])
+                  "values": [[CITY_LABELS[1]]]}]}), "--format", "json"])
         stale, base = color_rule_plan(all_cfs[sid], error_rule_formula(hdr))
         dels = [{"deleteConditionalFormatRule": {"sheetId": sid, "index": i}}
                 for i in stale]
         adds = [
-            _color_rule(sid, base + 0, 0, lastcol, VIOLET_FORMULA, VIOLET, white=True),
-            _city_rule(sid, base + 1, city_new_col, amber_formula, AMBER),
-            _city_rule(sid, base + 2, city_existing_col, green_formula, GREEN),
+            _color_rule(sid, base + 0, 0, lastcol,
+                        violet_formula(status_col), VIOLET, white=True),
+            _city_rule(sid, base + 1, city_new_col, AMBER_RULE),
+            _city_rule(sid, base + 2, city_existing_col, GREEN_RULE),
         ]
         gws(["sheets", "spreadsheets", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -45,9 +45,16 @@ def gws(args):
     return json.loads(txt[i:]) if i >= 0 else {}
 
 
-def read_tab(tab, rng="A1:CJ"):
+def read_tab(tab, rng=None):
+    """Read a whole tab. The range is the bare tab name by default so the read
+    window can never fall behind the sheet: a hardcoded bound (this used to be
+    "A1:CJ") silently truncates the moment a column is appended, and the column
+    it drops first is the newest one — which is how `Autofixes` (at CK) fell
+    outside the window and made apply() overwrite prior notes instead of
+    appending them. Sheets trims trailing empty rows/columns for us."""
+    rangespec = f"{tab}!{rng}" if rng else tab
     d = gws(["sheets", "spreadsheets", "values", "get", "--params",
-             json.dumps({"spreadsheetId": SHEET_ID, "range": f"{tab}!{rng}",
+             json.dumps({"spreadsheetId": SHEET_ID, "range": rangespec,
                          "majorDimension": "ROWS"}), "--format", "json"])
     vals = d.get("values", [])
     if not vals:
@@ -66,38 +73,85 @@ def colletter(n):  # 1-based -> A1 letter
 
 
 # ---------- role-tab provenance colors ----------
-# City (Existing) = col G (submitted dropdown); City (New) = col H (resolved
-# "Other" city). These two are addressed by fixed LETTER position — an explicit
-# exception to this module's usual header-name rule — because they are the
-# adjacent City,Resolved City pair the role-tab array formula always emits at
-# G then H. install_colors() guards that G/H really hold that pair before writing.
-CITY_EXISTING_COL, CITY_NEW_COL = 7, 8            # 1-based (G, H)
+# City (Existing) = the submitted dropdown; City (New) = the resolved "Other"
+# city. They are the adjacent City,Resolved City pair the role-tab array formula
+# emits, but their POSITION moves whenever a column is inserted upstream — they
+# started at G/H and are at H/I today. So they are located by header name at run
+# time (find_city_cols) and never hardcoded; a fixed letter here is exactly the
+# bug that made install_colors abort after the pair shifted by one.
 VIOLET = {"red": 0.60, "green": 0.20, "blue": 0.90}   # Status = Existing (from MLOps)
 AMBER  = {"red": 0.99, "green": 0.76, "blue": 0.30}   # net-new resolved city
 GREEN  = {"red": 0.72, "green": 0.88, "blue": 0.70}   # existing form city
-# Build the three rule formulas ONCE from the column constants, so the set used
-# to detect our own rules (for idempotent refresh) can never drift from the set
-# used to install them.
-VIOLET_FORMULA = '=$A2="Existing (from MLOps)"'
-AMBER_FORMULA = f'=${colletter(CITY_NEW_COL)}2<>""'
-# "Real city" = non-empty and not ANY "Other..." placeholder — the form has both
-# "Other" and "Other (PLEASE TELL US WHERE IN NEXT QUESTION)", so match the prefix.
-GREEN_FORMULA = (f'=AND(${colletter(CITY_EXISTING_COL)}2<>"",'
-                 f'LEFT(${colletter(CITY_EXISTING_COL)}2,5)<>"Other")')
-COLOR_FORMULAS = {VIOLET_FORMULA, AMBER_FORMULA, GREEN_FORMULA}
-# Formulas earlier releases installed: matched as stale so a refresh REPLACES
-# them instead of stacking a duplicate rule next to the old one.
-LEGACY_COLOR_FORMULAS = {(f'=AND(${colletter(CITY_EXISTING_COL)}2<>"",'
-                          f'${colletter(CITY_EXISTING_COL)}2<>"Other")')}
-STALE_COLOR_FORMULAS = COLOR_FORMULAS | LEGACY_COLOR_FORMULAS
-# The two source-column headers we expect at G/H before (or after) labeling.
+# The two source-column headers marking the pair, before (or after) labeling.
 CITY_SRC_HEADERS = ({"City", "City (Existing)"}, {"Resolved City", "City (New)"})
+
+VIOLET_FORMULA = '=$A2="Existing (from MLOps)"'      # column-independent
+
+
+def amber_formula(new_col):
+    """Amber: this row has a net-new resolved city."""
+    return f'=${colletter(new_col)}2<>""'
+
+
+def green_formula(existing_col):
+    """Green: the submitted city is a real one — non-empty and not ANY "Other..."
+    placeholder (the form has both "Other" and "Other (PLEASE TELL US WHERE IN
+    NEXT QUESTION)"), so match the prefix rather than the exact string."""
+    c = colletter(existing_col)
+    return f'=AND(${c}2<>"",LEFT(${c}2,5)<>"Other")'
+
+
+def find_city_cols(hdr, tab):
+    """1-based (City (Existing), City (New)) located by header name.
+
+    Returns the first ADJACENT pair, which is what the role-tab array formula
+    emits. Aborts loudly rather than guessing: recoloring the wrong columns
+    would paint provenance onto unrelated data."""
+    for i in range(len(hdr) - 1):
+        if hdr[i] in CITY_SRC_HEADERS[0] and hdr[i + 1] in CITY_SRC_HEADERS[1]:
+            return i + 1, i + 2
+    sys.exit(f"ABORT: {tab} has no adjacent City / Resolved City pair in its "
+             f"header row — columns moved or renamed? Headers: {hdr}")
+
+
+# Our own rules are recognised by SHAPE (any column) + one of our three colors,
+# not by exact formula text. Text-matching pinned to a column letter stops
+# recognising rules the moment the pair moves, so a refresh stacks a duplicate
+# next to the old rule instead of replacing it. The color test is what keeps the
+# broad amber pattern from also matching the bright-red Issues rule (=$W2<>"").
+STALE_PATTERNS = (
+    re.compile(r'^=\$A2="Existing \(from MLOps\)"$'),                     # violet
+    re.compile(r'^=\$[A-Z]+2<>""$'),                                      # amber
+    re.compile(r'^=AND\(\$[A-Z]+2<>"",LEFT\(\$[A-Z]+2,5\)<>"Other"\)$'),  # green
+    re.compile(r'^=AND\(\$[A-Z]+2<>"",\$[A-Z]+2<>"Other"\)$'),            # legacy green
+)
 
 
 def _rgb8(c):
     """Quantize a color dict to 8-bit ints — Sheets round-trips colors at 8-bit,
     so compare with this, never with exact float equality."""
     return tuple(round(c.get(k, 0) * 255) for k in ("red", "green", "blue"))
+
+
+def _color_eq(a, b, tol=1):
+    """8-bit color compare with a ±1 per-channel tolerance.
+
+    Sheets FLOORS the float->8-bit conversion where round() rounds, so a color
+    written as 0.90 comes back as 229 while round(0.90*255) is 230. Exact
+    equality therefore fails to recognise our own rules on the round trip —
+    which silently breaks idempotency: install_colors stops seeing the rules it
+    installed and stacks a duplicate set next to them on every run."""
+    return all(abs(x - y) <= tol for x, y in zip(_rgb8(a), _rgb8(b)))
+
+
+def error_rule_formula(hdr):
+    """Formula of the bright-red data-error rule install_flags writes.
+
+    Identified by the column it references, not by color: the red has been
+    re-picked in the UI (it is (214,28,30) today, not the BRIGHT_RED this module
+    writes), and a color match then fails to find it — which would drop our
+    rules ABOVE the error rule instead of below, losing error priority."""
+    return f'=${colletter(hdr.index("Issues") + 1)}2<>""' if "Issues" in hdr else None
 
 
 def formula_of(cf):
@@ -113,15 +167,38 @@ def _is_red(cf):
     return bool(bg) and _rgb8(bg) == _rgb8(BRIGHT_RED)
 
 
-def color_rule_plan(cfs):
+def is_ours(cf, err_formula=None):
+    """True if this rule is one of the three provenance rules we install, at ANY
+    column position. Requires BOTH a matching formula shape and one of our three
+    background colors — the amber shape (=$X2<>"") alone also matches the
+    bright-red Issues rule, and deleting that would drop error highlighting.
+    `err_formula` names that rule explicitly so it is never claimed even if its
+    color has drifted to something near ours."""
+    f = formula_of(cf)
+    if not f or (err_formula and f == err_formula):
+        return False
+    if not any(p.match(f) for p in STALE_PATTERNS):
+        return False
+    bg = cf.get("booleanRule", {}).get("format", {}).get("backgroundColor")
+    return bool(bg) and any(_color_eq(bg, c) for c in (VIOLET, AMBER, GREEN))
+
+
+def color_rule_plan(cfs, err_formula=None):
     """Pure planner for install_colors: given a tab's conditionalFormats, return
     (stale_indices_desc, base_index). stale = our own color rules to delete
-    (matched by formula); base = insert index just BELOW the bright-red error
-    rule so it keeps top priority — computed from the red rule's ACTUAL position
+    (matched by `is_ours`: formula SHAPE plus one of our colors, so they are
+    still recognised after the city pair moves); base = insert index just BELOW
+    the bright-red error rule so it keeps top priority — identified by
+    `err_formula` when given, else by color — computed from its ACTUAL position
     (not assumed to be index 0), adjusted for the stale rules deleted above it,
     since deletes and adds run in one batch. Testable without touching Sheets."""
-    stale = [i for i, cf in enumerate(cfs) if formula_of(cf) in STALE_COLOR_FORMULAS]
-    red = next((i for i, cf in enumerate(cfs) if _is_red(cf)), None)
+    stale = [i for i, cf in enumerate(cfs) if is_ours(cf, err_formula)]
+    # Prefer identifying the error rule by formula; fall back to its color for
+    # sheets where install_flags has not run and no Issues column exists yet.
+    red = next((i for i, cf in enumerate(cfs)
+                if err_formula and formula_of(cf) == err_formula), None)
+    if red is None:
+        red = next((i for i, cf in enumerate(cfs) if _is_red(cf)), None)
     if red is None:
         base = 0
     else:
@@ -286,10 +363,17 @@ def apply(path):
     fix = []
     for rn, phrases in notes.items():
         prior = rows[rn - 2][ai] if (rn - 2 < len(rows) and ai < len(rows[rn - 2])) else ""
+        # Dedupe against what the cell ALREADY says, not just within this run —
+        # re-resolving a row that was resolved before would otherwise accumulate
+        # "city resolved | city resolved | ...". Split on both separators this
+        # column has ever used.
+        seen = {p.strip() for p in re.split(r"[|;]", prior) if p.strip()}
         uniq = []
         for p in phrases:
-            if p not in uniq:
+            if p not in uniq and p not in seen:
                 uniq.append(p)
+        if not uniq:
+            continue                      # nothing new to say; leave the cell alone
         note = "; ".join(uniq)
         combined = f"{prior} | {note}" if prior.strip() else note
         fix.append({"range": f"{SOURCE}!{colletter(ai + 1)}{rn}", "values": [[combined]]})
@@ -302,7 +386,7 @@ def apply(path):
 # ---------- install live Issues flag + bright-red rule ----------
 def install_flags():
     for tab, sid in ROLE_TABS.items():
-        hdr, _ = read_tab(tab, "A1:BB")
+        hdr, _ = read_tab(tab)
         def L(name):
             return colletter(hdr.index(name) + 1) if name in hdr else None
         ts = L("Timestamp")
@@ -378,7 +462,7 @@ def _color_rule(sid, index, c0, c1, formula, bg, white=False):
 def install_colors():
     """Label the two city columns and (re)install violet/amber/green rules.
 
-    Idempotent: deletes the rules it owns (matched by formula, via
+    Idempotent: deletes the rules it owns (matched by formula shape + color, via
     `color_rule_plan`) and re-adds them just below the bright-red error rule so
     the error keeps top priority. The violet whole-row rule sits above amber/
     green, so on an "Existing (from MLOps)" row the whole row (city cells
@@ -387,34 +471,30 @@ def install_colors():
     """
     all_cfs = _all_conditional_formats()
     for tab, sid in ROLE_TABS.items():
-        hdr, _ = read_tab(tab, "A1:BB")
+        hdr, _ = read_tab(tab)
         lastcol = len(hdr)
-        # Guard the fixed G/H positions before overwriting those header cells:
-        # bail loudly if a column move has shifted the City / Resolved City pair
-        # (accepts both the pre-label and already-labeled header text).
-        gcur = hdr[CITY_EXISTING_COL - 1] if len(hdr) >= CITY_EXISTING_COL else ""
-        hcur = hdr[CITY_NEW_COL - 1] if len(hdr) >= CITY_NEW_COL else ""
-        if gcur not in CITY_SRC_HEADERS[0] or hcur not in CITY_SRC_HEADERS[1]:
-            sys.exit(f"ABORT: {tab} G/H are {gcur!r}/{hcur!r}, not the expected "
-                     f"City / Resolved City pair — columns moved? Fix before recoloring.")
+        # Locate the pair by header name rather than assuming a letter, so a
+        # column inserted upstream shifts the rules instead of aborting the run.
+        city_existing_col, city_new_col = find_city_cols(hdr, tab)
         cfs = all_cfs.get(sid)
         if cfs is None:
             sys.exit(f"ABORT: sheetId {sid} ({tab}) not found in the spreadsheet.")
         gws(["sheets", "spreadsheets", "values", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",
              json.dumps({"valueInputOption": "USER_ENTERED", "data": [
-                 {"range": f"{tab}!{colletter(CITY_EXISTING_COL)}1",
+                 {"range": f"{tab}!{colletter(city_existing_col)}1",
                   "values": [["City (Existing)"]]},
-                 {"range": f"{tab}!{colletter(CITY_NEW_COL)}1",
+                 {"range": f"{tab}!{colletter(city_new_col)}1",
                   "values": [["City (New)"]]}]}), "--format", "json"])
-        stale, base = color_rule_plan(cfs)
+        stale, base = color_rule_plan(cfs, error_rule_formula(hdr))
         dels = [{"deleteConditionalFormatRule": {"sheetId": sid, "index": i}}
                 for i in stale]
         adds = [
             _color_rule(sid, base + 0, 0, lastcol, VIOLET_FORMULA, VIOLET, white=True),
-            _color_rule(sid, base + 1, CITY_NEW_COL - 1, CITY_NEW_COL, AMBER_FORMULA, AMBER),
-            _color_rule(sid, base + 2, CITY_EXISTING_COL - 1, CITY_EXISTING_COL,
-                        GREEN_FORMULA, GREEN),
+            _color_rule(sid, base + 1, city_new_col - 1, city_new_col,
+                        amber_formula(city_new_col), AMBER),
+            _color_rule(sid, base + 2, city_existing_col - 1, city_existing_col,
+                        green_formula(city_existing_col), GREEN),
         ]
         gws(["sheets", "spreadsheets", "batchUpdate", "--params",
              json.dumps({"spreadsheetId": SHEET_ID}), "--json",

--- a/skills/aaif-clean-data/scripts/test_clean.py
+++ b/skills/aaif-clean-data/scripts/test_clean.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import json
 import os
+import tempfile
 import sys
 import unittest
 
@@ -29,6 +30,13 @@ def _our_rule(formula, bg=None):
     return {"booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
             "values": [{"userEnteredValue": formula}]},
             "format": {"backgroundColor": bg if bg else clean.AMBER}}}
+
+
+def _plan(cfs, err_formula):
+    """color_rule_plan with stderr swallowed. Most tests here assert on the
+    PLAN; the warnings themselves are asserted in TestColorRulePlanWarnings."""
+    with contextlib.redirect_stderr(io.StringIO()):
+        return clean.color_rule_plan(cfs, err_formula)
 
 
 class TestColletter(unittest.TestCase):
@@ -66,6 +74,16 @@ class TestFindCityCols(unittest.TestCase):
 
 
 class TestFormulaBuilders(unittest.TestCase):
+    def test_violet_tracks_the_discovered_status_column(self):
+        self.assertEqual(clean.violet_formula(1), '=$A2="Existing (from MLOps)"')
+        self.assertEqual(clean.violet_formula(2), '=$B2="Existing (from MLOps)"')
+
+    def test_find_status_col_by_header(self):
+        self.assertEqual(clean.find_status_col(["Status", "x"], "Organizers"), 1)
+        self.assertEqual(clean.find_status_col(["NEW", "Status"], "Organizers"), 2)
+        with self.assertRaises(SystemExit):
+            clean.find_status_col(["x", "y"], "Organizers")
+
     def test_formulas_track_the_discovered_column(self):
         self.assertEqual(clean.amber_formula(9), '=$I2<>""')
         self.assertEqual(clean.green_formula(8), '=AND($H2<>"",LEFT($H2,5)<>"Other")')
@@ -98,19 +116,19 @@ class TestIsRed(unittest.TestCase):
 
 class TestColorRulePlan(unittest.TestCase):
     def test_base_1_and_no_stale_when_only_red_present(self):
-        stale, base = clean.color_rule_plan([_red_rule()], None)
+        stale, base = _plan([_red_rule()], None)
         self.assertEqual(base, 1)      # our rules go BELOW the red rule
         self.assertEqual(stale, [])
 
     def test_base_0_when_no_red(self):
-        _, base = clean.color_rule_plan([], None)
+        _, base = _plan([], None)
         self.assertEqual(base, 0)
 
     def test_stale_lists_only_our_rules_descending(self):
         cfs = [_red_rule(),
-               _our_rule(clean.VIOLET_FORMULA, clean.VIOLET),
+               _our_rule(clean.violet_formula(1), clean.VIOLET),
                _our_rule(clean.amber_formula(9), clean.AMBER)]
-        stale, base = clean.color_rule_plan(cfs, None)
+        stale, base = _plan(cfs, None)
         self.assertEqual(stale, [2, 1])   # descending, red at index 0 untouched
         self.assertEqual(base, 1)
 
@@ -118,13 +136,13 @@ class TestColorRulePlan(unittest.TestCase):
         # red is NOT at index 0 (a Status color rule precedes it); we must still
         # insert just below red, not at index 1.
         other = _our_rule('=$A2="In progress"')   # not ours, not red -> not stale
-        stale, base = clean.color_rule_plan([other, _red_rule()], None)
+        stale, base = _plan([other, _red_rule()], None)
         self.assertEqual(stale, [])
         self.assertEqual(base, 2)                  # just below red at index 1
 
     def test_base_accounts_for_stale_deleted_above_red(self):
         # a stale rule sits above red; deleting it shifts red up by one.
-        stale, base = clean.color_rule_plan(
+        stale, base = _plan(
             [_our_rule(clean.amber_formula(9), clean.AMBER), _red_rule()], None)
         self.assertEqual(stale, [0])
         self.assertEqual(base, 1)                  # red -> index 0 after delete, insert at 1
@@ -140,13 +158,13 @@ class TestIsOurs(unittest.TestCase):
                             f"amber at col {col}")
             self.assertTrue(clean.is_ours(_our_rule(clean.green_formula(col), clean.GREEN), None),
                             f"green at col {col}")
-        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, clean.VIOLET), None))
+        self.assertTrue(clean.is_ours(_our_rule(clean.violet_formula(1), clean.VIOLET), None))
 
     def test_recognises_legacy_green(self):
         # Installed by an earlier release; must be deleted on refresh, not
         # stacked next to the new rule.
         legacy = _our_rule('=AND($G2<>"",$G2<>"Other")', clean.GREEN)
-        stale, base = clean.color_rule_plan([_red_rule(), legacy], None)
+        stale, base = _plan([_red_rule(), legacy], None)
         self.assertEqual(stale, [1])
         self.assertEqual(base, 1)
 
@@ -155,7 +173,7 @@ class TestIsOurs(unittest.TestCase):
         # the Issues rule. Only the color test keeps us from deleting it and
         # silently dropping error highlighting.
         self.assertFalse(clean.is_ours(_red_rule(), None))
-        stale, _ = clean.color_rule_plan([_red_rule()], None)
+        stale, _ = _plan([_red_rule()], None)
         self.assertEqual(stale, [])
 
     def test_ignores_unrelated_and_uncolored_rules(self):
@@ -170,7 +188,7 @@ class TestIsOurs(unittest.TestCase):
         finds nothing and a refresh stacks duplicates instead of replacing."""
         as_stored = {"red": 153 / 255, "green": 51 / 255, "blue": 229 / 255}   # violet, -1 blue
         self.assertNotEqual(clean._rgb8(as_stored), clean._rgb8(clean.VIOLET))
-        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, as_stored), None))
+        self.assertTrue(clean.is_ours(_our_rule(clean.violet_formula(1), as_stored), None))
         amber_stored = {"red": 252 / 255, "green": 193 / 255, "blue": 76 / 255}
         self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(9), amber_stored), None))
 
@@ -199,7 +217,7 @@ class TestErrorRuleIdentification(unittest.TestCase):
                           "values": [{"userEnteredValue": '=$J2<>""'}]}}}
         err = clean.error_rule_formula(self.HDR)
         self.assertFalse(clean._is_red(drifted))            # colour says "not red"
-        stale, base = clean.color_rule_plan([drifted], err)
+        stale, base = _plan([drifted], err)
         self.assertEqual(stale, [])                          # never claimed as ours
         self.assertEqual(base, 1)                            # inserted BELOW it
 
@@ -227,7 +245,7 @@ class TestIsRedFlooredRoundTrip(unittest.TestCase):
         self.assertTrue(clean._color_eq(stored, clean.BRIGHT_RED))
 
     def test_plan_puts_rules_below_a_floored_red_rule(self):
-        stale, base = clean.color_rule_plan([_red_rule()], None)
+        stale, base = _plan([_red_rule()], None)
         self.assertEqual((stale, base), ([], 1))   # 1 = below, 0 would be above
 
 
@@ -242,11 +260,11 @@ class TestVioletSurvivesColumnInsert(unittest.TestCase):
         self.assertTrue(clean.is_ours(_our_rule(shifted, clean.VIOLET), None))
 
     def test_violet_still_recognised_where_we_install_it(self):
-        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, clean.VIOLET), None))
+        self.assertTrue(clean.is_ours(_our_rule(clean.violet_formula(1), clean.VIOLET), None))
 
     def test_shifted_violet_is_refreshed_not_stacked(self):
         shifted = _our_rule('=$B2="Existing (from MLOps)"', clean.VIOLET)
-        stale, _ = clean.color_rule_plan([_red_rule(), shifted], None)
+        stale, _ = _plan([_red_rule(), shifted], None)
         self.assertEqual(stale, [1])
 
 
@@ -276,9 +294,18 @@ class TestColorEqTolerance(unittest.TestCase):
         self.assertTrue(clean._color_eq(clean.AMBER, off_by_one))
 
     def test_our_colors_never_collide_at_this_tolerance(self):
+        # Sanity check only — the closest pair is 20 apart in its nearest channel,
+        # so this still passes at tol=19 and does NOT pin the bound. That job
+        # belongs to test_tolerance_is_pinned_at_one above.
         for a, b in ((clean.AMBER, clean.GREEN), (clean.AMBER, clean.VIOLET),
                      (clean.GREEN, clean.VIOLET), (clean.AMBER, clean.BRIGHT_RED)):
             self.assertFalse(clean._color_eq(a, b))
+
+    def test_rgb8_treats_omitted_channels_as_zero(self):
+        # The Sheets Color proto omits zero-valued channels, so .get(k, 0) is
+        # load-bearing: pure red really does arrive as {"red": 1.0}.
+        self.assertEqual(clean._rgb8({"red": 1.0}), (255, 0, 0))
+        self.assertEqual(clean._rgb8({}), (0, 0, 0))
 
 
 class TestFindCityColsAmbiguity(unittest.TestCase):
@@ -333,25 +360,25 @@ class TestInstallColorsWiring(unittest.TestCase):
 
     HDR = ["Status", "Full name", "Email", "LinkedIn", "City", "Resolved City", "Issues"]
 
-    def _run(self, hdr):
+    def _run(self, hdr, extra_rules=(), cfs=None):
         calls = []
         # A red rule that references THIS header's Issues column, so the run
         # takes the primary formula-match path rather than the color fallback.
         red = _red_rule()
         red["booleanRule"]["condition"]["values"][0]["userEnteredValue"] = \
             clean.error_rule_formula(hdr)
-        orig_gws, orig_read, orig_cfs, orig_tabs = (
-            clean.gws, clean.read_tab, clean._all_conditional_formats, clean.ROLE_TABS)
+        table = {1: [red] + list(extra_rules)} if cfs is None else cfs
+        # addCleanup restores even if an assertion below raises, and each target
+        # is named once — a positional re-unpack got the order wrong too easily.
+        for name in ("gws", "read_tab", "_all_conditional_formats", "ROLE_TABS"):
+            self.addCleanup(setattr, clean, name, getattr(clean, name))
         clean.gws = lambda args: calls.append(args) or {}
         clean.read_tab = lambda tab: (hdr, [])
-        clean._all_conditional_formats = lambda: {1: [red]}
+        clean._all_conditional_formats = lambda: table
         clean.ROLE_TABS = {"Organizers": 1}
-        try:
-            with contextlib.redirect_stdout(io.StringIO()):
-                clean.install_colors()
-        finally:
-            (clean.gws, clean.read_tab, clean._all_conditional_formats,
-             clean.ROLE_TABS) = orig_gws, orig_read, orig_cfs, orig_tabs
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()):
+            clean.install_colors()
         labels = json.loads(calls[0][calls[0].index("--json") + 1])["data"]
         rules = json.loads(calls[1][calls[1].index("--json") + 1])["requests"]
         return labels, rules
@@ -395,6 +422,56 @@ class TestInstallColorsWiring(unittest.TestCase):
             if "addConditionalFormatRule" in r:
                 self.assertNotIn("endRowIndex", r["addConditionalFormatRule"]["rule"]["ranges"][0])
 
+    def test_each_rule_gets_the_colour_is_ours_recognises(self):
+        # Unasserted before, so swapping AMBER/GREEN between the two calls — or
+        # passing a colour is_ours does not know, which makes the rule invisible
+        # to every later run and stacks a duplicate each time — both passed.
+        _, rules = self._run(self.HDR)
+        adds = [r["addConditionalFormatRule"] for r in rules if "addConditionalFormatRule" in r]
+        got = [a["rule"]["booleanRule"]["format"]["backgroundColor"] for a in adds]
+        self.assertEqual(got, [clean.VIOLET, clean.AMBER, clean.GREEN])
+        for c in got:
+            self.assertTrue(any(clean._color_eq(c, k)
+                                for k in (clean.VIOLET, clean.AMBER, clean.GREEN)))
+
+    def test_violet_spans_the_row_and_tests_the_discovered_status_column(self):
+        _, rules = self._run(self.HDR)
+        violet = [r["addConditionalFormatRule"] for r in rules
+                  if "addConditionalFormatRule" in r][0]["rule"]
+        rng = violet["ranges"][0]
+        self.assertEqual((rng["startColumnIndex"], rng["endColumnIndex"]), (0, len(self.HDR)))
+        # Literal, not clean.violet_formula(1): comparing against the builder
+        # under test makes a builder mutation change both sides of the assertion.
+        self.assertEqual(violet["booleanRule"]["condition"]["values"][0]["userEnteredValue"],
+                         '=$A2="Existing (from MLOps)"')
+        self.assertTrue(violet["booleanRule"]["format"]["textFormat"]["bold"])
+
+    def test_violet_follows_status_when_a_column_is_inserted_before_it(self):
+        # Widening STALE_PATTERNS fixed recognition; this is correctness — a
+        # pinned builder would reinstall a rule testing column A, not Status.
+        _, rules = self._run(["NEW"] + self.HDR)
+        violet = [r["addConditionalFormatRule"] for r in rules
+                  if "addConditionalFormatRule" in r][0]["rule"]
+        self.assertEqual(violet["booleanRule"]["condition"]["values"][0]["userEnteredValue"],
+                         '=$B2="Existing (from MLOps)"')   # literal: Status moved to B
+
+    def test_stale_rules_are_deleted_in_the_same_batch(self):
+        # The fixture had no stale rules, so `dels` was always [] and the delete
+        # path never reached the batch: `dels = []` passed.
+        stale = [_our_rule(clean.violet_formula(1), clean.VIOLET),
+                 _our_rule(clean.amber_formula(6), clean.AMBER)]
+        _, rules = self._run(self.HDR, extra_rules=stale)
+        dels = [r["deleteConditionalFormatRule"]["index"]
+                for r in rules if "deleteConditionalFormatRule" in r]
+        self.assertEqual(dels, [2, 1], "descending, so earlier deletes don't shift later ones")
+        adds = [r["addConditionalFormatRule"]["index"]
+                for r in rules if "addConditionalFormatRule" in r]
+        self.assertEqual(adds, [1, 2, 3])
+
+    def test_aborts_when_a_role_tab_sheetid_is_missing(self):
+        with self.assertRaises(SystemExit):
+            self._run(self.HDR, cfs={})
+
     def test_no_tab_is_written_when_a_later_tab_fails_preflight(self):
         calls = []
         orig = (clean.gws, clean.read_tab, clean._all_conditional_formats, clean.ROLE_TABS)
@@ -409,6 +486,241 @@ class TestInstallColorsWiring(unittest.TestCase):
             (clean.gws, clean.read_tab, clean._all_conditional_formats,
              clean.ROLE_TABS) = orig
         self.assertEqual(calls, [], "Organizers must not be written when Hosts fails preflight")
+
+
+class TestInstallFlagsRedRule(unittest.TestCase):
+    """The endRowIndex fix never reached the live sheet: the red rule was only
+    ever ADDED when Issues was absent, and Issues is present on every role tab,
+    so the one rule that flags broken emails stayed pinned at row 1000 while the
+    provenance colors became unbounded."""
+
+    BASE = ["Status", "Timestamp", "Email", "LinkedIn", "City", "Resolved City"]
+
+    def _run(self, hdr, existing=()):
+        calls = []
+        for name in ("gws", "read_tab", "_all_conditional_formats",
+                     "ROLE_TABS", "install_colors"):
+            self.addCleanup(setattr, clean, name, getattr(clean, name))
+        clean.gws = lambda args: calls.append(args) or {}
+        clean.read_tab = lambda tab: (hdr, [])
+        clean._all_conditional_formats = lambda: {1: list(existing)}
+        clean.ROLE_TABS = {"Organizers": 1}
+        clean.install_colors = lambda: None
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()):
+            clean.install_flags()
+        batch = [c for c in calls if "batchUpdate" in c and "spreadsheets" in c]
+        return [json.loads(c[c.index("--json") + 1]) for c in batch]
+
+    def test_new_rule_is_unbounded(self):
+        payloads = self._run(self.BASE)
+        req = [r for p in payloads for r in p.get("requests", [])
+               if "addConditionalFormatRule" in r][0]
+        rng = req["addConditionalFormatRule"]["rule"]["ranges"][0]
+        self.assertNotIn("endRowIndex", rng)
+
+    def test_existing_rule_has_its_range_repointed_keeping_its_colour(self):
+        hdr = self.BASE + ["Issues"]
+        drifted = {"booleanRule": {          # the live red has been re-picked in the UI
+            "format": {"backgroundColor": {"red": 214 / 255, "green": 28 / 255, "blue": 30 / 255}},
+            "condition": {"type": "CUSTOM_FORMULA",
+                          "values": [{"userEnteredValue": '=$G2<>""'}]}},
+            "ranges": [{"sheetId": 1, "startRowIndex": 1, "endRowIndex": 1000,
+                        "startColumnIndex": 0, "endColumnIndex": 7}]}
+        payloads = self._run(hdr, existing=[drifted])
+        req = [r for p in payloads for r in p.get("requests", [])
+               if "updateConditionalFormatRule" in r][0]["updateConditionalFormatRule"]
+        self.assertEqual(req["index"], 0)
+        self.assertNotIn("endRowIndex", req["rule"]["ranges"][0])
+        self.assertEqual(req["rule"]["booleanRule"]["format"]["backgroundColor"]["red"],
+                         214 / 255, "the operator's colour choice must be preserved")
+
+    def test_no_duplicate_rule_is_added_when_one_already_exists(self):
+        hdr = self.BASE + ["Issues"]
+        existing = [{"booleanRule": {"format": {"backgroundColor": clean.BRIGHT_RED},
+                     "condition": {"type": "CUSTOM_FORMULA",
+                                   "values": [{"userEnteredValue": '=$G2<>""'}]}},
+                     "ranges": [{"sheetId": 1}]}]
+        payloads = self._run(hdr, existing=existing)
+        adds = [r for p in payloads for r in p.get("requests", [])
+                if "addConditionalFormatRule" in r]
+        self.assertEqual(adds, [])
+
+
+class TestAutofixNoteSeparators(unittest.TestCase):
+    """The regression the value-carrying phrase introduced: a value containing a
+    separator could not be split back out of `prior`, so it never matched `seen`
+    and re-appended on every run — unbounded growth, the exact bug autofix_note
+    exists to prevent. Values like "Frankfurt; Germany" are ordinary here."""
+
+    def test_a_value_containing_a_separator_still_dedupes(self):
+        for value in ("Washington, DC; USA", "Washington | DC", "A;B|C"):
+            p = f"city resolved -> {value}"
+            first = clean.autofix_note("", [p])
+            self.assertIsNone(clean.autofix_note(first, [p]), f"re-appended for {value!r}")
+
+    def test_separators_are_stripped_from_the_stored_note(self):
+        note = clean.autofix_note("", ["city resolved -> Frankfurt; Germany"])
+        self.assertEqual(note, "city resolved -> Frankfurt, Germany")
+
+    def test_does_not_grow_across_repeated_runs(self):
+        p = "city resolved -> Frankfurt; Germany"
+        cell = clean.autofix_note("", [p])
+        for _ in range(5):
+            nxt = clean.autofix_note(cell, [p])
+            if nxt is not None:
+                cell = nxt
+        self.assertEqual(cell.count("city resolved"), 1)
+
+    def test_trailing_whitespace_is_not_a_different_phrase(self):
+        self.assertIsNone(clean.autofix_note("x", ["x "]))
+
+    def test_empty_phrase_never_writes_a_blank_cell(self):
+        self.assertIsNone(clean.autofix_note("", [""]))
+        self.assertIsNone(clean.autofix_note("", ["   "]))
+
+
+class TestColorRulePlanWarnings(unittest.TestCase):
+    """base=0 and a mislocated error rule both mean "provenance colors outrank
+    error highlighting". Neither is visible in the stdout success line, so the
+    stderr warning is the only signal — and round 1 wired it to the branches
+    that mattered least."""
+
+    ERR = '=$W2<>""'
+
+    def _plan(self, cfs, err):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            stale, base = clean.color_rule_plan(cfs, err)
+        return stale, base, buf.getvalue()
+
+    def _rule(self, f, bg):
+        return {"booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
+                "values": [{"userEnteredValue": f}]}, "format": {"backgroundColor": bg}}}
+
+    def test_a_non_red_rule_on_the_issues_column_does_not_outrank_the_real_one(self):
+        # An operator's own grey "rows with issues" rule sitting above the red
+        # one used to win the formula match, putting our rules ABOVE the red.
+        grey = self._rule(self.ERR, {"red": 0.8, "green": 0.8, "blue": 0.8})
+        red = _red_rule()          # same Issues column, so both are formula hits
+        red["booleanRule"]["condition"]["values"][0]["userEnteredValue"] = self.ERR
+        stale, base, err = self._plan([grey, red], self.ERR)
+        self.assertEqual(base, 2, "must insert below the REAL red rule at index 1")
+        self.assertIn("2 rules reference the Issues column", err)
+
+    def test_warns_when_the_issues_rule_is_not_red(self):
+        grey = self._rule(self.ERR, {"red": 0.8, "green": 0.8, "blue": 0.8})
+        _, base, err = self._plan([grey], self.ERR)
+        self.assertEqual(base, 1)
+        self.assertIn("is not bright red", err)
+
+    def test_warns_when_the_issues_header_is_missing(self):
+        # err_formula=None means the Issues header was deleted or renamed — the
+        # state most worth reporting, and the one round 1 left silent.
+        _, base, err = self._plan([_red_rule()], None)
+        self.assertEqual(base, 1)
+        self.assertIn("no Issues header found", err)
+
+    def test_warns_when_no_red_rule_exists_at_all(self):
+        _, base, err = self._plan([], self.ERR)
+        self.assertEqual(base, 0)
+        self.assertIn("ABOVE any error highlighting", err)
+
+    def test_silent_on_a_genuinely_fresh_tab(self):
+        _, base, err = self._plan([], None)
+        self.assertEqual((base, err), (0, ""))
+
+
+class TestReadTabRange(unittest.TestCase):
+    def test_reads_the_bare_tab_name_with_no_bound(self):
+        """The A1:CJ window silently dropped the newest column (Autofixes at CK),
+        which is what made apply() overwrite prior notes instead of appending."""
+        seen = {}
+        orig = clean.gws
+        clean.gws = lambda args: seen.update(
+            json.loads(args[args.index("--params") + 1])) or {"values": [["A", "B"], ["1"]]}
+        try:
+            hdr, rows = clean.read_tab("Form Responses")
+        finally:
+            clean.gws = orig
+        self.assertEqual(seen["range"], "Form Responses")
+        self.assertNotIn("!", seen["range"])
+        self.assertEqual((hdr, rows), (["A", "B"], [["1", ""]]))   # short rows padded
+
+
+class TestApplyEndToEnd(unittest.TestCase):
+    """apply() had no coverage at all: the empty-write guard, the annotated-row
+    count, and the value-carrying phrase could each be deleted with a green
+    suite — and each is a silent data-integrity failure on a live sheet."""
+
+    HDR = ["Timestamp", "Full name", "Resolved City", "Autofixes"]
+
+    def _apply(self, wanted, rows):
+        calls, out = [], io.StringIO()
+        orig_gws, orig_read = clean.gws, clean.read_tab
+        clean.gws = lambda args: calls.append(args) or {}
+        clean.read_tab = lambda tab: (self.HDR, [list(r) for r in rows])
+        fh = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        json.dump(wanted, fh); fh.close()
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+                clean.apply(fh.name)
+        finally:
+            clean.gws, clean.read_tab = orig_gws, orig_read
+            os.unlink(fh.name)
+        return calls, out.getvalue()
+
+    @staticmethod
+    def _payload(call):
+        return json.loads(call[call.index("--json") + 1])
+
+    def test_the_note_carries_the_new_value(self):
+        calls, _ = self._apply([{"row": 2, "header": "Resolved City", "value": "Zurich"}],
+                               [["t", "n", "", ""]])
+        note = self._payload(calls[1])["data"][0]["values"][0][0]
+        self.assertEqual(note, "city resolved -> Zurich")
+
+    def test_a_second_edit_to_the_same_field_is_recorded(self):
+        # Without the value in the phrase this dedupes to None and the edit is
+        # applied to the sheet with NO provenance — the bug the value fixes.
+        calls, _ = self._apply([{"row": 2, "header": "Resolved City", "value": "Zürich"}],
+                               [["t", "n", "", "city resolved -> Zurich"]])
+        note = self._payload(calls[1])["data"][0]["values"][0][0]
+        self.assertEqual(note, "city resolved -> Zurich | city resolved -> Zürich")
+
+    def test_no_second_write_when_every_note_is_already_present(self):
+        calls, out = self._apply([{"row": 2, "header": "Resolved City", "value": "Zurich"}],
+                                 [["t", "n", "", "city resolved -> Zurich"]])
+        self.assertEqual(len(calls), 1, "must not fire an empty-data batchUpdate")
+        self.assertIn("on 0 row(s)", out)
+        self.assertIn("1 row(s) already noted", out)
+
+    def test_counts_report_rows_actually_annotated(self):
+        calls, out = self._apply(
+            [{"row": 2, "header": "Resolved City", "value": "Zurich"},
+             {"row": 3, "header": "Resolved City", "value": "Bern"}],
+            [["t", "n", "", "city resolved -> Zurich"], ["t", "n", "", ""]])
+        self.assertIn("annotated 'Autofixes' on 1 row(s) (1 row(s) already noted).", out)
+
+    def test_values_are_written_RAW_not_USER_ENTERED(self):
+        # USER_ENTERED turns a re-cased "=IMPORTXML(...)" from the public form
+        # into a live formula that can exfiltrate the row.
+        calls, _ = self._apply([{"row": 2, "header": "Full name", "value": "=importxml(1)"}],
+                               [["t", "n", "", ""]])
+        self.assertEqual(self._payload(calls[0])["valueInputOption"], "RAW")
+
+    def test_aborts_on_the_header_row(self):
+        with self.assertRaises(SystemExit):
+            self._apply([{"row": 1, "header": "Full name", "value": "X"}], [["t", "n", "", ""]])
+
+    def test_aborts_past_the_last_data_row(self):
+        with self.assertRaises(SystemExit):
+            self._apply([{"row": 99, "header": "Full name", "value": "X"}], [["t", "n", "", ""]])
+
+    def test_aborts_when_no_requested_header_exists(self):
+        # Distinct from "already clean": a stale change list must not exit 0.
+        with self.assertRaises(SystemExit):
+            self._apply([{"row": 2, "header": "Nope", "value": "X"}], [["t", "n", "", ""]])
 
 
 if __name__ == "__main__":

--- a/skills/aaif-clean-data/scripts/test_clean.py
+++ b/skills/aaif-clean-data/scripts/test_clean.py
@@ -14,16 +14,52 @@ def _red_rule():
                       "values": [{"userEnteredValue": '=$I2<>""'}]}}}
 
 
-def _our_rule(formula):
+def _our_rule(formula, bg=None):
+    """A provenance rule as Sheets returns it. `is_ours` requires one of OUR
+    colors as well as a matching formula shape, so tests must supply one."""
     return {"booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
-            "values": [{"userEnteredValue": formula}]}}}
+            "values": [{"userEnteredValue": formula}]},
+            "format": {"backgroundColor": bg if bg else clean.AMBER}}}
 
 
 class TestColletter(unittest.TestCase):
     def test_city_columns_and_wraparound(self):
-        self.assertEqual(clean.colletter(7), "G")   # City (Existing)
-        self.assertEqual(clean.colletter(8), "H")   # City (New)
+        self.assertEqual(clean.colletter(8), "H")   # City (Existing), today
+        self.assertEqual(clean.colletter(9), "I")   # City (New), today
         self.assertEqual(clean.colletter(27), "AA")
+
+
+class TestFindCityCols(unittest.TestCase):
+    HDR_TODAY = ["Status", "Full name", "", "", "Email", "Phone", "LinkedIn",
+                 "City (Existing)", "City (New)", "Chapter / city wanted"]
+    HDR_LEGACY = ["Status", "Full name", "", "", "Email", "Phone",
+                  "City", "Resolved City", "Chapter / city wanted"]
+
+    def test_finds_labeled_pair_at_current_position(self):
+        self.assertEqual(clean.find_city_cols(self.HDR_TODAY, "Organizers"), (8, 9))
+
+    def test_finds_unlabeled_pair_at_legacy_position(self):
+        # Pre-label header text, and one column to the left of today: the whole
+        # point of discovery is that BOTH resolve without a code change.
+        self.assertEqual(clean.find_city_cols(self.HDR_LEGACY, "Organizers"), (7, 8))
+
+    def test_aborts_when_pair_absent(self):
+        with self.assertRaises(SystemExit):
+            clean.find_city_cols(["Status", "Full name", "Email"], "Organizers")
+
+    def test_requires_adjacency(self):
+        # City and Resolved City present but separated -> not the emitted pair.
+        with self.assertRaises(SystemExit):
+            clean.find_city_cols(["City", "Phone", "Resolved City"], "Organizers")
+
+
+class TestFormulaBuilders(unittest.TestCase):
+    def test_formulas_track_the_discovered_column(self):
+        self.assertEqual(clean.amber_formula(9), '=$I2<>""')
+        self.assertEqual(clean.green_formula(8), '=AND($H2<>"",LEFT($H2,5)<>"Other")')
+        # and would have produced the old text at the old position
+        self.assertEqual(clean.amber_formula(8), '=$H2<>""')
+        self.assertEqual(clean.green_formula(7), '=AND($G2<>"",LEFT($G2,5)<>"Other")')
 
 
 class TestFormulaOf(unittest.TestCase):
@@ -42,7 +78,8 @@ class TestIsRed(unittest.TestCase):
         self.assertTrue(clean._is_red(_red_rule()))
 
     def test_rejects_other_colors_and_missing_bg(self):
-        self.assertFalse(clean._is_red(_our_rule('=$H2<>""')))  # no backgroundColor
+        self.assertFalse(clean._is_red(_our_rule('=$I2<>""')))   # amber, not red
+        self.assertFalse(clean._is_red({"booleanRule": {}}))     # no backgroundColor
         self.assertFalse(clean._is_red({"booleanRule": {"format": {
             "backgroundColor": clean.VIOLET}}}))
 
@@ -58,7 +95,9 @@ class TestColorRulePlan(unittest.TestCase):
         self.assertEqual(base, 0)
 
     def test_stale_lists_only_our_rules_descending(self):
-        cfs = [_red_rule(), _our_rule(clean.VIOLET_FORMULA), _our_rule(clean.AMBER_FORMULA)]
+        cfs = [_red_rule(),
+               _our_rule(clean.VIOLET_FORMULA, clean.VIOLET),
+               _our_rule(clean.amber_formula(9), clean.AMBER)]
         stale, base = clean.color_rule_plan(cfs)
         self.assertEqual(stale, [2, 1])   # descending, red at index 0 untouched
         self.assertEqual(base, 1)
@@ -73,30 +112,92 @@ class TestColorRulePlan(unittest.TestCase):
 
     def test_base_accounts_for_stale_deleted_above_red(self):
         # a stale rule sits above red; deleting it shifts red up by one.
-        stale, base = clean.color_rule_plan([_our_rule(clean.AMBER_FORMULA), _red_rule()])
+        stale, base = clean.color_rule_plan(
+            [_our_rule(clean.amber_formula(9), clean.AMBER), _red_rule()])
         self.assertEqual(stale, [0])
         self.assertEqual(base, 1)                  # red -> index 0 after delete, insert at 1
 
 
-class TestFormulaConsistency(unittest.TestCase):
-    def test_detected_set_equals_installed_formulas(self):
-        # Guards the idempotency contract: the set used to find our rules must
-        # cover the formulas we install (plus retired ones, matched as stale).
-        self.assertEqual(clean.COLOR_FORMULAS,
-                         {clean.VIOLET_FORMULA, clean.AMBER_FORMULA, clean.GREEN_FORMULA})
-        self.assertEqual(clean.STALE_COLOR_FORMULAS,
-                         clean.COLOR_FORMULAS | clean.LEGACY_COLOR_FORMULAS)
-        self.assertEqual(clean.AMBER_FORMULA, '=$H2<>""')
-        # Green must reject ANY "Other..." placeholder, not just the bare "Other".
-        self.assertEqual(clean.GREEN_FORMULA, '=AND($G2<>"",LEFT($G2,5)<>"Other")')
+class TestIsOurs(unittest.TestCase):
+    """The idempotency contract: every rule install_colors writes must be
+    recognised again on the next run, at whatever column it landed on."""
 
-    def test_legacy_green_rule_matched_stale(self):
-        # A rule installed by an earlier release (old green formula) must be
-        # deleted on refresh, not left to stack next to the new one.
-        legacy = _our_rule('=AND($G2<>"",$G2<>"Other")')
+    def test_recognises_installed_rules_at_any_column(self):
+        for col in (7, 8, 9, 30):
+            self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(col), clean.AMBER)),
+                            f"amber at col {col}")
+            self.assertTrue(clean.is_ours(_our_rule(clean.green_formula(col), clean.GREEN)),
+                            f"green at col {col}")
+        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, clean.VIOLET)))
+
+    def test_recognises_legacy_green(self):
+        # Installed by an earlier release; must be deleted on refresh, not
+        # stacked next to the new rule.
+        legacy = _our_rule('=AND($G2<>"",$G2<>"Other")', clean.GREEN)
         stale, base = clean.color_rule_plan([_red_rule(), legacy])
         self.assertEqual(stale, [1])
         self.assertEqual(base, 1)
+
+    def test_does_not_claim_the_bright_red_issues_rule(self):
+        # The regression that matters: the amber pattern (=$X2<>"") also matches
+        # the Issues rule. Only the color test keeps us from deleting it and
+        # silently dropping error highlighting.
+        self.assertFalse(clean.is_ours(_red_rule()))
+        stale, _ = clean.color_rule_plan([_red_rule()])
+        self.assertEqual(stale, [])
+
+    def test_ignores_unrelated_and_uncolored_rules(self):
+        self.assertFalse(clean.is_ours(_our_rule('=$A2="In progress"', clean.AMBER)))
+        self.assertFalse(clean.is_ours({"booleanRule": {"condition": {
+            "type": "CUSTOM_FORMULA",
+            "values": [{"userEnteredValue": '=$I2<>""'}]}}}))   # our shape, no color
+
+    def test_recognises_rules_after_sheets_floors_the_color(self):
+        """The idempotency regression: Sheets FLOORS float->8-bit where round()
+        rounds, so our own colors come back one unit low. Exact matching then
+        finds nothing and a refresh stacks duplicates instead of replacing."""
+        as_stored = {"red": 153 / 255, "green": 51 / 255, "blue": 229 / 255}   # violet, -1 blue
+        self.assertNotEqual(clean._rgb8(as_stored), clean._rgb8(clean.VIOLET))
+        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, as_stored)))
+        amber_stored = {"red": 252 / 255, "green": 193 / 255, "blue": 76 / 255}
+        self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(9), amber_stored)))
+
+    def test_color_eq_still_rejects_a_genuinely_different_color(self):
+        self.assertFalse(clean._color_eq(clean.AMBER, clean.GREEN))
+        self.assertFalse(clean._color_eq(clean.BRIGHT_RED, {"red": 214 / 255,
+                                                            "green": 28 / 255,
+                                                            "blue": 30 / 255}))
+
+
+class TestErrorRuleIdentification(unittest.TestCase):
+    HDR = ["Status", "Full name", "", "", "Email", "Phone", "LinkedIn",
+           "City (Existing)", "City (New)", "Issues"]
+
+    def test_formula_derived_from_issues_column(self):
+        self.assertEqual(clean.error_rule_formula(self.HDR), '=$J2<>""')
+        self.assertIsNone(clean.error_rule_formula(["Status", "Email"]))
+
+    def test_error_rule_found_by_formula_when_its_color_has_drifted(self):
+        # The live sheet's error rule is (214,28,30), not BRIGHT_RED — colour
+        # matching misses it, so our rules would land ABOVE it and outrank the
+        # error highlight. Formula matching still places them below.
+        drifted = {"booleanRule": {
+            "format": {"backgroundColor": {"red": 214 / 255, "green": 28 / 255, "blue": 30 / 255}},
+            "condition": {"type": "CUSTOM_FORMULA",
+                          "values": [{"userEnteredValue": '=$J2<>""'}]}}}
+        err = clean.error_rule_formula(self.HDR)
+        self.assertFalse(clean._is_red(drifted))            # colour says "not red"
+        stale, base = clean.color_rule_plan([drifted], err)
+        self.assertEqual(stale, [])                          # never claimed as ours
+        self.assertEqual(base, 1)                            # inserted BELOW it
+
+    def test_error_rule_never_deleted_even_though_shape_matches_amber(self):
+        drifted = {"booleanRule": {
+            "format": {"backgroundColor": {"red": 252 / 255, "green": 193 / 255, "blue": 76 / 255}},
+            "condition": {"type": "CUSTOM_FORMULA",
+                          "values": [{"userEnteredValue": '=$J2<>""'}]}}}
+        # worst case: error rule shaped like amber AND coloured like amber
+        self.assertFalse(clean.is_ours(drifted, clean.error_rule_formula(self.HDR)))
 
 
 if __name__ == "__main__":

--- a/skills/aaif-clean-data/scripts/test_clean.py
+++ b/skills/aaif-clean-data/scripts/test_clean.py
@@ -1,3 +1,6 @@
+import contextlib
+import io
+import json
 import os
 import sys
 import unittest
@@ -7,25 +10,34 @@ import clean  # noqa: E402
 
 
 def _red_rule():
-    # Sheets round-trips BRIGHT_RED (0.91,0.26,0.21) at 8-bit: 232/66/54 over 255.
+    """The bright-red error rule AS SHEETS RETURNS IT.
+
+    Blue is 53, not 54: BRIGHT_RED's 0.21*255 = 53.55, and Sheets FLOORS where
+    round() rounds. The fixture used to say 54 — the round value — which made
+    the suite agree with the bug that `_is_red`'s exact compare could never
+    match a rule this module wrote."""
     return {"booleanRule": {
-        "format": {"backgroundColor": {"red": 232 / 255, "green": 66 / 255, "blue": 54 / 255}},
+        "format": {"backgroundColor": {"red": 232 / 255, "green": 66 / 255, "blue": 53 / 255}},
         "condition": {"type": "CUSTOM_FORMULA",
                       "values": [{"userEnteredValue": '=$I2<>""'}]}}}
 
 
 def _our_rule(formula, bg=None):
     """A provenance rule as Sheets returns it. `is_ours` requires one of OUR
-    colors as well as a matching formula shape, so tests must supply one."""
+    colors as well as a matching formula shape; this defaults to AMBER, so pass
+    `bg` explicitly when the specific color is what the test is about."""
     return {"booleanRule": {"condition": {"type": "CUSTOM_FORMULA",
             "values": [{"userEnteredValue": formula}]},
             "format": {"backgroundColor": bg if bg else clean.AMBER}}}
 
 
 class TestColletter(unittest.TestCase):
-    def test_city_columns_and_wraparound(self):
-        self.assertEqual(clean.colletter(8), "H")   # City (Existing), today
-        self.assertEqual(clean.colletter(9), "I")   # City (New), today
+    def test_colletter_arithmetic(self):
+        # Pure base-26; deliberately NOT annotated with which city column is
+        # where — that mapping moves, and a comment here would rot while the
+        # assertion stayed green. It is covered in TestFindCityCols instead.
+        self.assertEqual(clean.colletter(8), "H")
+        self.assertEqual(clean.colletter(9), "I")
         self.assertEqual(clean.colletter(27), "AA")
 
 
@@ -86,19 +98,19 @@ class TestIsRed(unittest.TestCase):
 
 class TestColorRulePlan(unittest.TestCase):
     def test_base_1_and_no_stale_when_only_red_present(self):
-        stale, base = clean.color_rule_plan([_red_rule()])
+        stale, base = clean.color_rule_plan([_red_rule()], None)
         self.assertEqual(base, 1)      # our rules go BELOW the red rule
         self.assertEqual(stale, [])
 
     def test_base_0_when_no_red(self):
-        _, base = clean.color_rule_plan([])
+        _, base = clean.color_rule_plan([], None)
         self.assertEqual(base, 0)
 
     def test_stale_lists_only_our_rules_descending(self):
         cfs = [_red_rule(),
                _our_rule(clean.VIOLET_FORMULA, clean.VIOLET),
                _our_rule(clean.amber_formula(9), clean.AMBER)]
-        stale, base = clean.color_rule_plan(cfs)
+        stale, base = clean.color_rule_plan(cfs, None)
         self.assertEqual(stale, [2, 1])   # descending, red at index 0 untouched
         self.assertEqual(base, 1)
 
@@ -106,14 +118,14 @@ class TestColorRulePlan(unittest.TestCase):
         # red is NOT at index 0 (a Status color rule precedes it); we must still
         # insert just below red, not at index 1.
         other = _our_rule('=$A2="In progress"')   # not ours, not red -> not stale
-        stale, base = clean.color_rule_plan([other, _red_rule()])
+        stale, base = clean.color_rule_plan([other, _red_rule()], None)
         self.assertEqual(stale, [])
         self.assertEqual(base, 2)                  # just below red at index 1
 
     def test_base_accounts_for_stale_deleted_above_red(self):
         # a stale rule sits above red; deleting it shifts red up by one.
         stale, base = clean.color_rule_plan(
-            [_our_rule(clean.amber_formula(9), clean.AMBER), _red_rule()])
+            [_our_rule(clean.amber_formula(9), clean.AMBER), _red_rule()], None)
         self.assertEqual(stale, [0])
         self.assertEqual(base, 1)                  # red -> index 0 after delete, insert at 1
 
@@ -124,17 +136,17 @@ class TestIsOurs(unittest.TestCase):
 
     def test_recognises_installed_rules_at_any_column(self):
         for col in (7, 8, 9, 30):
-            self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(col), clean.AMBER)),
+            self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(col), clean.AMBER), None),
                             f"amber at col {col}")
-            self.assertTrue(clean.is_ours(_our_rule(clean.green_formula(col), clean.GREEN)),
+            self.assertTrue(clean.is_ours(_our_rule(clean.green_formula(col), clean.GREEN), None),
                             f"green at col {col}")
-        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, clean.VIOLET)))
+        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, clean.VIOLET), None))
 
     def test_recognises_legacy_green(self):
         # Installed by an earlier release; must be deleted on refresh, not
         # stacked next to the new rule.
         legacy = _our_rule('=AND($G2<>"",$G2<>"Other")', clean.GREEN)
-        stale, base = clean.color_rule_plan([_red_rule(), legacy])
+        stale, base = clean.color_rule_plan([_red_rule(), legacy], None)
         self.assertEqual(stale, [1])
         self.assertEqual(base, 1)
 
@@ -142,15 +154,15 @@ class TestIsOurs(unittest.TestCase):
         # The regression that matters: the amber pattern (=$X2<>"") also matches
         # the Issues rule. Only the color test keeps us from deleting it and
         # silently dropping error highlighting.
-        self.assertFalse(clean.is_ours(_red_rule()))
-        stale, _ = clean.color_rule_plan([_red_rule()])
+        self.assertFalse(clean.is_ours(_red_rule(), None))
+        stale, _ = clean.color_rule_plan([_red_rule()], None)
         self.assertEqual(stale, [])
 
     def test_ignores_unrelated_and_uncolored_rules(self):
-        self.assertFalse(clean.is_ours(_our_rule('=$A2="In progress"', clean.AMBER)))
+        self.assertFalse(clean.is_ours(_our_rule('=$A2="In progress"', clean.AMBER), None))
         self.assertFalse(clean.is_ours({"booleanRule": {"condition": {
             "type": "CUSTOM_FORMULA",
-            "values": [{"userEnteredValue": '=$I2<>""'}]}}}))   # our shape, no color
+            "values": [{"userEnteredValue": '=$I2<>""'}]}}}, None))  # our shape, no color
 
     def test_recognises_rules_after_sheets_floors_the_color(self):
         """The idempotency regression: Sheets FLOORS float->8-bit where round()
@@ -158,9 +170,9 @@ class TestIsOurs(unittest.TestCase):
         finds nothing and a refresh stacks duplicates instead of replacing."""
         as_stored = {"red": 153 / 255, "green": 51 / 255, "blue": 229 / 255}   # violet, -1 blue
         self.assertNotEqual(clean._rgb8(as_stored), clean._rgb8(clean.VIOLET))
-        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, as_stored)))
+        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, as_stored), None))
         amber_stored = {"red": 252 / 255, "green": 193 / 255, "blue": 76 / 255}
-        self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(9), amber_stored)))
+        self.assertTrue(clean.is_ours(_our_rule(clean.amber_formula(9), amber_stored), None))
 
     def test_color_eq_still_rejects_a_genuinely_different_color(self):
         self.assertFalse(clean._color_eq(clean.AMBER, clean.GREEN))
@@ -198,6 +210,205 @@ class TestErrorRuleIdentification(unittest.TestCase):
                           "values": [{"userEnteredValue": '=$J2<>""'}]}}}
         # worst case: error rule shaped like amber AND coloured like amber
         self.assertFalse(clean.is_ours(drifted, clean.error_rule_formula(self.HDR)))
+
+
+class TestIsRedFlooredRoundTrip(unittest.TestCase):
+    """`_is_red` decides rule PRIORITY. If it cannot recognise the red rule this
+    module itself wrote, color_rule_plan falls through to base=0 and installs
+    the provenance rules ABOVE the error rule — the whole-row violet then hides
+    error highlighting on exactly the rows most likely to have errors."""
+
+    def test_recognises_its_own_red_after_sheets_floors_it(self):
+        self.assertTrue(clean._is_red(_red_rule()))          # blue 53, floored
+
+    def test_exact_8bit_equality_would_have_missed_it(self):
+        stored = _red_rule()["booleanRule"]["format"]["backgroundColor"]
+        self.assertNotEqual(clean._rgb8(stored), clean._rgb8(clean.BRIGHT_RED))
+        self.assertTrue(clean._color_eq(stored, clean.BRIGHT_RED))
+
+    def test_plan_puts_rules_below_a_floored_red_rule(self):
+        stale, base = clean.color_rule_plan([_red_rule()], None)
+        self.assertEqual((stale, base), ([], 1))   # 1 = below, 0 would be above
+
+
+class TestVioletSurvivesColumnInsert(unittest.TestCase):
+    """Sheets REWRITES stored conditional-format formulas on a column insert —
+    the event this whole module defends against. The violet pattern was pinned
+    to $A2 while amber/green accepted any column, so a single insert left of
+    Status made violet unrecognisable and it stacked a duplicate every run."""
+
+    def test_violet_recognised_after_the_insert_shifts_it(self):
+        shifted = '=$B2="Existing (from MLOps)"'
+        self.assertTrue(clean.is_ours(_our_rule(shifted, clean.VIOLET), None))
+
+    def test_violet_still_recognised_where_we_install_it(self):
+        self.assertTrue(clean.is_ours(_our_rule(clean.VIOLET_FORMULA, clean.VIOLET), None))
+
+    def test_shifted_violet_is_refreshed_not_stacked(self):
+        shifted = _our_rule('=$B2="Existing (from MLOps)"', clean.VIOLET)
+        stale, _ = clean.color_rule_plan([_red_rule(), shifted], None)
+        self.assertEqual(stale, [1])
+
+
+class TestGreenPatternBindsOneColumn(unittest.TestCase):
+    def test_rejects_a_rule_testing_two_different_columns(self):
+        # green_formula can never emit this; the pattern should not accept it.
+        self.assertFalse(clean.is_ours(
+            _our_rule('=AND($H2<>"",LEFT($Z2,5)<>"Other")', clean.GREEN), None))
+        self.assertFalse(clean.is_ours(
+            _our_rule('=AND($G2<>"",$Z2<>"Other")', clean.GREEN), None))
+
+    def test_still_accepts_the_matched_pair(self):
+        self.assertTrue(clean.is_ours(_our_rule(clean.green_formula(8), clean.GREEN), None))
+        self.assertTrue(clean.is_ours(
+            _our_rule('=AND($G2<>"",$G2<>"Other")', clean.GREEN), None))
+
+
+class TestColorEqTolerance(unittest.TestCase):
+    def test_tolerance_is_pinned_at_one(self):
+        """The pre-existing negative case (BRIGHT_RED vs the drifted UI red) has
+        a minimum per-channel gap of 18, so it still passed at tol=18 and did
+        not constrain the bound at all. Off-by-2 in a single channel does."""
+        off_by_two = {"red": 252 / 255, "green": 192 / 255, "blue": 76 / 255}
+        self.assertEqual(clean._rgb8(clean.AMBER), (252, 194, 76))
+        self.assertFalse(clean._color_eq(clean.AMBER, off_by_two))
+        off_by_one = {"red": 252 / 255, "green": 193 / 255, "blue": 76 / 255}
+        self.assertTrue(clean._color_eq(clean.AMBER, off_by_one))
+
+    def test_our_colors_never_collide_at_this_tolerance(self):
+        for a, b in ((clean.AMBER, clean.GREEN), (clean.AMBER, clean.VIOLET),
+                     (clean.GREEN, clean.VIOLET), (clean.AMBER, clean.BRIGHT_RED)):
+            self.assertFalse(clean._color_eq(a, b))
+
+
+class TestFindCityColsAmbiguity(unittest.TestCase):
+    def test_refuses_two_candidate_pairs(self):
+        # A migration that left a stale block beside the live one: taking the
+        # leftmost would relabel and recolor the stale pair.
+        with self.assertRaises(SystemExit):
+            clean.find_city_cols(
+                ["City", "Resolved City", "x", "City (Existing)", "City (New)"], "Organizers")
+
+    def test_refuses_a_half_labeled_pair(self):
+        # Can only arise from a run that died between the two header writes.
+        with self.assertRaises(SystemExit):
+            clean.find_city_cols(["a", "City (Existing)", "Resolved City"], "Organizers")
+        with self.assertRaises(SystemExit):
+            clean.find_city_cols(["a", "City", "City (New)"], "Organizers")
+
+
+class TestAutofixNote(unittest.TestCase):
+    """The dedupe that stops 'city resolved | city resolved | ...' accumulating.
+    Previously inline in apply(), so it had no coverage at all."""
+
+    def test_empty_prior_takes_the_note_verbatim(self):
+        self.assertEqual(clean.autofix_note("", ["city resolved"]), "city resolved")
+
+    def test_returns_none_when_the_cell_already_says_it(self):
+        self.assertIsNone(clean.autofix_note("city resolved", ["city resolved"]))
+
+    def test_splits_prior_on_both_separators(self):
+        self.assertIsNone(clean.autofix_note("a; city resolved", ["city resolved"]))
+        self.assertIsNone(clean.autofix_note("a | city resolved", ["city resolved"]))
+
+    def test_keeps_only_the_genuinely_new_phrase(self):
+        self.assertEqual(clean.autofix_note("email normalized", ["email normalized", "x"]),
+                         "email normalized | x")
+
+    def test_collapses_duplicates_within_one_run(self):
+        self.assertEqual(clean.autofix_note("", ["x", "x", "y"]), "x; y")
+
+    def test_a_second_edit_to_the_same_field_is_not_deduped_away(self):
+        # apply() carries the new value in the phrase precisely so this appends
+        # rather than silently recording nothing.
+        self.assertEqual(clean.autofix_note("city resolved -> Zurich",
+                                            ["city resolved -> Zürich"]),
+                         "city resolved -> Zurich | city resolved -> Zürich")
+
+
+class TestInstallColorsWiring(unittest.TestCase):
+    """install_colors had zero coverage: hardcoding the pair back to (7, 8), or
+    swapping a rule's painted range against its formula, passed the whole suite.
+    These drive it with gws stubbed and assert on the emitted requests."""
+
+    HDR = ["Status", "Full name", "Email", "LinkedIn", "City", "Resolved City", "Issues"]
+
+    def _run(self, hdr):
+        calls = []
+        # A red rule that references THIS header's Issues column, so the run
+        # takes the primary formula-match path rather than the color fallback.
+        red = _red_rule()
+        red["booleanRule"]["condition"]["values"][0]["userEnteredValue"] = \
+            clean.error_rule_formula(hdr)
+        orig_gws, orig_read, orig_cfs, orig_tabs = (
+            clean.gws, clean.read_tab, clean._all_conditional_formats, clean.ROLE_TABS)
+        clean.gws = lambda args: calls.append(args) or {}
+        clean.read_tab = lambda tab: (hdr, [])
+        clean._all_conditional_formats = lambda: {1: [red]}
+        clean.ROLE_TABS = {"Organizers": 1}
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                clean.install_colors()
+        finally:
+            (clean.gws, clean.read_tab, clean._all_conditional_formats,
+             clean.ROLE_TABS) = orig_gws, orig_read, orig_cfs, orig_tabs
+        labels = json.loads(calls[0][calls[0].index("--json") + 1])["data"]
+        rules = json.loads(calls[1][calls[1].index("--json") + 1])["requests"]
+        return labels, rules
+
+    def test_labels_and_rules_track_the_discovered_columns(self):
+        labels, rules = self._run(self.HDR)          # pair at E/F -> cols 5,6
+        self.assertEqual([d["range"] for d in labels], ["Organizers!E1", "Organizers!F1"])
+        self.assertEqual([d["values"][0][0] for d in labels],
+                         ["City (Existing)", "City (New)"])
+        adds = [r["addConditionalFormatRule"] for r in rules if "addConditionalFormatRule" in r]
+        self.assertEqual(len(adds), 3)
+        # amber paints City (New) = col 6, and its formula must test that SAME column
+        amber = adds[1]["rule"]
+        self.assertEqual(amber["ranges"][0]["startColumnIndex"], 5)
+        self.assertEqual(amber["ranges"][0]["endColumnIndex"], 6)
+        self.assertEqual(amber["booleanRule"]["condition"]["values"][0]["userEnteredValue"],
+                         clean.amber_formula(6))
+        # green paints City (Existing) = col 5, formula on the same column
+        green = adds[2]["rule"]
+        self.assertEqual(green["ranges"][0]["startColumnIndex"], 4)
+        self.assertEqual(green["ranges"][0]["endColumnIndex"], 5)
+        self.assertEqual(green["booleanRule"]["condition"]["values"][0]["userEnteredValue"],
+                         clean.green_formula(5))
+
+    def test_everything_shifts_when_a_column_is_inserted_upstream(self):
+        labels, rules = self._run(["NEW"] + self.HDR)   # pair now at F/G -> 6,7
+        self.assertEqual([d["range"] for d in labels], ["Organizers!F1", "Organizers!G1"])
+        adds = [r["addConditionalFormatRule"] for r in rules if "addConditionalFormatRule" in r]
+        self.assertEqual(adds[1]["rule"]["ranges"][0]["startColumnIndex"], 6)
+        self.assertEqual(adds[1]["rule"]["booleanRule"]["condition"]["values"][0]
+                         ["userEnteredValue"], clean.amber_formula(7))
+
+    def test_rules_are_installed_below_the_error_rule(self):
+        _, rules = self._run(self.HDR)
+        adds = [r["addConditionalFormatRule"] for r in rules if "addConditionalFormatRule" in r]
+        self.assertEqual([a["index"] for a in adds], [1, 2, 3])   # red sits at 0
+
+    def test_row_range_is_unbounded(self):
+        _, rules = self._run(self.HDR)
+        for r in rules:
+            if "addConditionalFormatRule" in r:
+                self.assertNotIn("endRowIndex", r["addConditionalFormatRule"]["rule"]["ranges"][0])
+
+    def test_no_tab_is_written_when_a_later_tab_fails_preflight(self):
+        calls = []
+        orig = (clean.gws, clean.read_tab, clean._all_conditional_formats, clean.ROLE_TABS)
+        clean.gws = lambda args: calls.append(args) or {}
+        clean.read_tab = lambda tab: (self.HDR if tab == "Organizers" else ["Status"], [])
+        clean._all_conditional_formats = lambda: {1: [_red_rule()], 2: [_red_rule()]}
+        clean.ROLE_TABS = {"Organizers": 1, "Hosts": 2}
+        try:
+            with self.assertRaises(SystemExit):
+                clean.install_colors()
+        finally:
+            (clean.gws, clean.read_tab, clean._all_conditional_formats,
+             clean.ROLE_TABS) = orig
+        self.assertEqual(calls, [], "Organizers must not be written when Hosts fails preflight")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`install-colors` had stopped working: it addressed the `City` / `Resolved City` pair by fixed letter (G/H), a column was inserted upstream, and its own guard then aborted every run. Fixing that surfaced three more reasons the documented "idempotent — safe to re-run" contract was false, plus two unbounded-read bugs. Two rounds of self-review then found that each fix pass had itself introduced regressions of the same class.

**Behaviour changes worth calling out:**
- `apply()` writes values **RAW**, not `USER_ENTERED` (security — see below). A value that looks like a formula now stays inert text.
- `apply()` **aborts** on row 1, on rows past the data, and on a change list whose headers no longer exist, rather than writing or reporting success.
- `install-colors` **aborts before writing** on an ambiguous, absent or half-labelled city pair, a missing `Status` column, or an unknown sheetId.
- `install-flags` **re-points** an existing red rule's range instead of leaving it alone.

## Changesets

### 1. `fix(clean-data): header-driven city columns + genuinely idempotent install-colors` (`d5f3866`)
Locate the city pair by header name at run time; match our own rules by formula *shape* + colour rather than exact text pinned to a letter; compare colours with a ±1 tolerance (Sheets floors float→8-bit where `round()` rounds); identify the error rule by the `Issues` column it references rather than a colour that had been re-picked in the UI; drop the hardcoded `A1:CJ` / `A1:BB` read windows that were truncating the newest column.

### 2. `fix: address self-review findings` (`346fc70`)
`_is_red` had been left on exact colour equality, so it never matched the rule this module itself writes and the provenance rules installed **above** the error rule. The violet stale-pattern was still pinned to `$A2`, so a column insert made it stack a duplicate every run. Plus pre-flight validation of all role tabs, a required `err_formula`, `_city_rule` so a rule's range and formula can't name different columns, unbounded `endRowIndex`, and `apply()` fixes.

### 3. `fix: address round-2 self-review findings` (`dee9161`)
Round 1 had reviewed only the first commit, so commit 2 shipped unreviewed — and had introduced two new bugs of the class it was fixing:

| Regression | Cause | Fix |
|---|---|---|
| Unbounded note growth | The value-carrying phrase embedded free text containing `;`/`|`, which `autofix_note` splits on — so it never matched `seen` and re-appended every run | Strip separators out of the phrase |
| Violet rebuilt at the wrong column | Widening the pattern fixed *recognition*, not correctness: a rule deleted at `$B2` was reinstalled at `$A2` | Discover `Status` by header |

Also: `color_rule_plan` verifies the error-rule match is actually red (an operator's own rule on the `Issues` column used to outrank it, silently); warnings now cover the two states that were silent; `install_flags` re-points the existing red rule so the unbounded fix reaches the live sheet at all; and **`apply()`, `read_tab` and `install_flags` gained tests** — previously the empty-write guard, the RAW write, the bare read range and even dropping the value from the phrase could all be reverted with a green suite.

**Security.** `apply()` wrote with `USER_ENTERED`. `norm_name('=IMPORTXML("HTTPS://…")')` returns `'=importxml("https://…")'` — still a working formula, since Sheets function names are case-insensitive. So an all-caps payload submitted through the public form appeared in `scan` as a routine capitalisation fix and became live on write, able to exfiltrate the row. Self-concealing: `read_tab` sends no `valueRenderOption`, so later scans saw the rendered output. Now RAW.

## Test Plan
- [x] `pre-commit run --all-files` — all 15 hooks pass
- [x] `python3 skills/aaif-clean-data/scripts/test_clean.py` — **77 pass** (13 before the branch → 24 → 47 → 77)
- [x] Full repo sweep — all 10 script suites pass; `PYTHONPATH=lib` lib suite 66 pass
- [x] **Mutation-verified** across all three commits: every fix has a test that fails when the bug is reintroduced. One tautological test (comparing output against the same builder a mutation changed) was found and corrected to assert literals.
- [x] Read-only probes against the live sheet: bare tab name returns 89 columns where `A1:CJ` returned 88; `find_city_cols` resolves (8,9) on all three tabs; `base=1` on each; **`Hosts` currently carries a duplicate amber rule** (`=$I2<>""` and `=$J2<>""`), which the fixed `is_ours` marks stale and the next run will clean up
- [ ] **Live write verification still owed:** run `install-colors` twice against the real sheet and confirm three rules afterwards (not six), below the red rule. Not done here — these subcommands write to production.

## Related Issues
None referenced in the commits.

_Generated using hero-skills._