### PR TITLE
feat(sync-chapters): sync accepted people into chapter CRMs + per-chapter Drive access

### DIFF
--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -1,10 +1,42 @@
 ---
 name: aaif-sync-chapters
-description: Sync accepted/existing organizers from the Intake Ops sheet into the Chapters List — merge names into each city's Organizers column and add rows for net-new cities. Reports & proposes by default; only writes on explicit approval. Use when asked to sync organizers/chapters or push intake decisions to the chapters list.
-argument-hint: "[--write]"
+description: Push intake decisions out of the Intake Ops sheet — accepted organizers onto the Chapters List, accepted people plus their survey interest into their chapter's Attendee CRM, and per-chapter Drive access to replace the folder's public link-share. Reports & proposes by default; only writes on explicit approval. Use when asked to sync organizers/chapters/CRMs, push intake decisions to the chapters list, add intake people to a chapter's CRM, or give organizers access to their own chapter.
+argument-hint: "[chapters|crm|access] [--write]"
 ---
 
-# Sync Intake Organizers → Chapters List
+# Sync the Intake → Chapters List, chapter CRMs, chapter access
+
+Three engines, one intake sheet, same house rules — **the intake sheet is only
+ever read**, the report is the default, and `--write` re-verifies itself:
+
+| Engine | Script | Pushes | Into |
+|---|---|---|---|
+| Chapters feed | `sync_chapters.py` | **accepted organizer names** | the public Chapters List sheet |
+| Chapter CRMs | `sync_crm.py` | **accepted people + their survey interest** | each chapter's private `<City> CRM.xlsx` |
+| Chapter access | `sync_access.py` | **per-chapter Drive grants** | the Chapters folder's sharing |
+
+Run whichever the user asked for. "Sync everything" means feed → CRM → access, in
+that order: a net-new city needs its folder before its CRM can be written, and its
+CRM should hold the right people before anyone is granted access to it.
+
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
+---
+
+# 1. Sync Intake Organizers → Chapters List
 
 Push organizer decisions from the **AAIF Community Intake Ops** sheet
 (id `1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o`, tab `Organizers`) into the
@@ -90,7 +122,208 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
   between building the proposal and writing it (row numbers are snapshot indices,
   and the per-city Luma checks sit in that window).
 
-## Verify
+---
+
+# 2. Sync Intake People + Interests → chapter CRMs
+
+Every chapter folder under the **Chapters** Drive folder
+(`1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx`) holds one **`<City> CRM.xlsx`** whose
+`Attendees` tab is the chapter's private people database. `sync_crm.py` fills it
+from the intake and carries each person's survey interest across.
+
+**This CRM is the onboarding list.** It decides who gets access to a chapter's
+Drive folder, so a person reaches it after a **decision**, not on submitting the
+form. Only `Accepted` and `Existing (from MLOps)` sync; `New`, `Tentative` and
+`Denied` are all held back and reported.
+
+> As of 2026-08 that means **organizers only** — the Hosts and Speakers tabs have
+> never been triaged off `New` (0 of 26 and 0 of 55). Both start flowing the
+> moment someone accepts them; nothing in the engine needs to change for that.
+
+**Keep it minimal.** Only six of the eleven columns are ever written. `Signal`,
+`LinkedIn URL`, `Company`, `Role / title` and `Technical expertise` still exist
+for an organizer to fill in by hand — the automation just doesn't push a survey's
+worth of personal detail into a folder that is still link-readable while chapters
+are being onboarded (see the sharing note at the end of this section).
+
+## The flow: report → approve → write
+
+1. **Report (default, read-only):**
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/sync_crm.py            # all chapters
+   python3 ${CLAUDE_SKILL_DIR}/scripts/sync_crm.py --city Boston
+   ```
+   Opens every chapter workbook and prints, per chapter, the people it would add
+   (`+`) or fill in (`~`) with the exact cell values, then the near-miss cities,
+   the cities with no chapter folder, and a count of un-synced intake rows
+   (`--verbose` lists them individually). A full run reads ~82 workbooks and
+   takes a few minutes.
+
+2. **Show the user the proposal** and get explicit approval. Never skip to write.
+
+3. **Write (on approval only):**
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/sync_crm.py --write
+   ```
+   Saves each workbook's pre-edit bytes to a temp `before/` directory, uploads,
+   then re-downloads every written workbook and confirms a fresh plan is empty.
+   A workbook that fails is reported and the rest still finish — one bad file
+   must not abandon the other eighty-one.
+
+## Column mapping (intake → CRM `Attendees`)
+
+| CRM column | Filled from |
+|---|---|
+| `Full name` | role tab `Name` / `Full name` |
+| `Trusted/Regular` | `Yes` for an organizer — they're on the team, not a guest to triage |
+| `Status` | `Organizer` / `Speaker` / `Host` (everyone syncing is already accepted) |
+| `Notes (CRM)` | provenance — `Intake: Organizer · Accepted · 2026-08-07` |
+| `Email` | role tab `Email` — **also the dedupe key** |
+| `What brings you here?` | the survey answer **verbatim**, plus the role's detail (`Talk title` / `Venue name` / `Chapter / city wanted`) |
+
+**Never written:** `Signal`, `LinkedIn URL`, `Company`, `Role / title`,
+`Technical expertise`. They are absent from the mapping rather than written
+blank, so the automation cannot touch them even on a row it creates. The
+canonical list is `CRM_WRITTEN` in `sync_crm.py`, asserted by the tests.
+
+`What brings you here?` is the form's routing question, and the role tabs are
+filtered views that drop it — so it is read from `Form Responses` and joined back
+on email. When a row can't be joined, the form's own wording for that branch is
+used instead of inventing one.
+
+## Sync rules (what the engine does)
+
+- **Chapter resolution per intake row**: the role tab's `Chapter` assignment wins
+  (a human made it), then `City (New)`, then `City (Existing)` unless it's an
+  `Other…` placeholder. The result is matched to a chapter **folder** with the
+  same accent-, case- and punctuation-folded name as the chapters feed uses
+  (`Washington, DC` → the `Washington DC` folder; `Montreal` → `Montréal`).
+- **Near-miss folders are reported, never written** — same discriminating-token
+  rule and generic-word stoplist as the chapters engine, so `San Diego` never
+  lands in `San Francisco`. Cities with no folder at all are listed as the
+  follow-up queue for **`aaif-create-chapter`**.
+- **One row per person per chapter, deduped on email** — the workbook's own Guide
+  tab says to merge by email, so that is the key. Someone who applied as both an
+  organizer and a speaker gets **one** row: the higher-priority role sets
+  `Status`, and both interests are recorded in `What brings you here?`.
+- **Never clobber a human.** A CRM cell that already has content is left alone —
+  corrected spellings, hand-written notes and manually added companies all
+  survive every re-run. Only genuinely blank cells are filled.
+- **`Status` is the one exception**: it is upgraded when it still holds a value
+  the automation itself wrote (`New`, `Prospect`, `Organizer`, `Speaker`,
+  `Host`). That is how a person's role is corrected after re-triage — while a
+  human's `Attended`, `Regular`, `Volunteer` or `Declined` is never undone.
+- **Fixture rows are cleared, and only fixture rows.** A row is wiped **only** if
+  its `Email` is at a reserved example domain (`@example.com`, `.org`, `.net`,
+  `.edu`) — that is the sole gate, deliberately narrow and anchored on the `@` so
+  look-alikes (`a@examples.com`, `x@example.company`) are never caught. This
+  removes the `Sam Taylor` sample the template puts in **every** chapter CRM, and
+  the Tatooine test chapter's cast. The freed row is **reused**, so a chapter's
+  first real organizer lands at the top of the list instead of below a blank.
+  Anything with a real-looking address is left exactly where it is and listed
+  under "Already in a CRM and NOT touched" — a row a human typed is
+  indistinguishable from one we don't recognise, so it is never guessed at.
+  Clearing is planned for **every** chapter, including the ~30 that gain nobody.
+- **Rows land in the workbook's pre-created empty rows** (the template ships 1000
+  of them, already carrying the dropdowns and conditional formatting), lowest
+  first, copying row 2's per-column cell styles so a synced person looks like a
+  hand-entered one. Past row 1000 new `<row>` elements are inserted in ascending
+  order.
+- **The `Status` dropdown gains a `Host` value.** It shipped as
+  `New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined` with no
+  value for a venue host, so hosts had nowhere honest to land. Every workbook the
+  script opens is patched — including **TemplateCity**, or every chapter cloned
+  from it would re-inherit the gap. Both quote encodings are handled (the
+  template writes `"…"`, older workbooks write `&quot;…&quot;`). A workbook with
+  no Status list at all is reported, not guessed at.
+- **TemplateCity never receives people** — only the dropdown patch.
+- **Rows are skipped, and reported, when**: `Status` is anything other than
+  `Accepted` / `Existing (from MLOps)`; the email is missing or unparsable
+  (there'd be no dedupe key, so every run would re-add them); or the row has no
+  chapter or city at all.
+- **The run aborts** when `Form Responses` or a role tab comes back empty, or a
+  role tab has no `Status`/`Email` header. A workbook whose `Attendees` tab is
+  missing a column is **skipped with a reason**, never written by column letter.
+
+## Editing the workbooks
+
+The CRMs are **stored `.xlsx`**, not native Sheets, so they are edited as OOXML
+zip parts: download → rewrite `Attendees`' sheet XML → upload. Every part the
+script doesn't touch is repacked byte-for-byte, and values are written as
+**inline strings**, which Excel and Sheets both treat as literal text — a name
+starting with `=` can never become a formula, so there is no RAW-vs-`USER_ENTERED`
+hazard here.
+
+**Write order is load-bearing.** `Attendees.serialize()` rewrites the sheet part
+wholesale from the element tree, so a bytes-level dropdown patch applied *before*
+it is silently discarded — and the run still reports the patch as applied. That
+is why row writes, serialization and the dropdown patch all live inside
+`finalize()`, in that order; call it, don't re-implement it.
+
+## Sharing: these CRMs are currently link-readable
+
+As of 2026-08 the **Chapters** folder carries `anyone → reader` (plus
+`linuxfoundation.org → commenter`), and it **inherits all the way down** —
+verified on a chapter folder and on a `CRM.xlsx` itself. No chapter organizer has
+an individual grant; that public link is how they currently get in.
+
+So anything this script writes is readable by anyone with the link. That is why
+the column set is minimal and gated on acceptance. The plan is to onboard the
+right people to the right chapter first, then remove whole-folder access and
+grant each organizer their own chapter folder only. **Re-check the sharing before
+widening `CRM_WRITTEN` or `SYNC_STATUSES`** — those two constants are what keep
+un-vetted applicants and their survey detail out of a public folder.
+
+---
+
+# 3. Per-chapter access (`sync_access.py`)
+
+Moves the Chapters folder off its public link-share and onto per-chapter grants.
+Report-only by default. Three phases, and **the order is not negotiable**:
+
+1. **grant** — give each accepted organizer their chapter folder. Must precede
+   the lock: the public link is currently their only access.
+2. **lock** — remove `anyone:reader` from Chapters/.
+
+A **pin** phase also exists, for the case where something public genuinely lives
+in the tree. `--write` runs pin → grant → lock; `--phase pin|grant|lock` runs one.
+
+> **The website does not depend on this share — verified, not assumed.** The
+> chapters feed's `Image` column is full of `lh3.googleusercontent.com/d/<id>`
+> URLs pointing at `Web Banner.png` files inside chapter folders, which reads as
+> "80 public Drive images the site serves". It isn't. `aaif.io/community-chapters`
+> was loaded and inspected on 2026-08-07: 26 images, **all** from `cdn.sanity.io`,
+> none from Drive. Chapter content and imagery live in Sanity; the Drive banners
+> are source assets. A column full of image URLs is not evidence that anything
+> fetches them — load the page and look.
+
+> **`pin` is a no-op while the parent is still shared.** Drive merges a child's
+> `anyone:reader` into the inherited one, returns `200` with a permission id, and
+> stores nothing new — the file still reads `inherited: true`. A child can only
+> hold its own public share *after* the parent's is removed. Never trust the
+> phase's "N changes" line; re-read the permission and check
+> `permissionDetails[].inherited`.
+
+- **`assert_all_accepted()` is the last gate before write** and re-reads the
+  intake through a different code path than the filter that built the plan.
+  "The filter that made the list says the list is fine" is not a check.
+- **A bad address never abandons the run.** The intake is fed by a public form,
+  so a typo'd address is normal input and Drive rejects it with a hard 400.
+  Failures are collected and reported; every other grant still lands.
+- **Addresses with no Google account** are refused by Drive unless it may email
+  the person. There is no silent path, so they are skipped and reported unless
+  `--mail-if-required` (or `--notify`) is passed — sending mail to real people is
+  never a side effect of a sync.
+- Notifications are **off** by default: 98 share-mails arriving unannounced read
+  as a phishing wave.
+- `linuxfoundation.org` domain access is **kept** — that is LF staff reach, a
+  separate decision from de-publicising the folder.
+- Pre-existing direct grants on chapter folders are left alone and reported.
+  They survive the lock, so they are exactly what an audit needs to see.
+
+---
+
+# Verify
 
 After any run (and after editing the engine):
 
@@ -101,9 +334,13 @@ After any run (and after editing the engine):
 - Spot-check one touched row in the sheet: `Organizers` merged correctly, the
   MLOps and Luma columns untouched, and the version history shows a single edit
   for the whole sync.
-- Unit tests for the pure merge/slug/near-miss logic:
+- After a CRM `--write`, open one touched workbook and check the person's row
+  reads correctly, the sample row and any hand-written notes are untouched, and
+  the `Status` cell offers `Host` in its dropdown.
+- Unit tests for the pure logic in both engines (no network, no `gws`):
   ```bash
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_chapters.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_crm.py
   ```
 
 ## Notes
@@ -125,3 +362,16 @@ After any run (and after editing the engine):
   contains `&` and spaces.
 - Unresolved rows already hand-placed on the chapters list are flagged
   "no action needed" so they don't nag every run.
+- `sync_crm.py` imports the `gws` wrapper, city folding and near-miss stoplist
+  **from `sync_chapters.py`** rather than copying them. Two copies would drift,
+  and a city that folds one way in one engine and another way in the other would
+  put a person in a CRM whose feed row says something else.
+- The CRM's `Attendees` sheet is resolved through `xl/workbook.xml` and its rels,
+  never by guessing `xl/worksheets/sheet1.xml` — sheet order and file numbering
+  are independent, and the older workbooks are packed in a different order and
+  store their strings in a shared table rather than inline. Both are read; only
+  inline strings are ever written.
+- Bad LinkedIn values (`https://google.com/url`) and odd city spellings come
+  straight from the public form and are copied as-is. Fix them at the source with
+  **`aaif-clean-data`**, then re-run — the CRM only fills blanks, so a corrected
+  intake value will **not** overwrite the bad one already written. Clean first.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -156,7 +156,7 @@ are being onboarded (see the sharing note at the end of this section).
    Opens every chapter workbook and prints, per chapter, the people it would add
    (`+`) or fill in (`~`) with the exact cell values, then the near-miss cities,
    the cities with no chapter folder, and a count of un-synced intake rows
-   (`--verbose` lists them individually). A full run reads ~82 workbooks and
+   (`--verbose` lists them individually). A full run reads every chapter workbook and
    takes a few minutes.
 
 2. **Show the user the proposal** and get explicit approval. Never skip to write.
@@ -168,7 +168,7 @@ are being onboarded (see the sharing note at the end of this section).
    Saves each workbook's pre-edit bytes to a temp `before/` directory, uploads,
    then re-downloads every written workbook and confirms a fresh plan is empty.
    A workbook that fails is reported and the rest still finish — one bad file
-   must not abandon the other eighty-one.
+   must not abandon the rest.
 
 ## Column mapping (intake → CRM `Attendees`)
 
@@ -223,7 +223,7 @@ used instead of inventing one.
   Anything with a real-looking address is left exactly where it is and listed
   under "Already in a CRM and NOT touched" — a row a human typed is
   indistinguishable from one we don't recognise, so it is never guessed at.
-  Clearing is planned for **every** chapter, including the ~30 that gain nobody.
+  Clearing is planned for **every** chapter, including those that gain nobody.
 - **Rows land in the workbook's pre-created empty rows** (the template ships 1000
   of them, already carrying the dropdowns and conditional formatting), lowest
   first, copying row 2's per-column cell styles so a synced person looks like a
@@ -260,19 +260,21 @@ it is silently discarded — and the run still reports the patch as applied. Tha
 is why row writes, serialization and the dropdown patch all live inside
 `finalize()`, in that order; call it, don't re-implement it.
 
-## Sharing: these CRMs are currently link-readable
+## Sharing: minimal by design
 
-As of 2026-08 the **Chapters** folder carries `anyone → reader` (plus
-`linuxfoundation.org → commenter`), and it **inherits all the way down** —
-verified on a chapter folder and on a `CRM.xlsx` itself. No chapter organizer has
-an individual grant; that public link is how they currently get in.
+`CRM_WRITTEN` (six columns) and `SYNC_STATUSES` (accepted only) are what keep
+un-vetted applicants and their survey detail out of a folder shared more widely
+than intended. **Re-check the folder's sharing before widening either** — they
+are the whole mitigation, and the CRM is written *before* access is narrowed
+(feed → CRM → access), so the write lands under whatever sharing exists at the
+time.
 
-So anything this script writes is readable by anyone with the link. That is why
-the column set is minimal and gated on acceptance. The plan is to onboard the
-right people to the right chapter first, then remove whole-folder access and
-grant each organizer their own chapter folder only. **Re-check the sharing before
-widening `CRM_WRITTEN` or `SYNC_STATUSES`** — those two constants are what keep
-un-vetted applicants and their survey detail out of a public folder.
+> **State as of 2026-08-07:** the Chapters folder previously carried
+> `anyone → reader`, inherited all the way down to every `CRM.xlsx`. That share
+> has been removed (§3), the `linuxfoundation.org → commenter` grant was kept
+> deliberately, and each accepted organizer now holds `writer` on their own
+> chapter folder only. Confirm with `sync_access.py` (report mode) rather than
+> trusting this paragraph.
 
 ---
 
@@ -281,12 +283,20 @@ un-vetted applicants and their survey detail out of a public folder.
 Moves the Chapters folder off its public link-share and onto per-chapter grants.
 Report-only by default. Three phases, and **the order is not negotiable**:
 
-1. **grant** — give each accepted organizer their chapter folder. Must precede
-   the lock: the public link is currently their only access.
-2. **lock** — remove `anyone:reader` from Chapters/.
+Numbered as the console prints them:
 
-A **pin** phase also exists, for the case where something public genuinely lives
-in the tree. `--write` runs pin → grant → lock; `--phase pin|grant|lock` runs one.
+1. **pin** — give each banner its own `anyone:reader`. Usually a **no-op** (see
+   below), and not needed for the website; it exists for the case where
+   something public genuinely does live in the tree.
+2. **grant** — give each accepted organizer **`writer`** (the `--role` default)
+   on their chapter folder. Must precede the lock: the public link is currently
+   their only access.
+3. **lock** — remove `anyone:reader` from Chapters/.
+
+`--write` runs all three in that order; `--phase pin|grant|lock` runs one, and
+verifies whatever it ran. **`lock` refuses to run when any grant failed** —
+locking then would leave those organizers with no access at all; `--lock-anyway`
+overrides.
 
 > **The website does not depend on this share — verified, not assumed.** The
 > chapters feed's `Image` column is full of `lh3.googleusercontent.com/d/<id>`
@@ -314,12 +324,14 @@ in the tree. `--write` runs pin → grant → lock; `--phase pin|grant|lock` run
   the person. There is no silent path, so they are skipped and reported unless
   `--mail-if-required` (or `--notify`) is passed — sending mail to real people is
   never a side effect of a sync.
-- Notifications are **off** by default: 98 share-mails arriving unannounced read
-  as a phishing wave.
+- Notifications are **off** by default: a share-mail per organizer, arriving
+  unannounced and all at once, reads as a phishing wave.
 - `linuxfoundation.org` domain access is **kept** — that is LF staff reach, a
   separate decision from de-publicising the folder.
-- Pre-existing direct grants on chapter folders are left alone and reported.
-  They survive the lock, so they are exactly what an audit needs to see.
+- Pre-existing direct grants on chapter folders are left alone, and every one
+  held by someone the intake does not know about is **listed** in the report.
+  They survive the lock — a denied ex-organizer keeps `writer` until a human
+  removes it — so they are exactly what an audit needs to see.
 
 ---
 
@@ -329,18 +341,21 @@ After any run (and after editing the engine):
 
 - The report's intake counts should match a manual count of the sheet's Status
   column; a delta means status strings drifted.
-- After `--write`, the built-in re-verify must print
-  "Verified: a fresh run proposes zero changes."
+- After `--write`, each engine prints its OWN verify line — they differ:
+  `sync_chapters` "a fresh run proposes zero changes"; `sync_crm` "a fresh read
+  of every written workbook proposes zero changes"; `sync_access` "banners are
+  directly public and Chapters/ is no longer link-shared".
 - Spot-check one touched row in the sheet: `Organizers` merged correctly, the
   MLOps and Luma columns untouched, and the version history shows a single edit
   for the whole sync.
 - After a CRM `--write`, open one touched workbook and check the person's row
   reads correctly, the sample row and any hand-written notes are untouched, and
   the `Status` cell offers `Host` in its dropdown.
-- Unit tests for the pure logic in both engines (no network, no `gws`):
+- Unit tests for the pure logic in all three engines (no network, no `gws`):
   ```bash
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_chapters.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_crm.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_access.py
   ```
 
 ## Notes

--- a/skills/aaif-sync-chapters/scripts/sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/sync_access.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Move the Chapters folder off its public link-share and onto per-chapter grants.
+
+Third engine in this skill, and the one with teeth: it changes who can reach
+things. Report-only by default, like the other two.
+
+The Chapters folder is shared `anyone -> reader`, inherited by every chapter
+folder and every file in them. One thing depends on it: chapter organizers'
+access. Nobody has an individual grant — the public link IS how they get in (as
+a reader) — so `grant` must run before `lock`.
+
+    grant — give each accepted organizer access to their own chapter folder.
+    lock  — remove anyone:reader from the Chapters folder.
+
+The website does NOT depend on it, though the chapters feed makes it look like it
+does. Every `Image` cell on that feed is `lh3.googleusercontent.com/d/<id>`
+pointing at a `Web Banner.png` inside a chapter folder, which reads as "the site
+serves 80 public Drive images". It does not: aaif.io/community-chapters was
+loaded and inspected on 2026-08-07 and every one of its 26 images comes from
+`cdn.sanity.io`. Chapter content and imagery live in Sanity; the Drive banners
+are source assets, not what visitors fetch. Verify with the live page before ever
+concluding otherwise — the feed column is not evidence.
+
+A `pin` phase exists for the case where something public genuinely does live in
+the tree. It is a NO-OP while the parent is still shared: Drive merges a child's
+`anyone:reader` into the inherited one and reports success, so a child can only
+hold its own public share AFTER the parent's is gone. Never trust its "N changes"
+line — re-read the permission and check `permissionDetails[].inherited`.
+
+Usage:
+  python3 sync_access.py                  # full plan, changes nothing
+  python3 sync_access.py --write          # apply all three phases, in order
+  python3 sync_access.py --write --phase pin
+  python3 sync_access.py --role reader    # grant something other than writer
+"""
+import argparse, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sync_chapters import (CHAPTERS_ID, CHAPTERS_TAB, INTAKE_ID, gws_json, get_values,
+                           cell, fold)
+from sync_crm import (CHAPTERS_PARENT, SYNC_STATUSES, TEMPLATE_FOLDER, ROLE_TABS,
+                      fold_email, list_chapter_folders, match_chapters, merge_people,
+                      read_role_tab)
+
+PUBLIC_ID = "anyoneWithLink"       # the permission id Drive gives an anyone-share
+BANNER = "Web Banner.png"
+
+# Kept deliberately: this is the Linux Foundation's own staff access, not public
+# reach, and removing it is a separate decision from de-publicising the folder.
+KEEP_DOMAIN = "linuxfoundation.org"
+
+# Drive's refusal when the invitee has no Google account. It is a hard 400, not a
+# soft warning: the only way to grant these people access is to let it email them.
+NO_ACCOUNT = "there is no Google account"
+
+
+def canon_email(e):
+    """Match addresses the way DRIVE does, not the way the intake spells them.
+
+    Google canonicalises a Gmail address by dropping dots from the local part, so
+    granting `aman.singh.original@gmail.com` stores `amansinghoriginal@gmail.com`.
+    Comparing the intake spelling against the stored one therefore never matches,
+    and every run re-proposes a grant that is already in place. Only gmail.com is
+    folded — dots are significant on other hosts, which is why sync_crm's
+    fold_email (the CRM dedupe key) deliberately keeps them.
+    """
+    e = fold_email(e)
+    local, _, domain = e.partition("@")
+    return (local.replace(".", "") + "@" + domain) if domain == "gmail.com" else e
+
+
+def perms(file_id):
+    """Permissions on a file, each tagged with whether it is inherited."""
+    res = gws_json("drive", "permissions", "list", params={
+        "fileId": file_id, "supportsAllDrives": True, "pageSize": 100,
+        "fields": "permissions(id,type,role,emailAddress,domain,permissionDetails)"})
+    out = []
+    for p in res.get("permissions", []):
+        det = p.get("permissionDetails") or [{}]
+        out.append(dict(p, inherited=bool(det[0].get("inherited"))))
+    return out
+
+
+def direct_public(file_id):
+    """True when this file carries its OWN anyone:reader, not an inherited one.
+    An inherited share disappears with the parent's; a direct one survives."""
+    return any(p["type"] == "anyone" and not p["inherited"] for p in perms(file_id))
+
+
+def banner_ids():
+    """{chapter folder id -> banner file id} for the images the website serves.
+
+    Resolved from the feed's `Image` column, not by globbing for a file named
+    `Web Banner.png`: the feed is what the public site actually requests, so a
+    chapter whose cell points somewhere unexpected must be pinned there, and a
+    banner nothing references is not load-bearing.
+    """
+    rows = get_values(CHAPTERS_ID, "'%s'!A:AZ" % CHAPTERS_TAB)
+    headers = [h.strip() for h in rows[0]]
+    if "Image" not in headers:
+        sys.exit("ABORT: no 'Image' column on the chapters feed — cannot tell which "
+                 "files the website serves, so the lock step is unsafe to plan.")
+    i_img, i_city = headers.index("Image"), headers.index("City")
+    out = {}
+    for row in rows[1:]:
+        url, city = cell(row, i_img), cell(row, i_city)
+        if not (url and city):
+            continue
+        # .../d/<id> is the only form the feed uses; anything else is reported.
+        fid = url.rsplit("/d/", 1)[-1].split("/")[0].split("?")[0] if "/d/" in url else ""
+        out[fold(city)] = {"city": city, "file_id": fid, "url": url}
+    return out
+
+
+# Folder access is for ORGANIZERS ONLY — deliberately narrower than the CRM,
+# which carries all three roles. An accepted speaker belongs in a chapter's CRM
+# (they are a person the chapter deals with) but has no business with write
+# access to its Drive folder: trackers, decks, budgets and the CRM itself live
+# there. Looping ROLE_TABS here granted speakers and hosts the same writer role
+# as organizers — invisible today because neither tab has an accepted row, and a
+# silent privilege escalation the first time one is triaged.
+ACCESS_TABS = ("Organizers",)
+
+
+def plan(role):
+    folders = [f for f in list_chapter_folders() if f["name"] != TEMPLATE_FOLDER]
+    people = []
+    for tab in ACCESS_TABS:
+        pp, _ = read_role_tab(tab, {})
+        people += pp
+    by_folder, orphans, near = match_chapters(merge_people(people), folders)
+    imgs = banner_ids()
+
+    pins, grants, already_pinned, already_granted, no_banner = [], [], [], [], []
+    for f in folders:
+        img = imgs.get(fold(f["name"]))
+        if not img or not img["file_id"]:
+            no_banner.append(f["name"])
+        elif direct_public(img["file_id"]):
+            already_pinned.append(f["name"])
+        else:
+            pins.append({"chapter": f["name"], "file_id": img["file_id"], "url": img["url"]})
+
+        want = by_folder.get(f["id"], [])
+        if not want:
+            continue
+        # Owner/organizer access already covers everything, inherited or not —
+        # re-granting the folder owner is a no-op Drive rejects.
+        have = {canon_email(p.get("emailAddress", "")) for p in perms(f["id"])
+                if p["type"] == "user" and (not p["inherited"] or p["role"] == "owner")}
+        for p in want:
+            if canon_email(p["email"]) in have:
+                already_granted.append((f["name"], p["email"]))
+            else:
+                grants.append({"chapter": f["name"], "folder_id": f["id"],
+                               "email": p["email"], "name": p["name"], "role": role})
+
+    parent = perms(CHAPTERS_PARENT)
+    public = [p for p in parent if p["type"] == "anyone"]
+    return {"pins": pins, "grants": grants, "already_pinned": already_pinned,
+            "already_granted": already_granted, "no_banner": no_banner,
+            "public": public, "parent": parent, "orphans": orphans, "near": near}
+
+
+def report(p, role):
+    print("PHASE 1 — pin the website's banner images (make each one directly public)")
+    print("  %d banner(s) need their own anyone:reader; %d already have one."
+          % (len(p["pins"]), len(p["already_pinned"])))
+    for x in p["pins"][:6]:
+        print("     %-20s %s" % (x["chapter"], x["file_id"]))
+    if len(p["pins"]) > 6:
+        print("     … and %d more" % (len(p["pins"]) - 6))
+    if p["no_banner"]:
+        print("  !! %d chapter(s) have no resolvable Image on the feed — the site shows "
+              "nothing for them either way: %s" % (len(p["no_banner"]), ", ".join(p["no_banner"])))
+
+    print("\nPHASE 2 — grant each accepted organizer %r on their own chapter folder" % role)
+    print("  %d new grant(s) across %d chapter(s); %d already in place."
+          % (len(p["grants"]), len({g["chapter"] for g in p["grants"]}), len(p["already_granted"])))
+    by_ch = {}
+    for g in p["grants"]:
+        by_ch.setdefault(g["chapter"], []).append(g["email"])
+    for ch in sorted(by_ch)[:6]:
+        print("     %-20s %s" % (ch, ", ".join(by_ch[ch])))
+    if len(by_ch) > 6:
+        print("     … and %d more chapter(s)" % (len(by_ch) - 6))
+
+    print("\nPHASE 3 — remove the public share from the Chapters folder")
+    if not p["public"]:
+        print("  Nothing to remove — the folder is already not link-shared.")
+    for x in p["public"]:
+        print("     delete permission %s (%s:%s) on Chapters/" % (x["id"], x["type"], x["role"]))
+    print("  Kept on the parent:")
+    for x in p["parent"]:
+        if x["type"] == "anyone":
+            continue
+        who = x.get("emailAddress") or x.get("domain") or ""
+        print("     %-10s %-10s %s%s" % (x["type"], x["role"], who,
+                                         "   <- LF staff, kept by design"
+                                         if who == KEEP_DOMAIN else ""))
+    if p["orphans"] or p["near"]:
+        print("\nAccepted organizers with no matching chapter folder (they get NO grant):")
+        for o in p["orphans"]:
+            print("     %-24s %s" % (o["city"], ", ".join(x["name"] for x in o["people"])))
+        for m in p["near"]:
+            print("     %-24s ~ %s" % (m["city"], ", ".join(m["candidates"])))
+
+    print("\nNet effect: the website keeps its %d images, %d organizers keep access to "
+          "their own chapter only, and the CRMs stop being readable by anyone with the link."
+          % (len(p["pins"]) + len(p["already_pinned"]), len(p["grants"]) + len(p["already_granted"])))
+
+
+def apply_pins(p):
+    for x in p["pins"]:
+        gws_json("drive", "permissions", "create",
+                 params={"fileId": x["file_id"], "supportsAllDrives": True},
+                 body={"type": "anyone", "role": "reader"})
+        print("  pinned %s" % x["chapter"])
+    return len(p["pins"])
+
+
+def assert_all_accepted(grants):
+    """Re-read the intake and confirm every grant target really is an accepted
+    organizer, aborting on the first that isn't.
+
+    Deliberately redundant with read_role_tab's status filter, and deliberately a
+    different code path: this is the last gate before handing someone standing
+    write access to a chapter, and "the filter that built the list says the list
+    is fine" is not a check. Matches on email across ALL role tabs, because a
+    person can hold several rows and only one of them needs to be a decision.
+    """
+    ok = {}
+    for tab in ROLE_TABS:
+        rows = get_values(INTAKE_ID, "%s!A:BB" % tab)
+        headers = [h.strip() for h in rows[0]]
+        i_st, i_em = headers.index("Status"), headers.index("Email")
+        for row in rows[1:]:
+            row = row + [""] * (len(headers) - len(row))
+            e = fold_email(cell(row, i_em))
+            if e:
+                ok.setdefault(e, set()).add(cell(row, i_st))
+    bad = [g for g in grants
+           if not (ok.get(fold_email(g["email"]), set()) & set(SYNC_STATUSES))]
+    if bad:
+        sys.exit("ABORT: %d grant target(s) are NOT accepted/existing organizers — "
+                 "nothing was granted:\n%s"
+                 % (len(bad), "\n".join("  %s (%s) status=%s" % (
+                     g["email"], g["chapter"],
+                     sorted(ok.get(fold_email(g["email"]), {"<no intake row>"})))
+                     for g in bad)))
+    print("  double-checked: all %d target(s) hold an %s row."
+          % (len(grants), " / ".join(SYNC_STATUSES)))
+
+
+def apply_grants(p, notify, allow_mail=False):
+    """Grant each organizer their chapter, surviving individual failures.
+
+    One unusable address must not abandon the rest: the intake is fed by a public
+    form, so a typo'd address is a NORMAL input, and Drive rejects it with a hard
+    400. Aborting the phase on the first one left 82 of 91 grants unapplied and
+    made the failure look systemic rather than like one bad row to fix.
+    """
+    assert_all_accepted(p["grants"])
+    failed, mailed = [], []
+
+    def create(g, send):
+        gws_json("drive", "permissions", "create",
+                 params={"fileId": g["folder_id"], "supportsAllDrives": True,
+                         "sendNotificationEmail": send},
+                 body={"type": "user", "role": g["role"], "emailAddress": g["email"]})
+
+    for g in p["grants"]:
+        try:
+            # Notifications off by default: 98 share-mails arriving unannounced
+            # reads as a phishing wave, and everyone already has read access.
+            create(g, bool(notify))
+            print("  granted %s -> %s (%s)" % (g["email"], g["chapter"], g["role"]))
+            continue
+        except Exception as e:
+            msg = str(e)
+        # Drive REFUSES to share with an address that has no Google account
+        # unless it may email them — there is no silent path for these, so the
+        # notification is the price of granting access at all, not a choice.
+        if NO_ACCOUNT in msg and not notify:
+            if not allow_mail:
+                failed.append((g["chapter"], g["name"], g["email"],
+                               "no Google account — Drive requires emailing them; "
+                               "re-run with --notify (or --mail-if-required)"))
+                print("  SKIPPED %s -> %s: needs a notification email"
+                      % (g["email"], g["chapter"]), file=sys.stderr)
+                continue
+            try:
+                create(g, True)
+                mailed.append((g["chapter"], g["email"]))
+                print("  granted %s -> %s (%s, notification sent — no Google account)"
+                      % (g["email"], g["chapter"], g["role"]))
+                continue
+            except Exception as e:
+                msg = str(e)
+        hint = ("Drive rejected the address — check it for a typo on the intake row"
+                if "problem with this email" in msg else msg[:160])
+        failed.append((g["chapter"], g["name"], g["email"], hint))
+        print("  FAILED %s -> %s: %s" % (g["email"], g["chapter"], hint), file=sys.stderr)
+
+    if mailed:
+        print("\n  %d grant(s) sent a Drive notification email (unavoidable — no "
+              "Google account on the address):" % len(mailed))
+        for ch, em in mailed:
+            print("     %-18s %s" % (ch, em))
+    if failed:
+        print("\n  %d grant(s) could not be applied — fix the intake row and re-run:"
+              % len(failed))
+        for ch, name, em, why in failed:
+            print("     %-18s %-26s %s\n        %s" % (ch, name, em, why))
+    return len(p["grants"]) - len(failed)
+
+
+def apply_lock(p):
+    for x in p["public"]:
+        gws_json("drive", "permissions", "delete",
+                 params={"fileId": CHAPTERS_PARENT, "permissionId": x["id"],
+                         "supportsAllDrives": True})
+        print("  removed %s:%s from Chapters/" % (x["type"], x["role"]))
+    return len(p["public"])
+
+
+def verify(p):
+    """Re-read the three things the phases changed. The banners are checked FIRST
+    and individually — a site-wide image outage is the worst outcome here and the
+    only one nobody would notice from inside Drive."""
+    bad = []
+    for x in p["pins"]:
+        if not direct_public(x["file_id"]):
+            bad.append("banner for %s is still not directly public" % x["chapter"])
+    if any(q["type"] == "anyone" for q in perms(CHAPTERS_PARENT)):
+        bad.append("Chapters/ is still link-shared")
+    # Spot-check the grants rather than re-reading all 52 folders: a missing
+    # grant is recoverable and visible to the organizer, unlike a dark website.
+    for g in p["grants"][:5]:
+        if canon_email(g["email"]) not in {canon_email(q.get("emailAddress", ""))
+                                           for q in perms(g["folder_id"])}:
+            bad.append("%s has no grant on %s" % (g["email"], g["chapter"]))
+    return bad
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Plan/apply per-chapter access for the Chapters folder.")
+    ap.add_argument("--write", action="store_true", help="apply (default: report only)")
+    ap.add_argument("--role", default="writer", choices=("writer", "reader", "commenter"),
+                    help="role granted to each organizer on their chapter (default: writer)")
+    ap.add_argument("--phase", choices=("pin", "grant", "lock"),
+                    help="apply only one phase (default: all three, in order)")
+    ap.add_argument("--notify", action="store_true",
+                    help="let Drive email EVERY organizer about their new access")
+    ap.add_argument("--mail-if-required", action="store_true",
+                    help="email only the organizers whose address has no Google "
+                         "account, where Drive refuses to share without it")
+    a = ap.parse_args()
+
+    p = plan(a.role)
+    report(p, a.role)
+    if not a.write:
+        print("\nReport only — nothing was changed. Re-run with --write to apply.")
+        return 0
+
+    order = [("pin", apply_pins, (p,)), ("grant", apply_grants, (p, a.notify, a.mail_if_required)),
+             ("lock", apply_lock, (p,))]
+    for name, fn, args in order:
+        if a.phase and a.phase != name:
+            continue
+        print("\nApplying phase %r..." % name)
+        # Phases run in order and the loop stops on the first failure: locking
+        # after a failed pin is the one combination that takes the site down.
+        try:
+            n = fn(*args)
+        except Exception as e:
+            sys.exit("ABORT during phase %r: %s\nEarlier phases were applied; later "
+                     "ones were NOT. Re-run to continue." % (name, e))
+        print("  phase %r: %d change(s)" % (name, n))
+
+    if not a.phase:
+        print("\nVerifying...")
+        bad = verify(p)
+        if bad:
+            print("VERIFY FAILED:")
+            for b in bad:
+                print("  " + b)
+            return 1
+        print("Verified: banners are directly public and Chapters/ is no longer link-shared.")
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-chapters/scripts/sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/sync_access.py
@@ -4,10 +4,11 @@
 Third engine in this skill, and the one with teeth: it changes who can reach
 things. Report-only by default, like the other two.
 
-The Chapters folder is shared `anyone -> reader`, inherited by every chapter
-folder and every file in them. One thing depends on it: chapter organizers'
-access. Nobody has an individual grant — the public link IS how they get in (as
-a reader) — so `grant` must run before `lock`.
+The Chapters folder was shared `anyone -> reader`, inherited by every chapter
+folder and every file in them. One thing depended on it: chapter organizers'
+access. Before this engine first ran, essentially nobody held an individual
+grant — the public link was how organizers got in, as readers — which is why
+`grant` must always run before `lock`.
 
     grant — give each accepted organizer access to their own chapter folder.
     lock  — remove anyone:reader from the Chapters folder.
@@ -28,22 +29,27 @@ hold its own public share AFTER the parent's is gone. Never trust its "N changes
 line — re-read the permission and check `permissionDetails[].inherited`.
 
 Usage:
-  python3 sync_access.py                  # full plan, changes nothing
-  python3 sync_access.py --write          # apply all three phases, in order
-  python3 sync_access.py --write --phase pin
-  python3 sync_access.py --role reader    # grant something other than writer
+  python3 sync_access.py                    # full plan, changes nothing
+  python3 sync_access.py --write            # apply every phase, in order
+  python3 sync_access.py --write --phase grant
+  python3 sync_access.py --role reader      # grant something other than writer
+  python3 sync_access.py --write --mail-if-required   # email only the addresses
+                                            # with no Google account, which Drive
+                                            # refuses to share with otherwise
+  python3 sync_access.py --write --notify   # email EVERY grantee
+  python3 sync_access.py --write --lock-anyway        # lock even though some
+                                            # organizers could not be granted
 """
-import argparse, os, sys
+import argparse, os, re, sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from sync_chapters import (CHAPTERS_ID, CHAPTERS_TAB, INTAKE_ID, gws_json, get_values,
-                           cell, fold)
-from sync_crm import (CHAPTERS_PARENT, SYNC_STATUSES, TEMPLATE_FOLDER, ROLE_TABS,
+                           cell, fold_city, header_index)
+# ROLE_TABS is deliberately NOT imported: folder access reads ACCESS_TABS only,
+# and having the wider constant in scope is how the escalation crept in before.
+from sync_crm import (CHAPTERS_PARENT, SYNC_STATUSES, TEMPLATE_FOLDER,
                       fold_email, list_chapter_folders, match_chapters, merge_people,
                       read_role_tab)
-
-PUBLIC_ID = "anyoneWithLink"       # the permission id Drive gives an anyone-share
-BANNER = "Web Banner.png"
 
 # Kept deliberately: this is the Linux Foundation's own staff access, not public
 # reach, and removing it is a separate decision from de-publicising the folder.
@@ -66,19 +72,49 @@ def canon_email(e):
     """
     e = fold_email(e)
     local, _, domain = e.partition("@")
-    return (local.replace(".", "") + "@" + domain) if domain == "gmail.com" else e
+    if domain in ("gmail.com", "googlemail.com"):
+        # googlemail.com is the same mailbox as gmail.com, and Gmail ignores a
+        # +tag. Missing either reproduces exactly the bug this function fixes:
+        # Drive stores the canonical form, the comparison misses, and the grant
+        # is re-proposed on every run.
+        local = local.split("+", 1)[0].replace(".", "")
+        return local + "@gmail.com"
+    return e
 
 
 def perms(file_id):
-    """Permissions on a file, each tagged with whether it is inherited."""
-    res = gws_json("drive", "permissions", "list", params={
-        "fileId": file_id, "supportsAllDrives": True, "pageSize": 100,
-        "fields": "permissions(id,type,role,emailAddress,domain,permissionDetails)"})
-    out = []
-    for p in res.get("permissions", []):
-        det = p.get("permissionDetails") or [{}]
-        out.append(dict(p, inherited=bool(det[0].get("inherited"))))
-    return out
+    """Every permission on a file, each tagged with whether it is inherited.
+
+    Paginated, deliberately. A single page caps at 100, and the Chapters parent
+    is the most permission-heavy object in the tree — this PR alone adds ~92
+    user grants beneath it. If the `anyone` entry ever falls onto page 2, an
+    unpaginated read makes plan() report "already not link-shared", apply_lock
+    delete nothing, and verify() confirm success on a still-public folder. That
+    is fail-OPEN on the one decision that matters most here.
+    """
+    out, token = [], None
+    while True:
+        params = {"fileId": file_id, "supportsAllDrives": True, "pageSize": 100,
+                  "fields": "nextPageToken,permissions(id,type,role,emailAddress,"
+                            "domain,permissionDetails)"}
+        if token:
+            params["pageToken"] = token
+        res = gws_json("drive", "permissions", "list", params=params)
+        if "permissions" not in res:
+            # An unexpected response shape must not read as "no permissions".
+            raise RuntimeError("permissions.list returned no 'permissions' key for %s: %r"
+                               % (file_id, res))
+        for p in res["permissions"]:
+            det = p.get("permissionDetails") or []
+            # Default to inherited=True when the API doesn't say. The permissive
+            # answer (False = "this is our own direct grant") would classify a
+            # merely-inherited share as pinned/granted, skip the work, and then
+            # skip the verification too.
+            own = True if not det else any(d.get("inherited") for d in det)
+            out.append(dict(p, inherited=own))
+        token = res.get("nextPageToken")
+        if not token:
+            return out
 
 
 def direct_public(file_id):
@@ -87,28 +123,42 @@ def direct_public(file_id):
     return any(p["type"] == "anyone" and not p["inherited"] for p in perms(file_id))
 
 
-def banner_ids():
-    """{chapter folder id -> banner file id} for the images the website serves.
+_DRIVE_ID_RE = re.compile(r"(?:/d/|[?&]id=)([A-Za-z0-9_-]{20,})")
 
-    Resolved from the feed's `Image` column, not by globbing for a file named
-    `Web Banner.png`: the feed is what the public site actually requests, so a
-    chapter whose cell points somewhere unexpected must be pinned there, and a
-    banner nothing references is not load-bearing.
+
+def banner_ids():
+    """{folded city -> {city, file_id, url}} for each chapter's banner asset.
+
+    Resolved from the feed's `Image` column rather than by globbing for a file
+    named `Web Banner.png`, so a cell pointing somewhere unexpected is visible
+    rather than silently replaced by whatever the glob found.
+
+    These are the Drive SOURCE assets the feed points at — NOT what visitors
+    fetch. See the module docstring: the site serves its imagery from Sanity.
+
+    Keyed with fold_city, matching every other city-to-folder comparison in this
+    skill. Plain fold() leaves punctuation intact, so a feed spelling of
+    `Washington, DC` missed the `Washington DC` folder and the chapter was
+    reported as having no resolvable image at all.
     """
     rows = get_values(CHAPTERS_ID, "'%s'!A:AZ" % CHAPTERS_TAB)
+    if not rows:
+        sys.exit("ABORT: chapters feed tab %r came back empty." % CHAPTERS_TAB)
     headers = [h.strip() for h in rows[0]]
-    if "Image" not in headers:
-        sys.exit("ABORT: no 'Image' column on the chapters feed — cannot tell which "
-                 "files the website serves, so the lock step is unsafe to plan.")
-    i_img, i_city = headers.index("Image"), headers.index("City")
+    i_img, i_city = header_index(headers, CHAPTERS_TAB, "Image", "City")
     out = {}
     for row in rows[1:]:
         url, city = cell(row, i_img), cell(row, i_city)
         if not (url and city):
             continue
-        # .../d/<id> is the only form the feed uses; anything else is reported.
-        fid = url.rsplit("/d/", 1)[-1].split("/")[0].split("?")[0] if "/d/" in url else ""
-        out[fold(city)] = {"city": city, "file_id": fid, "url": url}
+        # Both forms Drive hands out: `/d/<id>` and `?id=<id>`. An unrecognised
+        # shape yields "" and is reported, never silently treated as absent.
+        m = _DRIVE_ID_RE.search(url)
+        key = fold_city(city)
+        if key in out:
+            print("  !! duplicate feed row for %r — the later one wins" % city,
+                  file=sys.stderr)
+        out[key] = {"city": city, "file_id": m.group(1) if m else "", "url": url}
     return out
 
 
@@ -117,8 +167,9 @@ def banner_ids():
 # (they are a person the chapter deals with) but has no business with write
 # access to its Drive folder: trackers, decks, budgets and the CRM itself live
 # there. Looping ROLE_TABS here granted speakers and hosts the same writer role
-# as organizers — invisible today because neither tab has an accepted row, and a
-# silent privilege escalation the first time one is triaged.
+# as organizers — invisible while neither tab has an accepted row (true as of
+# 2026-08), and a silent privilege escalation the first time one is triaged.
+# test_sync_access.py asserts this constant so the regression cannot return.
 ACCESS_TABS = ("Organizers",)
 
 
@@ -126,31 +177,47 @@ def plan(role):
     folders = [f for f in list_chapter_folders() if f["name"] != TEMPLATE_FOLDER]
     people = []
     for tab in ACCESS_TABS:
-        pp, _ = read_role_tab(tab, {})
+        pp, _, _ = read_role_tab(tab, {})
         people += pp
     by_folder, orphans, near = match_chapters(merge_people(people), folders)
     imgs = banner_ids()
 
     pins, grants, already_pinned, already_granted, no_banner = [], [], [], [], []
+    already_pinned_ids, already_granted_ids, stale = [], [], []
     for f in folders:
-        img = imgs.get(fold(f["name"]))
+        img = imgs.get(fold_city(f["name"]))
         if not img or not img["file_id"]:
             no_banner.append(f["name"])
         elif direct_public(img["file_id"]):
             already_pinned.append(f["name"])
+            already_pinned_ids.append((f["name"], img["file_id"]))
         else:
-            pins.append({"chapter": f["name"], "file_id": img["file_id"], "url": img["url"]})
+            pins.append({"chapter": f["name"], "folder_id": f["id"],
+                         "file_id": img["file_id"], "url": img["url"]})
 
         want = by_folder.get(f["id"], [])
+        # Read permissions for EVERY chapter, including the ones with no accepted
+        # organizer. Skipping those hid their stale grants entirely — and a
+        # chapter nobody is accepted for is exactly where an unexplained writer
+        # is most worth seeing.
+        folder_perms = perms(f["id"])
+        expected = {canon_email(x["email"]) for x in want}
+        for q in folder_perms:
+            if q["type"] != "user" or q["inherited"]:
+                continue
+            if canon_email(q.get("emailAddress", "")) not in expected:
+                stale.append((f["name"], q.get("emailAddress"), q["role"]))
         if not want:
             continue
-        # Owner/organizer access already covers everything, inherited or not —
-        # re-granting the folder owner is a no-op Drive rejects.
-        have = {canon_email(p.get("emailAddress", "")) for p in perms(f["id"])
+        # The folder owner already has everything, inherited or not — re-granting
+        # an owner is a no-op Drive rejects. (This tree is My Drive; on a Shared
+        # Drive the equivalent top-level role is "organizer".)
+        have = {canon_email(p.get("emailAddress", "")) for p in folder_perms
                 if p["type"] == "user" and (not p["inherited"] or p["role"] == "owner")}
         for p in want:
             if canon_email(p["email"]) in have:
                 already_granted.append((f["name"], p["email"]))
+                already_granted_ids.append((f["name"], f["id"], p["email"]))
             else:
                 grants.append({"chapter": f["name"], "folder_id": f["id"],
                                "email": p["email"], "name": p["name"], "role": role})
@@ -159,7 +226,9 @@ def plan(role):
     public = [p for p in parent if p["type"] == "anyone"]
     return {"pins": pins, "grants": grants, "already_pinned": already_pinned,
             "already_granted": already_granted, "no_banner": no_banner,
-            "public": public, "parent": parent, "orphans": orphans, "near": near}
+            "public": public, "parent": parent, "orphans": orphans, "near": near,
+            "already_pinned_ids": already_pinned_ids,
+            "already_granted_ids": already_granted_ids, "stale": stale, "role": role}
 
 
 def report(p, role):
@@ -171,8 +240,9 @@ def report(p, role):
     if len(p["pins"]) > 6:
         print("     … and %d more" % (len(p["pins"]) - 6))
     if p["no_banner"]:
-        print("  !! %d chapter(s) have no resolvable Image on the feed — the site shows "
-              "nothing for them either way: %s" % (len(p["no_banner"]), ", ".join(p["no_banner"])))
+        print("  !! %d chapter(s) have no resolvable Image id on the feed (the cell is "
+              "empty or not a Drive URL): %s"
+              % (len(p["no_banner"]), ", ".join(p["no_banner"])))
 
     print("\nPHASE 2 — grant each accepted organizer %r on their own chapter folder" % role)
     print("  %d new grant(s) across %d chapter(s); %d already in place."
@@ -205,18 +275,57 @@ def report(p, role):
         for m in p["near"]:
             print("     %-24s ~ %s" % (m["city"], ", ".join(m["candidates"])))
 
-    print("\nNet effect: the website keeps its %d images, %d organizers keep access to "
-          "their own chapter only, and the CRMs stop being readable by anyone with the link."
-          % (len(p["pins"]) + len(p["already_pinned"]), len(p["grants"]) + len(p["already_granted"])))
+    if p["stale"]:
+        # Direct grants held by people with no intake row. They survive the lock,
+        # so a denied ex-organizer keeps write access until someone removes it
+        # by hand — which requires knowing they exist.
+        print("\nDirect grants held by people the intake does not know about "
+              "(NOT touched; they survive the lock — audit these):")
+        for ch, em, r in sorted(p["stale"]):
+            print("     %-18s %-42s %s" % (ch, em, r))
+    print("\nNet effect: %d chapter-folder grant(s) at %r for accepted organizers, and "
+          "the CRMs stop being readable by anyone with the link."
+          % (len(p["grants"]) + len(p["already_granted"]), role))
+    print("           (%d Drive banner(s) would hold their own public share. The "
+          "website itself serves from Sanity and is unaffected either way.)"
+          % (len(p["pins"]) + len(p["already_pinned"])))
 
 
 def apply_pins(p):
+    """Give each banner its own anyone:reader — validated, then re-read.
+
+    The file id is string-sliced out of a spreadsheet cell that anyone with edit
+    access to the chapters feed can change. Without checking what it points at,
+    aiming an `Image` cell at a CRM file id would make that CRM permanently
+    world-readable — and `lock` only touches the parent, so the grant survives
+    the very step meant to make things private.
+    """
+    landed = 0
     for x in p["pins"]:
+        meta = gws_json("drive", "files", "get", params={
+            "fileId": x["file_id"], "supportsAllDrives": True,
+            "fields": "id,name,mimeType,parents"})
+        if not meta.get("mimeType", "").startswith("image/"):
+            sys.exit("ABORT: %s's Image cell points at %r (%s), which is not an image. "
+                     "Nothing further was pinned." % (x["chapter"], meta.get("name"),
+                                                      meta.get("mimeType")))
+        if x["folder_id"] not in (meta.get("parents") or []):
+            sys.exit("ABORT: %s's Image cell points at %r, which does not live in that "
+                     "chapter's folder. Nothing further was pinned."
+                     % (x["chapter"], meta.get("name")))
         gws_json("drive", "permissions", "create",
                  params={"fileId": x["file_id"], "supportsAllDrives": True},
                  body={"type": "anyone", "role": "reader"})
+        # Drive merges a duplicate anyone:reader into the inherited one and
+        # returns 200 having stored nothing, so the create call proves nothing.
+        if not direct_public(x["file_id"]):
+            sys.exit("ABORT: pinning %s returned success but the file still has no "
+                     "direct anyone:reader — Drive merged it into the parent's "
+                     "inherited share. The parent must be unshared FIRST. Do not "
+                     "run lock." % x["chapter"])
+        landed += 1
         print("  pinned %s" % x["chapter"])
-    return len(p["pins"])
+    return landed
 
 
 def assert_all_accepted(grants):
@@ -229,27 +338,44 @@ def assert_all_accepted(grants):
     is fine" is not a check. Matches on email across ALL role tabs, because a
     person can hold several rows and only one of them needs to be a decision.
     """
+    # Scan ACCESS_TABS, not ROLE_TABS. Matching a decision on ANY tab meant an
+    # accepted SPEAKER satisfied the gate — precisely the privilege escalation
+    # the ACCESS_TABS comment above records as having already shipped once. A
+    # gate has to be at least as narrow as the thing it guards.
     ok = {}
-    for tab in ROLE_TABS:
+    for tab in ACCESS_TABS:
         rows = get_values(INTAKE_ID, "%s!A:BB" % tab)
+        if not rows:
+            sys.exit("ABORT: intake tab %r came back empty — cannot verify grants." % tab)
         headers = [h.strip() for h in rows[0]]
-        i_st, i_em = headers.index("Status"), headers.index("Email")
+        i_st, i_em, i_ch = header_index(headers, tab, "Status", "Email", "Chapter")
+        i_h = headers.index("City (New)") if "City (New)" in headers else None
+        i_g = headers.index("City (Existing)") if "City (Existing)" in headers else None
         for row in rows[1:]:
             row = row + [""] * (len(headers) - len(row))
-            e = fold_email(cell(row, i_em))
-            if e:
-                ok.setdefault(e, set()).add(cell(row, i_st))
+            e = canon_email(cell(row, i_em))
+            if not e or cell(row, i_st) not in SYNC_STATUSES:
+                continue
+            g_, h_ = (cell(row, i_g) if i_g is not None else ""), \
+                     (cell(row, i_h) if i_h is not None else "")
+            city = cell(row, i_ch) or h_ or (g_ if g_ and not g_.lower().startswith("other") else "")
+            ok.setdefault(e, set()).add(fold_city(city))
+
+    # ...and the accepted row must name the chapter being granted. Without this
+    # an accepted organizer for one city satisfies a grant on any other, so a
+    # chapter mis-binding upstream would sail through the last gate.
     bad = [g for g in grants
-           if not (ok.get(fold_email(g["email"]), set()) & set(SYNC_STATUSES))]
+           if fold_city(g["chapter"]) not in ok.get(canon_email(g["email"]), set())]
     if bad:
-        sys.exit("ABORT: %d grant target(s) are NOT accepted/existing organizers — "
-                 "nothing was granted:\n%s"
-                 % (len(bad), "\n".join("  %s (%s) status=%s" % (
-                     g["email"], g["chapter"],
-                     sorted(ok.get(fold_email(g["email"]), {"<no intake row>"})))
+        sys.exit("ABORT: %d grant target(s) are not accepted ORGANIZERS for the "
+                 "chapter being granted — nothing was granted:\n%s"
+                 % (len(bad), "\n".join(
+                     "  %s -> %s (accepted organizer for: %s)"
+                     % (g["email"], g["chapter"],
+                        sorted(ok.get(canon_email(g["email"]), set())) or "<no accepted organizer row>")
                      for g in bad)))
-    print("  double-checked: all %d target(s) hold an %s row."
-          % (len(grants), " / ".join(SYNC_STATUSES)))
+    print("  double-checked: all %d target(s) hold an %s row on %s, for the chapter "
+          "being granted." % (len(grants), " / ".join(SYNC_STATUSES), "/".join(ACCESS_TABS)))
 
 
 def apply_grants(p, notify, allow_mail=False):
@@ -257,7 +383,7 @@ def apply_grants(p, notify, allow_mail=False):
 
     One unusable address must not abandon the rest: the intake is fed by a public
     form, so a typo'd address is a NORMAL input, and Drive rejects it with a hard
-    400. Aborting the phase on the first one left 82 of 91 grants unapplied and
+    400. Aborting the phase on the first one left most of the batch unapplied and
     made the failure look systemic rather than like one bad row to fix.
     """
     assert_all_accepted(p["grants"])
@@ -271,8 +397,8 @@ def apply_grants(p, notify, allow_mail=False):
 
     for g in p["grants"]:
         try:
-            # Notifications off by default: 98 share-mails arriving unannounced
-            # reads as a phishing wave, and everyone already has read access.
+            # Notifications off by default: one share-mail per organizer, all
+            # arriving unannounced at once, reads as a phishing wave.
             create(g, bool(notify))
             print("  granted %s -> %s (%s)" % (g["email"], g["chapter"], g["role"]))
             continue
@@ -312,7 +438,7 @@ def apply_grants(p, notify, allow_mail=False):
               % len(failed))
         for ch, name, em, why in failed:
             print("     %-18s %-26s %s\n        %s" % (ch, name, em, why))
-    return len(p["grants"]) - len(failed)
+    return len(p["grants"]) - len(failed), failed
 
 
 def apply_lock(p):
@@ -324,22 +450,50 @@ def apply_lock(p):
     return len(p["public"])
 
 
-def verify(p):
-    """Re-read the three things the phases changed. The banners are checked FIRST
-    and individually — a site-wide image outage is the worst outcome here and the
-    only one nobody would notice from inside Drive."""
-    bad = []
-    for x in p["pins"]:
-        if not direct_public(x["file_id"]):
-            bad.append("banner for %s is still not directly public" % x["chapter"])
-    if any(q["type"] == "anyone" for q in perms(CHAPTERS_PARENT)):
-        bad.append("Chapters/ is still link-shared")
-    # Spot-check the grants rather than re-reading all 52 folders: a missing
-    # grant is recoverable and visible to the organizer, unlike a dark website.
-    for g in p["grants"][:5]:
-        if canon_email(g["email"]) not in {canon_email(q.get("emailAddress", ""))
-                                           for q in perms(g["folder_id"])}:
-            bad.append("%s has no grant on %s" % (g["email"], g["chapter"]))
+def verify(p, ran):
+    """Re-read what the phases changed, for the phases that actually ran.
+
+    Every check here re-reads remote truth. Three earlier weaknesses are closed:
+
+      * it verified only the PLANNED pins/grants, so anything the plan
+        classified as `already_*` — i.e. exactly the case where the
+        classification was wrong — was never checked;
+      * it sampled `grants[:5]` of ninety-odd, so a systematic failure past the
+        fifth passed clean;
+      * it accepted ANY permission for the address, so an inherited or
+        reader-level one satisfied a check for a direct `writer` grant.
+
+    `ran` also matters: an empty plan must not print a success line claiming
+    checks that iterated nothing.
+    """
+    bad, checked = [], 0
+    if "pin" in ran:
+        # `already_pinned` is an assertion the plan made from an earlier read —
+        # re-verify it rather than trusting it.
+        for x in p["pins"] + [{"chapter": c, "file_id": i}
+                              for c, i in p.get("already_pinned_ids", [])]:
+            checked += 1
+            if not direct_public(x["file_id"]):
+                bad.append("banner for %s is still not directly public" % x["chapter"])
+    if "grant" in ran:
+        want = [(g["chapter"], g["folder_id"], g["email"], g["role"]) for g in p["grants"]]
+        want += [(c, fid, e, p["role"]) for c, fid, e in p.get("already_granted_ids", [])]
+        for chapter, folder_id, email, role in want:
+            checked += 1
+            direct = {canon_email(q.get("emailAddress", "")): q["role"]
+                      for q in perms(folder_id)
+                      if q["type"] == "user" and not q["inherited"]}
+            got = direct.get(canon_email(email))
+            if got is None:
+                bad.append("%s has no direct grant on %s" % (email, chapter))
+            elif got != role:
+                bad.append("%s has %r on %s, expected %r" % (email, got, chapter, role))
+    if "lock" in ran:
+        checked += 1
+        if any(q["type"] == "anyone" for q in perms(CHAPTERS_PARENT)):
+            bad.append("Chapters/ is still link-shared")
+    if not checked:
+        bad.append("nothing was verified — the plan was empty for the phase(s) that ran")
     return bad
 
 
@@ -352,6 +506,9 @@ def main():
                     help="apply only one phase (default: all three, in order)")
     ap.add_argument("--notify", action="store_true",
                     help="let Drive email EVERY organizer about their new access")
+    ap.add_argument("--lock-anyway", action="store_true",
+                    help="remove the public share even when some organizers could "
+                         "not be granted access (they will lose all access)")
     ap.add_argument("--mail-if-required", action="store_true",
                     help="email only the organizers whose address has no Google "
                          "account, where Drive refuses to share without it")
@@ -365,22 +522,38 @@ def main():
 
     order = [("pin", apply_pins, (p,)), ("grant", apply_grants, (p, a.notify, a.mail_if_required)),
              ("lock", apply_lock, (p,))]
+    grant_failures = []
     for name, fn, args in order:
         if a.phase and a.phase != name:
             continue
+        # Removing the public share is the last thing that happens, and only if
+        # every organizer actually has their own grant. Skipping a no-Google-
+        # account address is the DOCUMENTED DEFAULT, so without this gate the
+        # normal run locks out exactly the people it failed to grant — the
+        # public link being the only access they had.
+        if name == "lock" and grant_failures and not a.lock_anyway:
+            sys.exit("ABORT before lock: %d organizer(s) have no grant (listed above). "
+                     "Removing the public share now would leave them with NO access at "
+                     "all.\nFix the intake rows (or pass --mail-if-required), then "
+                     "re-run — or pass --lock-anyway to accept locking them out."
+                     % len(grant_failures))
         print("\nApplying phase %r..." % name)
-        # Phases run in order and the loop stops on the first failure: locking
-        # after a failed pin is the one combination that takes the site down.
         try:
             n = fn(*args)
         except Exception as e:
             sys.exit("ABORT during phase %r: %s\nEarlier phases were applied; later "
                      "ones were NOT. Re-run to continue." % (name, e))
+        if name == "grant":
+            n, grant_failures = n
         print("  phase %r: %d change(s)" % (name, n))
 
-    if not a.phase:
+    # Verify whatever ran, including a single --phase. `--write --phase lock` is
+    # the most destructive invocation available and used to be the one path with
+    # no re-read at all, reporting a PLANNED count as its result.
+    ran = [n for n, _, _ in order if not a.phase or a.phase == n]
+    if ran:
         print("\nVerifying...")
-        bad = verify(p)
+        bad = verify(p, ran)
         if bad:
             print("VERIFY FAILED:")
             for b in bad:
@@ -391,4 +564,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    # sys.exit(main()), not main(): the return code is the ONLY signal a caller,
+    # CI step or `&&` chain gets. Discarding it made every run — including
+    # "VERIFY FAILED" after the public share was removed — exit 0.
+    sys.exit(main())

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -69,9 +69,11 @@ _TRANSIENT_STATUS = re.compile(r"(?<![0-9])(?:429|500|502|503|504)(?![0-9])")
 def _transient(msg):
     return any(k in msg for k in _TRANSIENT) or bool(_TRANSIENT_STATUS.search(msg))
 
-def _gws(cmd, retries=5):
+def _gws(cmd, retries=5, cwd=None):
+    # cwd: gws rejects --output/--upload paths outside its working directory, so
+    # the Drive callers in sync_crm.py run it from the file's own directory.
     for i in range(max(1, retries)):   # retries<=0 must raise below, not return None
-        r = subprocess.run(cmd, capture_output=True, text=True)
+        r = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
         if r.returncode == 0:
             return r.stdout
         msg = (r.stderr or "") + (r.stdout or "")

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -1,0 +1,974 @@
+#!/usr/bin/env python3
+"""Sync intake people (organizers / hosts / speakers) into each chapter's
+Attendee CRM workbook, carrying their survey answers across.
+
+Companion engine to sync_chapters.py: that one pushes accepted organizer *names*
+onto the public chapters feed, this one pushes accepted *people and their stated
+interest* into the private per-chapter CRM. Same house rules — the intake sheet
+is only ever READ, the report is the default, and --write re-verifies itself.
+
+Only Accepted / Existing (from MLOps) people sync, across all three role tabs
+(see SYNC_STATUSES). The CRM is the onboarding list that decides who gets access
+to a chapter folder, so a person reaches it after a decision, not on submitting
+the form.
+
+Each chapter folder under the Chapters Drive holds one "<City> CRM.xlsx" whose
+"Attendees" tab has eleven columns. Only six are ever written (CRM_WRITTEN) —
+identity, decision and interest, and nothing else:
+
+    Full name           <- role tab name
+    Trusted/Regular     <- "Yes" for an organizer (they're on the team)
+    Status              <- Organizer / Speaker / Host
+    Notes (CRM)         <- provenance: role, intake status, date
+    Email               <- role tab email        (also the dedupe key)
+    What brings you here? <- the survey answer verbatim, + talk/venue/city detail
+
+Deliberately NOT written: Signal, LinkedIn URL, Company, Role / title, Technical
+expertise. They exist on the sheet for an organizer to fill in by hand; the
+automation does not push a survey's worth of personal detail into the folder.
+
+The workbooks are stored .xlsx (not native Sheets), so they are edited as OOXML
+zip parts: download, rewrite the Attendees sheet XML, upload. Every part we do
+not touch is repacked byte-for-byte.
+
+Usage:
+  python3 sync_crm.py                    # report + proposed changes, writes nothing
+  python3 sync_crm.py --city Boston      # scope the report to one chapter
+  python3 sync_crm.py --write            # apply, then re-read and verify
+"""
+import argparse, datetime, io, json, os, re, sys, tempfile, zipfile
+from collections import namedtuple
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Shared with the chapters-feed engine on purpose: one gws retry/JSON path, one
+# city-folding rule, one near-miss stoplist. Two copies would drift, and a city
+# that folds one way here and another way there syncs a person to a chapter whose
+# feed row says something else.
+from sync_chapters import (INTAKE_ID, _gws, gws_json, get_values, fold, fold_city,
+                           city_tokens, cell, header_index)
+
+CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
+TEMPLATE_FOLDER = "TemplateCity"                        # cloned per city; never gets people
+XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+CRM_SHEET = "Attendees"
+# The exact eleven, in order. A workbook whose header row disagrees is skipped
+# with a report line rather than written by column letter — the columns have been
+# renumbered once already (the Guide tab's live-list formula still references L).
+CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)",
+               "Email", "LinkedIn URL", "Company", "Role / title",
+               "Technical expertise", "What brings you here?")
+
+# ONLY these two statuses sync. The CRM is the onboarding list that decides who
+# gets access to a chapter folder, so a person reaches it after a decision, not
+# on submitting the form: "New", "Tentative" and "Denied" are all held back.
+# Exact dropdown strings — "Existing" alone would miss every MLOps row.
+# Consequence, and it is intended: the Hosts and Speakers tabs have never been
+# triaged off "New", so today this syncs organizers only. Both start flowing the
+# moment someone accepts them; nothing here needs to change for that.
+SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
+
+ROLE_TABS = ("Organizers", "Speakers", "Hosts")   # also the merge priority order
+CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
+
+# Status values this script is allowed to overwrite — everything the automation
+# itself writes, plus the sheet's own default and the "Prospect" an earlier,
+# wider-scoped run could have left behind. A human who moved someone to
+# "Attended", "Regular", "Volunteer" or "Declined" has said something the intake
+# does not know; a later triage decision must not silently undo it.
+AUTO_STATUS = frozenset(("", "New", "Prospect", "Organizer", "Speaker", "Host"))
+
+# Keep the CRM minimal. Identity, decision and interest — nothing else. The
+# columns left out (LinkedIn URL, Company, Role / title, Technical expertise)
+# still exist on the sheet for an organizer to fill in by hand; the automation
+# just doesn't push a survey's worth of personal detail into a folder that is
+# still link-readable while chapters are being onboarded.
+CRM_WRITTEN = ("Full name", "Trusted/Regular", "Status", "Notes (CRM)", "Email",
+               "What brings you here?")
+
+# Rows whose email is at one of these domains are shipped fixture data — the
+# "Sam Taylor" sample the template puts in every chapter, and the Tatooine test
+# chapter's cast. They are cleared, and their rows reused by real people.
+DUMMY_DOMAINS = ("example.com", "example.org", "example.net", "example.edu")
+
+# The Status dropdown shipped without a value for a venue host, so hosts had
+# nowhere honest to land. Patched in place on every workbook we open.
+DV_STATUS_OLD = "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined"
+DV_STATUS_NEW = "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
+
+# Per-role source columns on the intake role tabs, resolved by header name and
+# taken in order (first non-empty wins). Organizers have no company or title
+# question; hosts have no title. Missing headers are tolerated here — unlike the
+# feed writer, a blank CRM cell is a gap, not a corrupt public row.
+ROLE_FIELDS = {
+    "Organizers": {"name": ("Full name",), "company": (), "title": (),
+                   "expertise": ("Technical expertise",),
+                   "detail": ("Chapter / city wanted",)},
+    "Speakers":   {"name": ("Name", "Full name"), "company": ("Affiliation",),
+                   "title": ("Headline",), "expertise": ("Areas of expertise",),
+                   "detail": ("Talk title",)},
+    "Hosts":      {"name": ("Name", "Full name"), "company": ("Company",), "title": (),
+                   "expertise": ("Industry",), "detail": ("Venue name",)},
+}
+
+# Fallback for "What brings you here?" when a role-tab row can't be joined back to
+# its Form Responses row by email — the form's own wording for that branch.
+DEFAULT_INTEREST = {
+    "Organizers": "I want to be an organizer/volunteer for the local chapter",
+    "Speakers":   "I want to be a speaker",
+    "Hosts":      "I want to host a meetup (offer a venue)",
+}
+
+# Free text goes into a *private* workbook as an inline string, which Excel and
+# Sheets both treat as literal text — a leading "=" can never become a formula,
+# so no RAW-vs-USER_ENTERED equivalent is needed here. Control characters are
+# still stripped (they make the XML unopenable) and absurd lengths capped well
+# under Excel's 32767-character ceiling.
+MAX_CELL_TEXT = 2000
+_CONTROL = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+_XLNS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+_RELNS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+X = "{%s}" % _XLNS
+R_ID = "{%s}id" % _RELNS
+_XMLNS_RE = re.compile(rb'xmlns:([A-Za-z0-9_]+)="([^"]+)"')
+_XML_DECL = b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+
+
+# ----------------------------------------------------------------------------
+# Text helpers
+# ----------------------------------------------------------------------------
+def clean_text(s):
+    """Strip control characters, collapse newlines, cap the length."""
+    s = _CONTROL.sub("", (s or "").replace("\r\n", "\n"))
+    s = re.sub(r"[\n\t]+", " ", s)
+    s = re.sub(r" {2,}", " ", s).strip()
+    return s if len(s) <= MAX_CELL_TEXT else s[:MAX_CELL_TEXT - 1] + "…"
+
+
+def fold_email(s):
+    """Dedupe key for a person. Case- and whitespace-insensitive; the local part
+    is NOT otherwise normalised (dots and +tags are meaningful on some hosts)."""
+    return clean_text(s).casefold()
+
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s.]+(\.[^@\s.]+)+$")
+
+
+def valid_email(s):
+    return bool(_EMAIL_RE.match(clean_text(s)))
+
+
+def first_of(row, headers, names):
+    """First non-empty value among `names`, resolved by header name."""
+    for n in names:
+        if n in headers:
+            v = cell(row, headers.index(n))
+            if v:
+                return v
+    return ""
+
+
+def join_distinct(values, sep=" · "):
+    """Join non-empty values, dropping folded duplicates, preserving order."""
+    out, seen = [], set()
+    for v in values:
+        v = clean_text(v)
+        if v and fold(v) not in seen:
+            seen.add(fold(v))
+            out.append(v)
+    return sep.join(out)
+
+
+# ----------------------------------------------------------------------------
+# OOXML: read/write the Attendees sheet inside a stored .xlsx
+# ----------------------------------------------------------------------------
+def register_namespaces(xml_bytes):
+    """Keep the document's own xmlns prefixes on re-serialization. Without this
+    ElementTree renames every namespaced attribute to ns0:/ns1: and Excel
+    rejects the file."""
+    ET.register_namespace("", _XLNS)
+    for m in _XMLNS_RE.finditer(xml_bytes):
+        prefix, uri = m.group(1).decode(), m.group(2).decode()
+        try:
+            ET.register_namespace(prefix, uri)
+        except ValueError:
+            pass   # reserved prefixes like "xml"
+
+
+def col_of(ref):
+    """'AB12' -> 27 (0-based column index)."""
+    n = 0
+    for ch in ref:
+        if not ch.isalpha():
+            break
+        n = n * 26 + (ord(ch.upper()) - 64)
+    return n - 1
+
+
+def cell_ref(col, row):
+    """(27, 12) -> 'AB12'."""
+    s, i = "", col + 1
+    while i:
+        i, r = divmod(i - 1, 26)
+        s = chr(ord("A") + r) + s
+    return "%s%d" % (s, row)
+
+
+def load_parts(raw):
+    """Return (names, {name: bytes}) — the whole zip, order preserved."""
+    with zipfile.ZipFile(io.BytesIO(raw)) as z:
+        names = z.namelist()
+        return names, {n: z.read(n) for n in names}
+
+
+def save_parts(names, parts):
+    with io.BytesIO() as buf:
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+            for n in names:
+                z.writestr(n, parts[n])
+        return buf.getvalue()
+
+
+def sheet_part(parts, sheet_name):
+    """Resolve a sheet's zip part through workbook.xml + its rels, never by
+    guessing 'xl/worksheets/sheet1.xml' — sheet order and file numbering are
+    independent, and the legacy CRMs are packed in a different order."""
+    wb = ET.fromstring(parts["xl/workbook.xml"])
+    rid = None
+    for s in wb.iter(X + "sheet"):
+        if s.get("name") == sheet_name:
+            rid = s.get(R_ID)
+            break
+    if rid is None:
+        return None
+    rels = ET.fromstring(parts["xl/_rels/workbook.xml.rels"])
+    for rel in rels:
+        if rel.get("Id") == rid:
+            t = rel.get("Target").lstrip("/")
+            return t if t.startswith("xl/") else "xl/" + t
+    return None
+
+
+def shared_strings(parts):
+    raw = parts.get("xl/sharedStrings.xml")
+    if not raw:
+        return []
+    return ["".join(t.text or "" for t in si.iter(X + "t"))
+            for si in ET.fromstring(raw)]
+
+
+def cell_text(c, sst):
+    """Text of a <c>, whichever of the three storage forms it uses. We only ever
+    WRITE inline strings, but the older CRMs read back as shared-string indices."""
+    if c.get("t") == "inlineStr":
+        el = c.find(X + "is")
+        return "".join(t.text or "" for t in el.iter(X + "t")) if el is not None else ""
+    v = c.find(X + "v")
+    if v is None or v.text is None:
+        return ""
+    if c.get("t") == "s":
+        i = int(v.text)
+        return sst[i] if 0 <= i < len(sst) else ""
+    return v.text
+
+
+def set_cell(row_el, col, text, style=None):
+    """Write `text` into (row_el, col) as an inline string, creating the <c> in
+    column order if it isn't there. `style` is applied only to a cell we create,
+    so an operator's own formatting on an existing cell survives."""
+    ref = cell_ref(col, int(row_el.get("r")))
+    kids = list(row_el)
+    target, insert_at = None, len(kids)
+    for i, c in enumerate(kids):
+        ci = col_of(c.get("r") or "")
+        if ci == col:
+            target = c
+            break
+        if ci > col:
+            insert_at = i
+            break
+    if target is None:
+        target = ET.Element(X + "c", {"r": ref})
+        if style is not None:
+            target.set("s", style)
+        row_el.insert(insert_at, target)
+    for child in list(target):
+        target.remove(child)
+    target.set("r", ref)
+    target.set("t", "inlineStr")
+    is_el = ET.SubElement(target, X + "is")
+    t_el = ET.SubElement(is_el, X + "t")
+    t_el.set("{http://www.w3.org/XML/1998/namespace}space", "preserve")
+    t_el.text = text
+
+
+class Attendees:
+    """The Attendees sheet of one chapter CRM, addressed by header name."""
+
+    def __init__(self, parts, part_name):
+        raw = parts[part_name]
+        register_namespaces(raw)
+        self.parts, self.part_name = parts, part_name
+        self.root = ET.fromstring(raw)
+        self.sst = shared_strings(parts)
+        self.data = self.root.find(X + "sheetData")
+        if self.data is None:
+            raise ValueError("no <sheetData> in %s" % part_name)
+        self.rows = {int(r.get("r")): r for r in self.data.findall(X + "row")}
+        head = self.rows.get(1)
+        if head is None:
+            raise ValueError("no header row")
+        self.headers = {}
+        for c in head.findall(X + "c"):
+            txt = clean_text(cell_text(c, self.sst))
+            if txt:
+                self.headers[txt] = col_of(c.get("r"))
+        missing = [h for h in CRM_HEADERS if h not in self.headers]
+        if missing:
+            raise ValueError("missing column(s): %s" % ", ".join(missing))
+        # Row 2 is the shipped sample row and is the only place the per-column
+        # cell styles exist; new rows copy them so a synced person looks like a
+        # hand-entered one instead of falling back to the sheet default.
+        self.sample = {}
+        row2 = self.rows.get(2)
+        for c in (row2.findall(X + "c") if row2 is not None else []):
+            if c.get("s"):
+                self.sample[col_of(c.get("r"))] = c.get("s")
+
+    def value(self, rownum, header):
+        row = self.rows.get(rownum)
+        if row is None:
+            return ""
+        col = self.headers[header]
+        for c in row.findall(X + "c"):
+            if col_of(c.get("r") or "") == col:
+                return clean_text(cell_text(c, self.sst))
+        return ""
+
+    def index_by_email(self):
+        """Folded email -> row number, for every populated row. First wins: a
+        workbook that already has the same person twice is a pre-existing mess,
+        and picking the later row would strand the earlier one's history."""
+        out = {}
+        for rownum in sorted(self.rows):
+            if rownum == 1:
+                continue
+            e = fold_email(self.value(rownum, "Email"))
+            if e and e not in out:
+                out[e] = rownum
+        return out
+
+    def occupied(self, rownum):
+        return bool(self.value(rownum, "Full name") or self.value(rownum, "Email"))
+
+    def free_rows(self, also_free=()):
+        """Row numbers available for new people, lowest first, then rows past the
+        end of the grid. The shipped workbook pre-creates 1000 styled rows, so a
+        new person almost always lands in one that already exists.
+
+        `also_free` are rows being cleared in the same plan — the sample row the
+        template ships is row 2, so reusing it puts the chapter's first real
+        organizer at the top of the list instead of stranding a blank row there.
+        """
+        existing = sorted(r for r in self.rows if r > 1)
+        for r in existing:
+            if r in also_free or not self.occupied(r):
+                yield r
+        nxt = (existing[-1] if existing else 1) + 1
+        while True:
+            yield nxt
+            nxt += 1
+
+    def clear(self, rownum):
+        """Blank every CRM column on a row, keeping the cells and their styles."""
+        for header in CRM_HEADERS:
+            self.write(rownum, header, "")
+
+    def row_for(self, rownum):
+        row = self.rows.get(rownum)
+        if row is None:
+            row = ET.Element(X + "row", {"r": str(rownum)})
+            # sheetData children must stay in ascending row order or Excel
+            # reports the file as corrupt.
+            kids = list(self.data)
+            at = len(kids)
+            for i, r in enumerate(kids):
+                if int(r.get("r")) > rownum:
+                    at = i
+                    break
+            self.data.insert(at, row)
+            self.rows[rownum] = row
+        return row
+
+    def write(self, rownum, header, text):
+        col = self.headers[header]
+        set_cell(self.row_for(rownum), col, text, self.sample.get(col))
+
+    def serialize(self):
+        """Write the sheet back into its zip part, refreshing <dimension> to
+        cover the rows we added. ET emits its own XML declaration with a
+        different encoding spelling, so it is sliced off and replaced with the
+        one Excel writes."""
+        dim = self.root.find(X + "dimension")
+        if dim is not None and self.rows:
+            start = (dim.get("ref") or "A1").split(":")[0] or "A1"
+            dim.set("ref", "%s:%s" % (start, cell_ref(max(self.headers.values()),
+                                                      max(self.rows))))
+        body = ET.tostring(self.root, encoding="UTF-8")
+        self.parts[self.part_name] = _XML_DECL + body[body.find(b"<worksheet"):]
+
+
+def patch_status_dropdown(parts, part_name):
+    """Add "Host" to the Status column's data-validation list.
+
+    Returns "patched" (the part changed), "already" (Host is offered), or
+    "absent" (no list matching either spelling — reported, never guessed at).
+
+    A bytes-level swap of the one formula string: the validation lives outside
+    <sheetData>, nothing else in the file mentions it, and re-serializing the
+    whole sheet through ElementTree just to change a literal would rewrite
+    unrelated markup. Both quote encodings are handled — the template writes
+    `"…"` and the older workbooks write `&quot;…&quot;`, and matching only the
+    first silently left every legacy CRM un-patched while reporting success.
+    """
+    raw = parts[part_name]
+    for q in (b'"', b"&quot;"):
+        new = b"<formula1>" + q + DV_STATUS_NEW.encode() + q + b"</formula1>"
+        if new in raw:
+            return "already"
+        old = b"<formula1>" + q + DV_STATUS_OLD.encode() + q + b"</formula1>"
+        if old in raw:
+            parts[part_name] = raw.replace(old, new)
+            return "patched"
+    return "absent"
+
+
+# ----------------------------------------------------------------------------
+# Read the intake
+# ----------------------------------------------------------------------------
+def read_survey_interests():
+    """Folded email -> the person's verbatim "What brings you here?" answer.
+
+    The role tabs are filtered views that drop the routing question, so the one
+    column that is literally the person's stated interest has to come from
+    `Form Responses`. Joined on email; a repeat applicant's latest answer wins.
+    """
+    rows = get_values(INTAKE_ID, "'Form Responses'!A:CO")
+    if not rows:
+        sys.exit("ABORT: 'Form Responses' came back empty.")
+    i_email, i_what = header_index(rows[0], "Form Responses",
+                                   "Email", "What brings you here?")
+    out = {}
+    for row in rows[1:]:
+        e, what = fold_email(cell(row, i_email)), clean_text(cell(row, i_what))
+        if e and what:
+            out[e] = what
+    return out
+
+
+def read_role_tab(tab, interests):
+    """Return (people, rejected) for one role tab.
+
+    people   = [{row, tab, name, email, city, status, ...}]
+    rejected = [{row, tab, name, why}]   no email / no city / denied — never written
+    """
+    rows = get_values(INTAKE_ID, "%s!A:BB" % tab)
+    if not rows:
+        sys.exit("ABORT: intake tab %r came back empty." % tab)
+    headers = [h.strip() for h in rows[0]]
+    # Status and Email are load-bearing: without Status we cannot drop denied
+    # applicants, and without Email there is no dedupe key at all. Both are
+    # resolved up front so a header rename aborts instead of syncing everyone as
+    # a brand-new row on every run.
+    i_status, i_email = header_index(headers, tab, "Status", "Email")
+    i_chapter = headers.index("Chapter") if "Chapter" in headers else None
+    i_g = headers.index("City (Existing)") if "City (Existing)" in headers else None
+    i_h = headers.index("City (New)") if "City (New)" in headers else None
+    f = ROLE_FIELDS[tab]
+
+    people, rejected = [], []
+    for rownum, row in enumerate(rows[1:], start=2):
+        email = cell(row, i_email)
+        name = first_of(row, headers, f["name"])
+        if not (email or name):
+            continue                          # trailing empty grid row
+        status = cell(row, i_status)
+        if status not in SYNC_STATUSES:
+            rejected.append({"row": rownum, "tab": tab, "name": name,
+                             "why": "status %r — not accepted yet" % (status or "New")})
+            continue
+        if not valid_email(email):
+            rejected.append({"row": rownum, "tab": tab, "name": name,
+                             "why": "no usable email (%r) — the CRM dedupes on it" % email})
+            continue
+        # Chapter assignment wins (a human made it); then the resolved city, then
+        # the submitted dropdown unless it is an "Other…" placeholder.
+        chapter = cell(row, i_chapter) if i_chapter is not None else ""
+        g = cell(row, i_g) if i_g is not None else ""
+        h = cell(row, i_h) if i_h is not None else ""
+        city = chapter or h or (g if g and not fold(g).startswith("other") else "")
+        if not city:
+            rejected.append({"row": rownum, "tab": tab, "name": name,
+                             "why": "no chapter/city on the intake row"})
+            continue
+        detail = first_of(row, headers, f["detail"])
+        interest = interests.get(fold_email(email)) or DEFAULT_INTEREST[tab]
+        people.append({
+            "row": rownum, "tab": tab, "status": status,
+            "name": clean_text(name) or clean_text(email),
+            "email": clean_text(email), "city": clean_text(city),
+            "linkedin": clean_text(first_of(row, headers, ("LinkedIn",))),
+            "company": clean_text(first_of(row, headers, f["company"])),
+            "title": clean_text(first_of(row, headers, f["title"])),
+            "expertise": clean_text(first_of(row, headers, f["expertise"])),
+            "interest": join_distinct([interest, detail]),
+        })
+    return people, rejected
+
+
+def merge_people(people):
+    """One CRM row per person per chapter, even when they applied twice.
+
+    Keyed on (folded city, folded email). Role precedence follows ROLE_TABS, so
+    someone who is both an organizer and a speaker lands as Organizer with both
+    interests recorded — the alternative, two rows, breaks the workbook's own
+    "keep one row per person, merge by email" rule.
+    """
+    merged = {}
+    for tab in ROLE_TABS:                       # priority order
+        for p in (x for x in people if x["tab"] == tab):
+            key = (fold_city(p["city"]), fold_email(p["email"]))
+            cur = merged.get(key)
+            if cur is None:
+                merged[key] = dict(p, tabs=[tab], rows=[p["row"]])
+                continue
+            cur["tabs"].append(tab)
+            cur["rows"].append(p["row"])
+            for field in ("linkedin", "company", "title"):
+                cur[field] = cur[field] or p[field]
+            cur["expertise"] = join_distinct([cur["expertise"], p["expertise"]])
+            cur["interest"] = join_distinct([cur["interest"], p["interest"]])
+    return list(merged.values())
+
+
+def crm_fields(p, today):
+    """The CRM values for one merged person.
+
+    Only CRM_WRITTEN columns are produced — `Signal` and the detail columns are
+    deliberately absent, so the automation never touches them. A blank value
+    means "leave that cell alone", never "blank it out".
+
+    Every person reaching here is Accepted or Existing (from MLOps): read_role_tab
+    drops everything else, so the CRM Status is always the role itself.
+    """
+    role_tab = p["tabs"][0]
+    return {
+        "Full name": p["name"],
+        # An accepted organizer is on the chapter's team, not a guest to triage.
+        "Trusted/Regular": "Yes" if role_tab == "Organizers" else "",
+        "Status": CRM_STATUS[role_tab],
+        "Notes (CRM)": "Intake: %s · %s · %s" % (
+            "/".join(CRM_STATUS[t] for t in p["tabs"]), p["status"], today),
+        "Email": p["email"],
+        "What brings you here?": p["interest"],
+    }
+
+
+def is_dummy(email):
+    """True only for the reserved example domains. This is the ONLY gate on
+    clearing a row, and it is deliberately narrow: anything with a real-looking
+    address is left exactly where it is and reported instead, because a row a
+    human typed is indistinguishable from one we do not recognise."""
+    e = fold_email(email)
+    return any(e.endswith("@" + d) for d in DUMMY_DOMAINS)
+
+
+def preexisting(att, ops, people=()):
+    """Occupied rows that are neither fixture data, nor touched by this plan, nor
+    someone the intake expects to be there — i.e. people a human added by hand.
+
+    `people` matters on a settled CRM: once everyone is synced there are no ops,
+    so every row the sync itself wrote would otherwise be reported back as an
+    unrecognised "real-looking address — clear by hand if it's fixture data".
+    That reads as a warning about correct data, which trains an operator to
+    ignore the one section that exists to flag the genuinely unexpected.
+    """
+    touched = {o["rownum"] for o in ops}
+    expected = {fold_email(p["email"]) for p in people}
+    return [{"row": r, "name": att.value(r, "Full name"), "email": att.value(r, "Email")}
+            for r in sorted(att.rows)
+            if r > 1 and r not in touched and att.occupied(r)
+            and fold_email(att.value(r, "Email")) not in expected
+            and not is_dummy(att.value(r, "Email"))]
+
+
+def plan_workbook(att, people, today):
+    """Diff one chapter's Attendees sheet against its people. Returns
+    [{kind, email, name, rownum, sets}] — empty when in sync. `kind` is
+    "clear" (fixture row), "add" (new person) or "fill" (existing person).
+
+    Two write rules, and they are the whole safety story for a sheet humans curate:
+      * a cell that already has content is left alone, so notes, corrected
+        spellings and hand-added detail survive every re-run;
+      * except `Status`, which is upgraded when it still holds a value this
+        script wrote (AUTO_STATUS) — that is how a person's role is corrected
+        after re-triage, without ever undoing a human's "Declined".
+    """
+    # Fixture rows go first so their row numbers are reusable below, and so a
+    # dummy address can never be mistaken for an existing person to merge into.
+    clears = [r for r in sorted(att.rows)
+              if r > 1 and att.occupied(r) and is_dummy(att.value(r, "Email"))]
+    ops = [{"kind": "clear", "rownum": r, "email": att.value(r, "Email"),
+            "name": att.value(r, "Full name"), "sets": {}} for r in clears]
+
+    dropped = set(clears)
+    by_email = {e: r for e, r in att.index_by_email().items() if r not in dropped}
+    free = att.free_rows(also_free=dropped)
+    for p in sorted(people, key=lambda x: (fold(x["name"]), x["email"])):
+        want = crm_fields(p, today)
+        rownum = by_email.get(fold_email(p["email"]))
+        new = rownum is None
+        if new:
+            rownum = next(free)
+        sets = {}
+        for header, value in want.items():
+            if not value:
+                continue
+            # A reused fixture row still reads back its dummy content here, but
+            # it is `new`, so nothing on it is treated as a human's edit.
+            current = "" if new else att.value(rownum, header)
+            if current == value:
+                continue
+            if current and not (header == "Status" and current in AUTO_STATUS):
+                continue
+            sets[header] = value
+        if sets:
+            ops.append({"kind": "add" if new else "fill", "email": p["email"],
+                        "name": p["name"], "rownum": rownum, "sets": sets})
+        if new:
+            # Claim the row even when nothing was written, so two people can
+            # never be planned into the same empty row.
+            by_email[fold_email(p["email"])] = rownum
+    return ops
+
+
+def apply_ops(att, ops):
+    # Clears first, and as a separate pass: a cleared row is reused by a person
+    # later in the same plan, so blanking after writing would wipe them out.
+    for op in (o for o in ops if o["kind"] == "clear"):
+        att.clear(op["rownum"])
+    for op in (o for o in ops if o["kind"] != "clear"):
+        for header, value in op["sets"].items():
+            att.write(op["rownum"], header, value)
+
+
+def finalize(book, ops):
+    """Produce the workbook's new bytes: rows first, then serialize, then the
+    dropdown patch — in that order, and only in that order.
+
+    `serialize()` rewrites the sheet part wholesale from the element tree, which
+    was parsed before any bytes-level edit. Patching the dropdown first and
+    serializing second therefore throws the patch away, and the run still reports
+    it as applied — exactly what shipped to a probe workbook until this was
+    caught. Keeping both steps in one function is what stops the order drifting
+    apart again.
+    """
+    apply_ops(book.att, ops)
+    book.att.serialize()
+    patch_status_dropdown(book.parts, book.part)
+    return save_parts(book.names, book.parts)
+
+
+# ----------------------------------------------------------------------------
+# Drive
+# ----------------------------------------------------------------------------
+def list_chapter_folders():
+    res = gws_json("drive", "files", "list", params={
+        "q": "'%s' in parents and mimeType='application/vnd.google-apps.folder' "
+             "and trashed=false" % CHAPTERS_PARENT,
+        "fields": "files(id,name)", "pageSize": 1000,
+        "supportsAllDrives": True, "includeItemsFromAllDrives": True})
+    return sorted(res.get("files", []), key=lambda f: f["name"])
+
+
+def find_crm(folder_id):
+    """The one "* CRM.xlsx" in a chapter folder, or (None, why)."""
+    res = gws_json("drive", "files", "list", params={
+        "q": "'%s' in parents and trashed=false" % folder_id,
+        "fields": "files(id,name,mimeType)", "pageSize": 1000,
+        "supportsAllDrives": True, "includeItemsFromAllDrives": True})
+    crms = [f for f in res.get("files", [])
+            if f["name"].lower().endswith("crm.xlsx") and f["mimeType"] == XLSX]
+    if not crms:
+        return None, "no '<City> CRM.xlsx' in the folder"
+    if len(crms) > 1:
+        return None, "%d CRM files (%s) — expected one" % (
+            len(crms), ", ".join(sorted(f["name"] for f in crms)))
+    return crms[0], None
+
+
+def download(file_id, path):
+    # gws rejects --output paths outside its cwd, so run it in the file's dir.
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    _gws(["gws", "drive", "files", "get", "--params",
+          json.dumps({"fileId": file_id, "supportsAllDrives": True, "alt": "media"}),
+          "--output", os.path.basename(path)], cwd=os.path.dirname(path) or ".")
+    with open(path, "rb") as fh:
+        return fh.read()
+
+
+def upload(file_id, path, raw):
+    with open(path, "wb") as fh:
+        fh.write(raw)
+    _gws(["gws", "drive", "files", "update", "--params",
+          json.dumps({"fileId": file_id, "supportsAllDrives": True}),
+          "--upload", os.path.basename(path), "--upload-content-type", XLSX],
+         cwd=os.path.dirname(path) or ".")
+
+
+# ----------------------------------------------------------------------------
+# Chapter matching
+# ----------------------------------------------------------------------------
+def match_chapters(people, folders):
+    """Return (by_folder, orphans, near_misses).
+
+    by_folder   = {folder_id: [person]}
+    orphans     = [{city, people}]                 no folder at all
+    near_misses = [{city, people, candidates}]     similar folder(s) — never written
+    """
+    live = [f for f in folders if f["name"] != TEMPLATE_FOLDER]
+    folded = [(f, fold_city(f["name"])) for f in live]
+    by_fold = {cf: f for f, cf in folded}
+
+    groups = {}
+    for p in people:
+        groups.setdefault(fold_city(p["city"]), []).append(p)
+
+    by_folder, orphans, near_misses = {}, [], []
+    for fc, grp in sorted(groups.items()):
+        folder = by_fold.get(fc)
+        if folder:
+            by_folder.setdefault(folder["id"], []).extend(grp)
+            continue
+        toks = city_tokens(grp[0]["city"])
+        cands = [f["name"] for f, cf in folded
+                 if (fc and cf and (fc in cf or cf in fc)) or (toks & set(cf.split()))]
+        rec = {"city": grp[0]["city"], "people": grp}
+        if cands:
+            near_misses.append(dict(rec, candidates=sorted(set(cands))))
+        else:
+            orphans.append(rec)
+    return by_folder, orphans, near_misses
+
+
+# ----------------------------------------------------------------------------
+# Report + write
+# ----------------------------------------------------------------------------
+Book = namedtuple("Book", "folder crm names parts part att path")
+
+
+def open_crm(folder, workdir):
+    """Download a chapter's CRM and parse its Attendees sheet.
+
+    Returns (Book, None) or (None, reason). A chapter whose workbook we cannot
+    understand is reported and left untouched — never written by column letter.
+    """
+    crm, why = find_crm(folder["id"])
+    if crm is None:
+        return None, why
+    path = os.path.join(workdir, "%s.xlsx" % re.sub(r"[^\w.-]", "_", folder["name"]))
+    names, parts = load_parts(download(crm["id"], path))
+    part = sheet_part(parts, CRM_SHEET)
+    if part is None:
+        return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
+    try:
+        att = Attendees(parts, part)
+    except ValueError as e:
+        return None, "%s: %s" % (crm["name"], e)
+    return Book(folder, crm, names, parts, part, att, path), None
+
+
+def run(args):
+    today = datetime.date.today().isoformat()
+    interests = read_survey_interests()
+
+    people, rejected = [], []
+    counts = {}
+    for tab in ROLE_TABS:
+        pp, rr = read_role_tab(tab, interests)
+        counts[tab] = len(pp)
+        people += pp
+        rejected += rr
+    merged = merge_people(people)
+
+    # People are matched against EVERY chapter folder, then --city narrows only
+    # which workbooks get opened. Filtering first made --city report every other
+    # city in the world as an orphan with no chapter folder.
+    all_folders = list_chapter_folders()
+    by_folder, orphans, near_misses = match_chapters(merged, all_folders)
+    folders = all_folders
+    if args.city:
+        want = fold_city(args.city)
+        folders = [f for f in all_folders if fold_city(f["name"]) == want]
+        if not folders:
+            sys.exit("ABORT: no chapter folder matches %r." % args.city)
+        # The orphan/near-miss lists are global facts about the intake, not about
+        # the scoped chapter; showing them under --city reads as this chapter's
+        # problem. The full run reports them.
+        orphans, near_misses = [], []
+
+    print("Intake  : %d people across %d chapters (%s); %d intake row(s) not synced."
+          % (len(merged), len(by_folder),
+             ", ".join("%d %s" % (counts[t], t.lower()) for t in ROLE_TABS),
+             len(rejected)))
+    print("Chapters: %d folder(s) in scope.\n" % len(folders))
+
+    touched, skipped, no_dropdown, keepers = [], [], [], []
+    workdir = tempfile.mkdtemp(prefix="aaif-crm-")
+    # Every folder is opened, not just the ones with people: the Status dropdown
+    # patch has to reach chapters that gained nobody this run, and TemplateCity
+    # most of all — otherwise every chapter created from it re-inherits a list
+    # with no value for a venue host.
+    for folder in folders:
+        book, why = open_crm(folder, workdir)
+        if book is None:
+            skipped.append((folder["name"], why))
+            print("  %-18s SKIPPED — %s" % (folder["name"], why))
+            continue
+        grp = by_folder.get(folder["id"], [])
+        # Always planned, even for a chapter that gains nobody: every workbook
+        # carries the template's fixture row, and only 57 of the 82 chapters have
+        # people. `if grp else []` left Sam Taylor sitting in the other 25.
+        ops = plan_workbook(book.att, grp, today)
+        kept = preexisting(book.att, ops, grp)
+        if kept:
+            keepers.append((folder["name"], kept))
+        # Detection only — over a shallow copy, so the real patch happens exactly
+        # once, inside finalize(), after the sheet has been serialized.
+        dv = patch_status_dropdown(dict(book.parts), book.part)
+        if dv == "absent":
+            # Not fatal — people still sync — but say so: a chapter whose Status
+            # column has no dropdown at all will not constrain what gets typed.
+            no_dropdown.append(folder["name"])
+        if not ops and dv != "patched":
+            continue
+        n = {k: sum(1 for o in ops if o["kind"] == k) for k in ("clear", "add", "fill")}
+        bits = ([("%d dummy cleared" % n["clear"])] if n["clear"] else []) \
+            + ([("%d new" % n["add"])] if n["add"] else []) \
+            + ([("%d filled in" % n["fill"])] if n["fill"] else []) \
+            + (['Status dropdown += "Host"'] if dv == "patched" else [])
+        print("  %-18s %s" % (folder["name"], ", ".join(bits)))
+        for o in ops:
+            mark = {"clear": "-", "add": "+", "fill": "~"}[o["kind"]]
+            detail = ("dummy row wiped" if o["kind"] == "clear" else
+                      ", ".join("%s=%r" % (k, v if len(v) < 60 else v[:57] + "…")
+                                for k, v in o["sets"].items()))
+            print("      %s row %-4d %s <%s> — %s"
+                  % (mark, o["rownum"], o["name"], o["email"], detail))
+        touched.append({"book": book, "ops": ops, "dv": dv})
+
+    if near_misses:
+        print("\nNear-miss chapter names (NOT written — fix the intake city or rename the folder):")
+        for m in near_misses:
+            print("  intake %r (%d people) ~ folder(s) %s"
+                  % (m["city"], len(m["people"]), ", ".join(map(repr, m["candidates"]))))
+    if orphans:
+        print("\nNo chapter folder (NOT written — run aaif-create-chapter for these cities):")
+        for o in sorted(orphans, key=lambda x: -len(x["people"])):
+            print("  %-28s %d person/people: %s"
+                  % (o["city"], len(o["people"]),
+                     ", ".join(p["name"] for p in o["people"][:4])
+                     + (", …" if len(o["people"]) > 4 else "")))
+    if keepers:
+        print("\nAlready in a CRM and NOT touched (real-looking address — clear by hand "
+              "if it's fixture data):")
+        for name, rows in keepers:
+            for r in rows:
+                print("  %-18s row %-4d %s <%s>" % (name, r["row"], r["name"], r["email"]))
+    if skipped:
+        # Recapped at the end, not just inline: in an 82-chapter run the inline
+        # line scrolls away, and a skipped chapter means people silently did not
+        # reach a CRM that the operator believes is now in sync.
+        print("\nChapters SKIPPED — nobody was synced to these, fix the workbook and re-run:")
+        for name, why in skipped:
+            print("  %-28s %s (%d person/people waiting)"
+                  % (name, why, len(by_folder.get(
+                      next((f["id"] for f in folders if f["name"] == name), ""), []))))
+    if no_dropdown:
+        print("\nNo Status dropdown to extend (people still sync; the column just "
+              "won't constrain typing):\n  %s" % ", ".join(no_dropdown))
+    if rejected and args.verbose:
+        print("\nIntake rows not synced:")
+        for r in rejected:
+            print("  %s row %d: %s — %s" % (r["tab"], r["row"], r["name"] or "(no name)", r["why"]))
+    elif rejected:
+        print("\n%d intake row(s) not synced (denied, or no email/city) — --verbose lists them."
+              % len(rejected))
+
+    if not touched:
+        print("\nNo changes needed — every chapter CRM is in sync with the intake.")
+        return 0
+    if not args.write:
+        print("\n%d workbook(s) would change. Re-run with --write to apply." % len(touched))
+        return 0
+
+    print("\nWriting %d workbook(s)..." % len(touched))
+    backup_dir = os.path.join(workdir, "before")
+    os.makedirs(backup_dir, exist_ok=True)
+    written, failed = [], []
+    for t in touched:
+        book = t["book"]
+        name = book.folder["name"]
+        try:
+            # Keep the pre-edit bytes before touching anything: an upload that
+            # lands a workbook Excel won't open is otherwise only recoverable by
+            # hand, through Drive's revision history.
+            with open(os.path.join(backup_dir, os.path.basename(book.path)), "wb") as fh:
+                fh.write(download(book.crm["id"], os.path.join(workdir, "reread.xlsx")))
+            upload(book.crm["id"], book.path, finalize(book, t["ops"]))
+            written.append(name)
+            print("  wrote %s (%s)" % (name, book.crm["name"]))
+        except Exception as e:                     # one bad workbook must not
+            failed.append((name, str(e)))          # abandon the other eighty
+            print("  FAILED %s — %s" % (name, e), file=sys.stderr)
+    print("Wrote %d workbook(s); pre-edit copies in %s" % (len(written), backup_dir))
+
+    print("\nRe-verifying...")
+    stale = []
+    for t in touched:
+        folder = t["book"].folder
+        if folder["name"] not in written:
+            continue
+        book, why = open_crm(folder, os.path.join(workdir, "verify"))
+        if book is None:
+            stale.append((folder["name"], "could not re-open: %s" % why))
+            continue
+        left = plan_workbook(book.att, by_folder.get(folder["id"], []), today)
+        if left:
+            stale.append((folder["name"], "%d op(s) still pending" % len(left)))
+        elif t["dv"] == "patched" and patch_status_dropdown(dict(book.parts), book.part) != "already":
+            stale.append((folder["name"], 'Status dropdown still lacks "Host"'))
+    if failed or stale:
+        print("VERIFY FAILED:")
+        for name, why in failed + stale:
+            print("  %s — %s" % (name, why))
+        return 1
+    print("Verified: a fresh read of every written workbook proposes zero changes.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Sync intake people + their survey interests into the chapter CRMs.")
+    ap.add_argument("--write", action="store_true",
+                    help="apply the proposed changes (default: report only)")
+    ap.add_argument("--city", help="limit to one chapter folder")
+    ap.add_argument("--verbose", action="store_true",
+                    help="list every intake row that was not synced")
+    sys.exit(run(ap.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -34,6 +34,7 @@ not touch is repacked byte-for-byte.
 Usage:
   python3 sync_crm.py                    # report + proposed changes, writes nothing
   python3 sync_crm.py --city Boston      # scope the report to one chapter
+  python3 sync_crm.py --verbose          # also list every intake row NOT synced
   python3 sync_crm.py --write            # apply, then re-read and verify
 """
 import argparse, datetime, io, json, os, re, sys, tempfile, zipfile
@@ -53,9 +54,11 @@ TEMPLATE_FOLDER = "TemplateCity"                        # cloned per city; never
 XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 CRM_SHEET = "Attendees"
-# The exact eleven, in order. A workbook whose header row disagrees is skipped
-# with a report line rather than written by column letter — the columns have been
-# renumbered once already (the Guide tab's live-list formula still references L).
+# The eleven the sheet must have. PRESENCE is checked, not order or position —
+# every access is by header name, and extra columns are tolerated. A workbook
+# missing any of them is skipped with a report line rather than written by column
+# letter: the columns were renumbered once already, and the Guide tab's live-list
+# formula still references L, so letter addressing must never come back.
 CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)",
                "Email", "LinkedIn URL", "Company", "Role / title",
                "Technical expertise", "What brings you here?")
@@ -64,9 +67,11 @@ CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)"
 # gets access to a chapter folder, so a person reaches it after a decision, not
 # on submitting the form: "New", "Tentative" and "Denied" are all held back.
 # Exact dropdown strings — "Existing" alone would miss every MLOps row.
-# Consequence, and it is intended: the Hosts and Speakers tabs have never been
-# triaged off "New", so today this syncs organizers only. Both start flowing the
-# moment someone accepts them; nothing here needs to change for that.
+# Consequence, and it is intended: as of 2026-08 the Hosts and Speakers tabs
+# had no accepted row, so in practice this synced organizers only. Both start
+# flowing the moment someone accepts them and nothing here needs to change —
+# do NOT read the organizers-only shape as permanent. The report's per-tab
+# counts are the live source of truth.
 SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
 
 ROLE_TABS = ("Organizers", "Speakers", "Hosts")   # also the merge priority order
@@ -79,11 +84,11 @@ CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
 # does not know; a later triage decision must not silently undo it.
 AUTO_STATUS = frozenset(("", "New", "Prospect", "Organizer", "Speaker", "Host"))
 
-# Keep the CRM minimal. Identity, decision and interest — nothing else. The
-# columns left out (LinkedIn URL, Company, Role / title, Technical expertise)
-# still exist on the sheet for an organizer to fill in by hand; the automation
-# just doesn't push a survey's worth of personal detail into a folder that is
-# still link-readable while chapters are being onboarded.
+# Keep the CRM minimal. Identity, decision and interest — nothing else. The five
+# columns left out (Signal, LinkedIn URL, Company, Role / title, Technical
+# expertise) still exist on the sheet for an organizer to fill in by hand; the
+# automation does not push a survey's worth of personal detail into a shared
+# folder. Enforced by Attendees.write(), not just by crm_fields()'s dict body.
 CRM_WRITTEN = ("Full name", "Trusted/Regular", "Status", "Notes (CRM)", "Email",
                "What brings you here?")
 
@@ -187,10 +192,26 @@ def join_distinct(values, sep=" · "):
 def register_namespaces(xml_bytes):
     """Keep the document's own xmlns prefixes on re-serialization. Without this
     ElementTree renames every namespaced attribute to ns0:/ns1: and Excel
-    rejects the file."""
+    rejects the file.
+
+    Two traps, both of which produced a corrupt-but-uploaded worksheet:
+
+    1. A document may bind a PREFIX to the spreadsheetml namespace as well as
+       the default. Registering that prefix displaces the default binding, and
+       the root then serializes as `<x:worksheet>` — which `serialize()`'s
+       `find(b"<worksheet")` misses entirely. The spreadsheetml URI therefore
+       keeps the empty prefix here, always.
+    2. `ET.register_namespace` is GLOBAL process state, so what is registered
+       last wins for the whole run. `run()` opens every workbook before it
+       serializes the first one, which means the map would reflect the LAST
+       workbook opened. Callers must re-register immediately before writing —
+       `Attendees.serialize()` does, from its own stored bytes.
+    """
     ET.register_namespace("", _XLNS)
     for m in _XMLNS_RE.finditer(xml_bytes):
         prefix, uri = m.group(1).decode(), m.group(2).decode()
+        if uri == _XLNS:
+            continue   # never let an alias displace the default binding
         try:
             ET.register_namespace(prefix, uri)
         except ValueError:
@@ -297,6 +318,14 @@ def set_cell(row_el, col, text, style=None):
     for child in list(target):
         target.remove(child)
     target.set("r", ref)
+    if not text:
+        # A truly blank cell, not an empty inline string. `<is><t/></is>` is a
+        # zero-length TEXT VALUE: ISBLANK reads FALSE and COUNTA counts it, so
+        # a cleared fixture row would still register as populated in the Guide
+        # tab's live-list formula. Keep the cell (and its style) but drop the
+        # type and the value.
+        target.attrib.pop("t", None)
+        return
     target.set("t", "inlineStr")
     is_el = ET.SubElement(target, X + "is")
     t_el = ET.SubElement(is_el, X + "t")
@@ -311,6 +340,10 @@ class Attendees:
         raw = parts[part_name]
         register_namespaces(raw)
         self.parts, self.part_name = parts, part_name
+        # Kept so serialize() can re-register this workbook's prefixes right
+        # before writing — the registry is global and every other workbook in
+        # the run has been opened in between.
+        self.raw = raw
         self.root = ET.fromstring(raw)
         self.sst = shared_strings(parts)
         self.data = self.root.find(X + "sheetData")
@@ -361,7 +394,17 @@ class Attendees:
         return out
 
     def occupied(self, rownum):
-        return bool(self.value(rownum, "Full name") or self.value(rownum, "Email"))
+        """True if ANY CRM column on the row holds something.
+
+        Not just name+email: the five columns this script never writes are also
+        never cleared, so a row whose name and email an operator deleted still
+        carries the departed person's LinkedIn, Company and expertise. Treating
+        it as free hands those fields to the next person written there — a real
+        current organizer showing a stranger's employer, in the workbook that
+        decides folder access. Nothing downstream can detect it, because the
+        verify only ever compares CRM_WRITTEN.
+        """
+        return any(self.value(rownum, h) for h in CRM_HEADERS)
 
     def free_rows(self, also_free=()):
         """Row numbers available for new people, lowest first, then rows past the
@@ -382,9 +425,13 @@ class Attendees:
             nxt += 1
 
     def clear(self, rownum):
-        """Blank every CRM column on a row, keeping the cells and their styles."""
+        """Blank every CRM column on a row, keeping the cells and their styles.
+
+        Goes through _write, not write: clearing legitimately touches all
+        eleven columns, including the five the automation may never author.
+        """
         for header in CRM_HEADERS:
-            self.write(rownum, header, "")
+            self._write(rownum, header, "")
 
     def row_for(self, rownum):
         row = self.rows.get(rownum)
@@ -403,6 +450,21 @@ class Attendees:
         return row
 
     def write(self, rownum, header, text):
+        """Write one CRM cell. Only CRM_WRITTEN columns may be written.
+
+        The "we never push survey detail into this folder" promise was upheld
+        only by the literal body of crm_fields() and guarded only by a test.
+        Enforcing it here means the privacy boundary cannot be crossed by a
+        future caller at all — use clear() for the blanking path, which is
+        allowed to touch every column.
+        """
+        if header not in CRM_WRITTEN:
+            raise ValueError(
+                "%r is not in CRM_WRITTEN — the automation must not write it. "
+                "Use clear() to blank a fixture row." % header)
+        self._write(rownum, header, text)
+
+    def _write(self, rownum, header, text):
         col = self.headers[header]
         set_cell(self.row_for(rownum), col, text, self.sample.get(col))
 
@@ -411,13 +473,31 @@ class Attendees:
         cover the rows we added. ET emits its own XML declaration with a
         different encoding spelling, so it is sliced off and replaced with the
         one Excel writes."""
+        # The namespace registry is global and every other workbook in the run
+        # has been opened since __init__ ran, so re-register from this
+        # workbook's own bytes before serializing.
+        register_namespaces(self.raw)
         dim = self.root.find(X + "dimension")
         if dim is not None and self.rows:
-            start = (dim.get("ref") or "A1").split(":")[0] or "A1"
-            dim.set("ref", "%s:%s" % (start, cell_ref(max(self.headers.values()),
-                                                      max(self.rows))))
+            ref = dim.get("ref") or "A1"
+            start = ref.split(":")[0] or "A1"
+            # Never NARROW the sheet: a workbook with columns past the last
+            # CRM header would have them fall outside the declared range.
+            end = ref.split(":")[-1] if ":" in ref else ""
+            width = max([max(self.headers.values())] + ([col_of(end)] if end else []))
+            dim.set("ref", "%s:%s" % (start, cell_ref(width, max(self.rows))))
         body = ET.tostring(self.root, encoding="UTF-8")
-        self.parts[self.part_name] = _XML_DECL + body[body.find(b"<worksheet"):]
+        at = body.find(b"<worksheet")
+        if at < 0:
+            # `find` returns -1 on a miss and body[-1:] is the LAST BYTE, which
+            # packs and uploads as a 57-byte "worksheet" without a murmur. Only
+            # reachable if the root serialized under a prefix, which
+            # register_namespaces now prevents — so this is the assertion that
+            # keeps it prevented.
+            raise ValueError(
+                "%s: serialized root is not <worksheet> (got %r) — refusing to write"
+                % (self.part_name, body[:80]))
+        self.parts[self.part_name] = _XML_DECL + body[at:]
 
 
 def patch_status_dropdown(parts, part_name):
@@ -453,7 +533,9 @@ def read_survey_interests():
 
     The role tabs are filtered views that drop the routing question, so the one
     column that is literally the person's stated interest has to come from
-    `Form Responses`. Joined on email; a repeat applicant's latest answer wins.
+    `Form Responses`. Joined on email; the LAST row for an address wins, which
+    is the latest answer only because the form appends chronologically — a
+    sorted or hand-reordered tab would silently change which answer is used.
     """
     rows = get_values(INTAKE_ID, "'Form Responses'!A:CO")
     if not rows:
@@ -472,23 +554,41 @@ def read_role_tab(tab, interests):
     """Return (people, rejected) for one role tab.
 
     people   = [{row, tab, name, email, city, status, ...}]
-    rejected = [{row, tab, name, why}]   no email / no city / denied — never written
+    rejected = [{row, tab, name, why}]   not accepted / no email / no city
     """
     rows = get_values(INTAKE_ID, "%s!A:BB" % tab)
     if not rows:
         sys.exit("ABORT: intake tab %r came back empty." % tab)
     headers = [h.strip() for h in rows[0]]
-    # Status and Email are load-bearing: without Status we cannot drop denied
-    # applicants, and without Email there is no dedupe key at all. Both are
-    # resolved up front so a header rename aborts instead of syncing everyone as
-    # a brand-new row on every run.
-    i_status, i_email = header_index(headers, tab, "Status", "Email")
-    i_chapter = headers.index("Chapter") if "Chapter" in headers else None
+    # Every column that decides WHO syncs and WHERE they land is load-bearing —
+    # resolved through header_index so a rename aborts loudly:
+    #   Status  — without it nothing can be filtered
+    #   Email   — the only dedupe key; without it everyone re-adds every run
+    #   Chapter — the human's assignment, which outranks the self-reported city
+    # A soft `.index(...) if in headers else None` on Chapter silently demoted
+    # every hand-corrected assignment to the submitted dropdown, writing people
+    # into the wrong chapter's CRM with no way to tell from the report.
+    i_status, i_email, i_chapter = header_index(headers, tab, "Status", "Email", "Chapter")
+    # These two are genuinely optional — the tabs carried the legacy
+    # City/Resolved City names before the rename, and either alone still
+    # resolves a city.
     i_g = headers.index("City (Existing)") if "City (Existing)" in headers else None
     i_h = headers.index("City (New)") if "City (New)" in headers else None
+    if i_g is None and i_h is None:
+        sys.exit("ABORT: tab %r has neither 'City (Existing)' nor 'City (New)' — "
+                 "every row would be rejected as having no city. Headers: %s"
+                 % (tab, headers))
     f = ROLE_FIELDS[tab]
+    # The name column is load-bearing too, but per-role: its absence would send
+    # every person through the `or email` fallback below, writing email
+    # addresses into `Full name` across dozens of workbooks — and since
+    # populated cells are never overwritten, the script could not repair it.
+    if not any(n in headers for n in f["name"]):
+        sys.exit("ABORT: tab %r has none of the name column(s) %s — every row "
+                 "would be named after its email address. Headers: %s"
+                 % (tab, list(f["name"]), headers))
 
-    people, rejected = [], []
+    people, rejected, fallbacks = [], [], []
     for rownum, row in enumerate(rows[1:], start=2):
         email = cell(row, i_email)
         name = first_of(row, headers, f["name"])
@@ -505,7 +605,7 @@ def read_role_tab(tab, interests):
             continue
         # Chapter assignment wins (a human made it); then the resolved city, then
         # the submitted dropdown unless it is an "Other…" placeholder.
-        chapter = cell(row, i_chapter) if i_chapter is not None else ""
+        chapter = cell(row, i_chapter)
         g = cell(row, i_g) if i_g is not None else ""
         h = cell(row, i_h) if i_h is not None else ""
         city = chapter or h or (g if g and not fold(g).startswith("other") else "")
@@ -514,7 +614,13 @@ def read_role_tab(tab, interests):
                              "why": "no chapter/city on the intake row"})
             continue
         detail = first_of(row, headers, f["detail"])
-        interest = interests.get(fold_email(email)) or DEFAULT_INTEREST[tab]
+        # A failed join is invisible once written: the generic branch text is
+        # indistinguishable from a real answer, and the cell is then non-empty
+        # so no later run corrects it. Count the fallbacks so run() can say so.
+        joined = interests.get(fold_email(email))
+        if not joined:
+            fallbacks.append(rownum)
+        interest = joined or DEFAULT_INTEREST[tab]
         people.append({
             "row": rownum, "tab": tab, "status": status,
             "name": clean_text(name) or clean_text(email),
@@ -525,7 +631,18 @@ def read_role_tab(tab, interests):
             "expertise": clean_text(first_of(row, headers, f["expertise"])),
             "interest": join_distinct([interest, detail]),
         })
-    return people, rejected
+    # Only when a join was actually attempted: sync_access calls this with an
+    # empty interests dict on purpose (it needs the roster, not the answers), and
+    # every row missing a match is the expected result there, not a broken join.
+    if interests and fallbacks and len(fallbacks) == len(people) and people:
+        # Every single person missing a Form Responses match is a broken join
+        # (a renamed email column, a diverged address set), not a data
+        # condition — and it would write boilerplate into every interest cell.
+        sys.exit("ABORT: none of the %d person/people on tab %r matched a "
+                 "'Form Responses' row by email, so every 'What brings you here?' "
+                 "would be generic branch text. Check the Email columns on both "
+                 "tabs." % (len(people), tab))
+    return people, rejected, fallbacks
 
 
 def merge_people(people):
@@ -542,7 +659,14 @@ def merge_people(people):
             key = (fold_city(p["city"]), fold_email(p["email"]))
             cur = merged.get(key)
             if cur is None:
-                merged[key] = dict(p, tabs=[tab], rows=[p["row"]])
+                m = dict(p, tabs=[tab], rows=[p["row"]])
+                # Drop the singular forms: on a merged person `tab`/`row` are
+                # an arbitrary member of `tabs`/`rows`, equal to the winning
+                # one only by the accident that the highest-priority tab seeds
+                # the entry. Removing them makes a stale read a KeyError
+                # instead of a plausible wrong answer.
+                m.pop("tab", None), m.pop("row", None)
+                merged[key] = m
                 continue
             cur["tabs"].append(tab)
             cur["rows"].append(p["row"])
@@ -618,8 +742,17 @@ def plan_workbook(att, people, today):
     """
     # Fixture rows go first so their row numbers are reusable below, and so a
     # dummy address can never be mistaken for an existing person to merge into.
+    #
+    # A row is only fixture data if NOBODY IN THE PLAN owns that address.
+    # `valid_email("sam@example.com")` is true, so an intake person really can
+    # have an example-domain address — and clearing their row while also
+    # re-adding them makes the plan non-empty forever. Under --write the
+    # re-verify then never converges and the chapter reports "ops still
+    # pending" permanently, indistinguishable from a real write failure.
+    owned = {fold_email(p["email"]) for p in people}
     clears = [r for r in sorted(att.rows)
-              if r > 1 and att.occupied(r) and is_dummy(att.value(r, "Email"))]
+              if r > 1 and att.occupied(r) and is_dummy(att.value(r, "Email"))
+              and fold_email(att.value(r, "Email")) not in owned]
     ops = [{"kind": "clear", "rownum": r, "email": att.value(r, "Email"),
             "name": att.value(r, "Full name"), "sets": {}} for r in clears]
 
@@ -659,12 +792,19 @@ def apply_ops(att, ops):
     # later in the same plan, so blanking after writing would wipe them out.
     for op in (o for o in ops if o["kind"] == "clear"):
         att.clear(op["rownum"])
-    for op in (o for o in ops if o["kind"] != "clear"):
+    # Match the write kinds explicitly rather than `!= "clear"`. The negative
+    # form treats any future kind as a write — the fail-open direction, on the
+    # one path that touches the workbook, while the report (which indexes a
+    # dict of the three known marks) would crash or undercount.
+    unknown = [o["kind"] for o in ops if o["kind"] not in ("clear", "add", "fill")]
+    if unknown:
+        raise ValueError("unknown op kind(s) %s — refusing to write" % sorted(set(unknown)))
+    for op in (o for o in ops if o["kind"] in ("add", "fill")):
         for header, value in op["sets"].items():
             att.write(op["rownum"], header, value)
 
 
-def finalize(book, ops):
+def finalize(book, ops, expected_dv=None):
     """Produce the workbook's new bytes: rows first, then serialize, then the
     dropdown patch — in that order, and only in that order.
 
@@ -675,9 +815,22 @@ def finalize(book, ops):
     caught. Keeping both steps in one function is what stops the order drifting
     apart again.
     """
+    # finalize serializes through `att` but saves `book.parts` — they must be
+    # the same dict, or the returned zip silently loses either the row writes or
+    # the dropdown patch. open_crm builds them that way; assert it rather than
+    # trusting every future caller to.
+    if book.parts is not book.att.parts or book.part != book.att.part_name:
+        raise ValueError("Book.parts/part must be the same objects Attendees holds")
     apply_ops(book.att, ops)
     book.att.serialize()
-    patch_status_dropdown(book.parts, book.part)
+    got = patch_status_dropdown(book.parts, book.part)
+    if expected_dv is not None and got != expected_dv:
+        # The prediction was made against the downloaded bytes; the real patch
+        # runs against ElementTree's re-encoding of them. They agree today
+        # because both quote spellings are handled — this is what catches the
+        # day they stop agreeing, rather than reporting a patch never applied.
+        raise ValueError("dropdown patch predicted %r but returned %r for %s"
+                         % (expected_dv, got, book.crm["name"]))
     return save_parts(book.names, book.parts)
 
 
@@ -779,14 +932,20 @@ def open_crm(folder, workdir):
     if crm is None:
         return None, why
     path = os.path.join(workdir, "%s.xlsx" % re.sub(r"[^\w.-]", "_", folder["name"]))
-    names, parts = load_parts(download(crm["id"], path))
-    part = sheet_part(parts, CRM_SHEET)
-    if part is None:
-        return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
+    # Everything from the download onward is guarded, not just Attendees(): a
+    # truncated download raises zipfile.BadZipFile, a missing rels part raises
+    # KeyError, and ET.ParseError is a SyntaxError — NOT a ValueError. Catching
+    # only ValueError let any of those abort the whole run, and in the verify
+    # loop that happens AFTER uploads have landed, replacing the summary with a
+    # bare traceback that names neither the chapter nor what was written.
     try:
+        names, parts = load_parts(download(crm["id"], path))
+        part = sheet_part(parts, CRM_SHEET)
+        if part is None:
+            return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
         att = Attendees(parts, part)
-    except ValueError as e:
-        return None, "%s: %s" % (crm["name"], e)
+    except Exception as e:
+        return None, "%s: %s: %s" % (crm["name"], type(e).__name__, e)
     return Book(folder, crm, names, parts, part, att, path), None
 
 
@@ -794,13 +953,14 @@ def run(args):
     today = datetime.date.today().isoformat()
     interests = read_survey_interests()
 
-    people, rejected = [], []
+    people, rejected, fallbacks = [], [], []
     counts = {}
     for tab in ROLE_TABS:
-        pp, rr = read_role_tab(tab, interests)
+        pp, rr, fb = read_role_tab(tab, interests)
         counts[tab] = len(pp)
         people += pp
         rejected += rr
+        fallbacks += fb
     merged = merge_people(people)
 
     # People are matched against EVERY chapter folder, then --city narrows only
@@ -840,7 +1000,7 @@ def run(args):
         grp = by_folder.get(folder["id"], [])
         # Always planned, even for a chapter that gains nobody: every workbook
         # carries the template's fixture row, and only 57 of the 82 chapters have
-        # people. `if grp else []` left Sam Taylor sitting in the other 25.
+        # people. `if grp else []` left the sample row sitting in all the rest.
         ops = plan_workbook(book.att, grp, today)
         kept = preexisting(book.att, ops, grp)
         if kept:
@@ -888,7 +1048,7 @@ def run(args):
             for r in rows:
                 print("  %-18s row %-4d %s <%s>" % (name, r["row"], r["name"], r["email"]))
     if skipped:
-        # Recapped at the end, not just inline: in an 82-chapter run the inline
+        # Recapped at the end, not just inline: across every chapter the inline
         # line scrolls away, and a skipped chapter means people silently did not
         # reach a CRM that the operator believes is now in sync.
         print("\nChapters SKIPPED — nobody was synced to these, fix the workbook and re-run:")
@@ -896,6 +1056,12 @@ def run(args):
             print("  %-28s %s (%d person/people waiting)"
                   % (name, why, len(by_folder.get(
                       next((f["id"] for f in folders if f["name"] == name), ""), []))))
+    if fallbacks:
+        # Silent once written: the branch text is indistinguishable from a real
+        # answer and the cell is never corrected on a later run.
+        print("\n%d person/people had no 'Form Responses' match, so their "
+              "'What brings you here?' is the generic branch text for their role."
+              % len(fallbacks))
     if no_dropdown:
         print("\nNo Status dropdown to extend (people still sync; the column just "
               "won't constrain typing):\n  %s" % ", ".join(no_dropdown))
@@ -904,10 +1070,17 @@ def run(args):
         for r in rejected:
             print("  %s row %d: %s — %s" % (r["tab"], r["row"], r["name"] or "(no name)", r["why"]))
     elif rejected:
-        print("\n%d intake row(s) not synced (denied, or no email/city) — --verbose lists them."
-              % len(rejected))
+        print("\n%d intake row(s) not synced (not yet accepted, or no email/city) "
+              "— --verbose lists them." % len(rejected))
 
     if not touched:
+        # Never claim a clean sweep over chapters that were never opened: a
+        # skipped workbook means people silently did not reach a CRM the
+        # operator now believes is in sync.
+        if skipped:
+            print("\nNo changes needed for the chapters that could be opened — but "
+                  "%d was/were SKIPPED above and are NOT in sync." % len(skipped))
+            return 1
         print("\nNo changes needed — every chapter CRM is in sync with the intake.")
         return 0
     if not args.write:
@@ -927,7 +1100,7 @@ def run(args):
             # hand, through Drive's revision history.
             with open(os.path.join(backup_dir, os.path.basename(book.path)), "wb") as fh:
                 fh.write(download(book.crm["id"], os.path.join(workdir, "reread.xlsx")))
-            upload(book.crm["id"], book.path, finalize(book, t["ops"]))
+            upload(book.crm["id"], book.path, finalize(book, t["ops"], t["dv"]))
             written.append(name)
             print("  wrote %s (%s)" % (name, book.crm["name"]))
         except Exception as e:                     # one bad workbook must not

--- a/skills/aaif-sync-chapters/scripts/test_sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_access.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure/mockable logic in sync_access.py (no network/gws).
+
+This engine grants standing write access to real people and de-publicises a
+folder, so the parts that decide WHO gets access are exercised here rather than
+only in production. Drive itself is mocked the same way test_sync_chapters.py
+mocks the Sheets reads — `mock.patch.object(module, "helper", ...)`.
+"""
+import os, sys
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sync_access
+from sync_access import ACCESS_TABS, banner_ids, canon_email
+
+fails = 0
+def check(label, got, want):
+    global fails
+    ok = got == want
+    fails += 0 if ok else 1
+    print("%s %s" % ("ok  " if ok else "FAIL", label))
+    if not ok:
+        print("      got : %r\n      want: %r" % (got, want))
+
+
+def aborts(fn):
+    """True if fn() calls sys.exit — the script's only refusal mechanism."""
+    try:
+        fn()
+    except SystemExit:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# ACCESS_TABS — the organizers-only rule, as a standing regression guard
+# ---------------------------------------------------------------------------
+# The comment above ACCESS_TABS records a privilege escalation that already
+# shipped once: looping all three role tabs gave accepted speakers and hosts the
+# same writer role as organizers. It is invisible in production while neither
+# tab has an accepted row, so only an assertion keeps it from coming back.
+check("folder access is organizers-only", ACCESS_TABS, ("Organizers",))
+check("speakers and hosts are not access tabs",
+      [t for t in ("Speakers", "Hosts") if t in ACCESS_TABS], [])
+
+# sync_access reads the roster with an EMPTY interests dict — it needs who was
+# accepted, not what they answered. sync_crm's "the Form Responses join is
+# broken" guard must not fire for that caller, where zero matches is expected.
+import sync_crm  # noqa: E402  (imported here, beside the behaviour it guards)
+
+ORG_MIN = [["Status", "Full name", "Email", "Chapter", "City (Existing)"],
+           ["Accepted", "Ada", "ada@x.io", "Boston", "Boston"]]
+with mock.patch.object(sync_crm, "get_values", return_value=ORG_MIN):
+    pp, _, fb = sync_crm.read_role_tab("Organizers", {})
+check("an empty interests dict does not trip the broken-join guard",
+      (len(pp), len(fb)), (1, 1))
+with mock.patch.object(sync_crm, "get_values", return_value=ORG_MIN):
+    check("a populated interests dict that matches nothing DOES abort",
+          aborts(lambda: sync_crm.read_role_tab("Organizers", {"someone@else.io": "x"})),
+          True)
+
+
+# ---------------------------------------------------------------------------
+# canon_email — match addresses the way Drive stores them
+# ---------------------------------------------------------------------------
+check("gmail dots are folded",
+      canon_email("aman.singh.original@gmail.com"), "amansinghoriginal@gmail.com")
+check("case is folded", canon_email("Zoheb.Shaik7@GMAIL.com"), "zohebshaik7@gmail.com")
+check("googlemail is the same mailbox as gmail",
+      canon_email("a.b@googlemail.com"), canon_email("ab@gmail.com"))
+check("gmail +tags are ignored", canon_email("jane+aaif@gmail.com"), "jane@gmail.com")
+check("dots are significant off gmail", canon_email("a.b@example.co"), "a.b@example.co")
+check("+tags are kept off gmail",
+      canon_email("a+tag@fastmail.com"), "a+tag@fastmail.com")
+check("blank stays blank", canon_email(""), "")
+
+
+# ---------------------------------------------------------------------------
+# banner_ids — city key and URL parsing
+# ---------------------------------------------------------------------------
+FEED_HEADERS = ["Title", "City", "Country", "Generated Geolocation", "Summary",
+                "Image", "CTA", "URL for CTA", "Organizers", "Chapter Luma Link",
+                "MLOps Community Organizers"]
+ID_A, ID_B = "1usAa88CR88_XUlMp35tFoF2OIv1mf3IO", "1Q-OzWVYW1lzjI_Hlu6QvY8bNBZYXlodH"
+
+
+def feed_row(city, image):
+    row = [""] * len(FEED_HEADERS)
+    row[FEED_HEADERS.index("City")] = city
+    row[FEED_HEADERS.index("Image")] = image
+    return row
+
+
+def banners_over(rows):
+    with mock.patch.object(sync_access, "get_values", return_value=rows):
+        return banner_ids()
+
+
+got = banners_over([FEED_HEADERS,
+                    feed_row("Washington, DC", "https://lh3.googleusercontent.com/d/" + ID_A),
+                    feed_row("Montréal", "https://drive.google.com/uc?id=" + ID_B),
+                    feed_row("Nowhere", "not a drive url"),
+                    feed_row("", "https://lh3.googleusercontent.com/d/" + ID_A)])
+# fold_city, not fold: plain fold leaves punctuation intact, so the feed's
+# 'Washington, DC' missed the 'Washington DC' folder and the chapter was
+# reported as having no image at all — then never pinned, then locked.
+check("city key is punctuation-folded", "washington dc" in got, True)
+check("city key is accent-folded", "montreal" in got, True)
+check("the /d/<id> form parses", got["washington dc"]["file_id"], ID_A)
+check("the ?id=<id> form parses", got["montreal"]["file_id"], ID_B)
+check("an unrecognised URL yields no id, not a bogus one",
+      got["nowhere"]["file_id"], "")
+check("a row with no city is skipped", len(got), 3)
+check("the original city spelling is preserved for the report",
+      got["washington dc"]["city"], "Washington, DC")
+
+check("a missing Image column aborts rather than planning a lock",
+      aborts(lambda: banners_over([[h for h in FEED_HEADERS if h != "Image"]])), True)
+check("an empty feed aborts", aborts(lambda: banners_over([])), True)
+
+# A trailing-fragment URL must not produce a truncated-but-plausible id.
+frag = banners_over([FEED_HEADERS,
+                     feed_row("Boston", "https://lh3.googleusercontent.com/d/%s#gid=1" % ID_A)])
+check("a URL fragment does not corrupt the id", frag["boston"]["file_id"], ID_A)
+
+
+# ---------------------------------------------------------------------------
+# assert_all_accepted — the last gate before standing write access
+# ---------------------------------------------------------------------------
+ORG_HEADERS = ["Status", "Full name", "Timestamp", "Name", "Email", "Phone",
+               "LinkedIn", "City (Existing)", "City (New)", "Chapter"]
+
+
+def org_row(status, email, chapter, city=""):
+    row = [""] * len(ORG_HEADERS)
+    row[0] = status
+    row[ORG_HEADERS.index("Email")] = email
+    row[ORG_HEADERS.index("Chapter")] = chapter
+    row[ORG_HEADERS.index("City (Existing)")] = city
+    return row
+
+
+def grant(email, chapter):
+    return {"chapter": chapter, "folder_id": "f1", "email": email,
+            "name": "X", "role": "writer"}
+
+
+def gate(rows, grants):
+    with mock.patch.object(sync_access, "get_values", return_value=rows):
+        return aborts(lambda: sync_access.assert_all_accepted(grants))
+
+
+TAB = [ORG_HEADERS,
+       org_row("Accepted", "ada@x.io", "Boston"),
+       org_row("Existing (from MLOps)", "bo@x.io", "Berlin"),
+       org_row("New", "cy@x.io", "Boston"),
+       org_row("Denied", "dee@x.io", "Boston")]
+
+check("an accepted organizer for that chapter passes",
+      gate(TAB, [grant("ada@x.io", "Boston")]), False)
+check("Existing (from MLOps) counts as accepted",
+      gate(TAB, [grant("bo@x.io", "Berlin")]), False)
+check("a New organizer is refused", gate(TAB, [grant("cy@x.io", "Boston")]), True)
+check("a Denied organizer is refused", gate(TAB, [grant("dee@x.io", "Boston")]), True)
+check("an address with no intake row is refused",
+      gate(TAB, [grant("nobody@x.io", "Boston")]), True)
+# The gate must bind person AND chapter: without this, an accepted organizer for
+# one city satisfies a grant on any other, so a chapter mis-binding upstream
+# (e.g. a folder renamed to collide) sails straight through the last check.
+check("an accepted organizer for a DIFFERENT chapter is refused",
+      gate(TAB, [grant("ada@x.io", "Berlin")]), True)
+check("the chapter match is punctuation/accent folded",
+      gate([ORG_HEADERS, org_row("Accepted", "ada@x.io", "Washington, DC")],
+           [grant("ada@x.io", "Washington DC")]), False)
+check("gmail dot spellings still match",
+      gate([ORG_HEADERS, org_row("Accepted", "a.b@gmail.com", "Boston")],
+           [grant("ab@gmail.com", "Boston")]), False)
+check("one bad grant in a batch refuses the whole batch",
+      gate(TAB, [grant("ada@x.io", "Boston"), grant("cy@x.io", "Boston")]), True)
+check("a missing Status/Email/Chapter header aborts",
+      gate([[h for h in ORG_HEADERS if h != "Chapter"]], [grant("ada@x.io", "Boston")]), True)
+
+
+# ---------------------------------------------------------------------------
+# apply_grants — the four failure branches
+# ---------------------------------------------------------------------------
+def run_grants(side_effects, notify=False, allow_mail=False):
+    """Drive apply_grants over a scripted sequence of gws outcomes."""
+    calls = []
+
+    def fake(*args, **kw):
+        calls.append(kw.get("params", {}).get("sendNotificationEmail"))
+        out = side_effects[len(calls) - 1]
+        if isinstance(out, Exception):
+            raise out
+        return out
+
+    plan = {"grants": [grant("ada@x.io", "Boston")]}
+    with mock.patch.object(sync_access, "gws_json", side_effect=fake), \
+         mock.patch.object(sync_access, "assert_all_accepted", lambda g: None):
+        applied, failed = sync_access.apply_grants(plan, notify, allow_mail)
+    return applied, failed, calls
+
+
+NO_ACCT = RuntimeError('Bad Request. User message: "You are trying to invite x. '
+                       'Since there is no Google account associated with this address"')
+TYPO = RuntimeError('Bad Request. User message: "There\'s a problem with this email or domain."')
+
+applied, failed, calls = run_grants([{}])
+check("a normal grant applies", (applied, len(failed)), (1, 0))
+check("notifications are off by default", calls, [False])
+
+applied, failed, calls = run_grants([{}], notify=True)
+check("--notify emails every grantee", calls, [True])
+
+# Drive refuses a no-Google-account address unless it may email them. Mailing
+# real people must never be a silent side effect of a sync.
+applied, failed, calls = run_grants([NO_ACCT])
+check("no-account without permission is skipped, not mailed", (applied, len(failed)), (0, 1))
+check("no mail was sent", calls, [False])
+check("the skip explains itself", "no Google account" in failed[0][3], True)
+
+applied, failed, calls = run_grants([NO_ACCT, {}], allow_mail=True)
+check("--mail-if-required retries with a notification",
+      (applied, len(failed), calls), (1, 0, [False, True]))
+
+applied, failed, _ = run_grants([TYPO])
+check("a typo'd address fails without retrying", (applied, len(failed)), (0, 1))
+check("the typo hint points at the intake row",
+      "typo" in failed[0][3], True)
+
+# One bad row must not abandon the rest — the shipped incident this guards.
+def run_many(effects):
+    plan = {"grants": [grant("a@x.io", "Boston"), grant("b@x.io", "Berlin"),
+                       grant("c@x.io", "Pune")]}
+    seq = list(effects)
+
+    def fake(*args, **kw):
+        out = seq.pop(0)
+        if isinstance(out, Exception):
+            raise out
+        return out
+
+    with mock.patch.object(sync_access, "gws_json", side_effect=fake), \
+         mock.patch.object(sync_access, "assert_all_accepted", lambda g: None):
+        return sync_access.apply_grants(plan, False, False)
+
+
+applied, failed = run_many([TYPO, {}, {}])
+check("a failure mid-batch does not abandon the remaining grants",
+      (applied, len(failed)), (2, 1))
+
+
+print()
+print("FAILED %d check(s)" % fails if fails else "All checks passed.")
+sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure logic in sync_crm.py (no network/gws).
+
+The .xlsx fixtures are built here rather than checked in as binaries, from the
+same shape the real chapter CRMs have — inline strings, a styled sample row 2,
+pre-created empty rows, and the Status data-validation list. A checked-in binary
+would silently stop resembling the live workbooks; this can't.
+"""
+import os, sys
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sync_crm
+from sync_crm import (Attendees, CRM_HEADERS, DV_STATUS_NEW, DV_STATUS_OLD, X,
+                      apply_ops, cell_ref, clean_text, col_of, crm_fields,
+                      fold_email, join_distinct, load_parts, match_chapters,
+                      merge_people, patch_status_dropdown, plan_workbook,
+                      save_parts, sheet_part, valid_email)
+
+TODAY = "2026-08-06"
+
+fails = 0
+def check(label, got, want):
+    global fails
+    ok = got == want
+    fails += 0 if ok else 1
+    print("%s %s" % ("ok  " if ok else "FAIL", label))
+    if not ok:
+        print("      got : %r\n      want: %r" % (got, want))
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a workbook shaped like a real chapter CRM
+# ---------------------------------------------------------------------------
+def _c(ref, text, style=None):
+    s = ' s="%s"' % style if style else ""
+    if text is None:
+        return '<c r="%s"%s t="n" />' % (ref, s)
+    return ('<c r="%s"%s t="inlineStr"><is><t>%s</t></is></c>' % (ref, s, text))
+
+
+def make_xlsx(sample_row=None, blank_rows=8, headers=CRM_HEADERS,
+              shared=False, dv=DV_STATUS_OLD):
+    """A two-sheet workbook whose 'Attendees' tab mirrors the shipped template."""
+    head = "".join(_c(cell_ref(i, 1), h, "2") for i, h in enumerate(headers))
+    rows = ['<row r="1" ht="30" customHeight="1" s="20">%s</row>' % head]
+    if sample_row:
+        cells = "".join(_c(cell_ref(i, 2), v, "4" if i == 4 else "3")
+                        for i, v in enumerate(sample_row) if v)
+        rows.append('<row r="2">%s</row>' % cells)
+    # Rows 3.. ship with only the three dropdown columns materialised.
+    for r in range(3, 3 + blank_rows):
+        rows.append('<row r="%d">%s</row>'
+                    % (r, "".join(_c(cell_ref(i, r), None, "5") for i in (1, 2, 3))))
+    sheet = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        '<dimension ref="A1:K%d" /><sheetData>%s</sheetData>'
+        '<dataValidations count="1"><dataValidation sqref="D2:D1000" type="list">'
+        '<formula1>"%s"</formula1></dataValidation></dataValidations>'
+        '</worksheet>' % (2 + blank_rows, "".join(rows), dv))
+    parts = {
+        "[Content_Types].xml": "<Types />",
+        "_rels/.rels": "<Relationships />",
+        "xl/workbook.xml":
+            '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+            ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+            '<sheets><sheet name="Guide" sheetId="2" r:id="rId9" />'
+            '<sheet name="Attendees" sheetId="1" r:id="rId7" /></sheets></workbook>',
+        "xl/_rels/workbook.xml.rels":
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            '<Relationship Id="rId9" Target="worksheets/sheet2.xml" />'
+            '<Relationship Id="rId7" Target="worksheets/sheet1.xml" /></Relationships>',
+        "xl/worksheets/sheet1.xml": sheet,
+        "xl/worksheets/sheet2.xml": "<worksheet />",
+    }
+    if shared:
+        parts["xl/sharedStrings.xml"] = (
+            '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            + "".join("<si><t>%s</t></si>" % h for h in headers) + "</sst>")
+        # Same header row, stored as shared-string indices — the legacy variant.
+        idx = "".join('<c r="%s" s="2" t="s"><v>%d</v></c>' % (cell_ref(i, 1), i)
+                      for i in range(len(headers)))
+        parts["xl/worksheets/sheet1.xml"] = sheet.replace(head, idx)
+    names = list(parts)
+    return names, {n: v.encode() for n, v in parts.items()}
+
+
+# The fixture row a human is presumed to have typed — a REAL-looking address, so
+# it must survive every run untouched. Kept distinct from DUMMY below: making the
+# general-purpose sample an @example.com address would mean the "never clobber a
+# human" tests were quietly running against a row the cleaner deletes.
+SAMPLE = ["Ravi Menon", "High", "Yes", "Regular",
+          "Brought three friends to the Feb event.", "ravi@vendor.co", "", "Vendor Inc.",
+          "Sales", "—", "Community regular"]
+
+# The template's shipped fixture row, which every chapter CRM carries.
+DUMMY = ["Sam Taylor", "Non-grata", "No", "Declined",
+         "Pitched from the floor. Do not invite.", "sam@example.com", "", "Vendor Inc.",
+         "Sales", "—", "Wanted to pitch"]
+
+
+def book(**kw):
+    names, parts = make_xlsx(**kw)
+    return names, parts, Attendees(parts, sheet_part(parts, "Attendees"))
+
+
+def person(name, email, city, tab="Organizers", status="Accepted", **kw):
+    base = {"row": 7, "tab": tab, "status": status, "name": name, "email": email,
+            "city": city, "linkedin": "", "company": "", "title": "",
+            "expertise": "", "interest": "I want to be an organizer/volunteer"}
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Text + key helpers
+# ---------------------------------------------------------------------------
+check("clean_text collapses newlines", clean_text("a\r\nb\tc"), "a b c")
+check("clean_text strips control chars", clean_text("a\x00\x07b"), "ab")
+check("clean_text caps length", len(clean_text("x" * 5000)), sync_crm.MAX_CELL_TEXT)
+check("fold_email is case-insensitive", fold_email(" A@B.io "), fold_email("a@b.IO"))
+check("fold_email keeps dots/plus", fold_email("a.b+x@c.io"), "a.b+x@c.io")
+check("valid_email accepts", valid_email("a.b+x@c.co.uk"), True)
+check("valid_email rejects blank", valid_email(""), False)
+check("valid_email rejects no-tld", valid_email("a@b"), False)
+check("valid_email rejects free text", valid_email("ask me on LinkedIn"), False)
+check("join_distinct dedupes case-insensitively",
+      join_distinct(["Agents", "agents", "MCP", ""]), "Agents · MCP")
+check("col_of round-trips", [col_of(cell_ref(i, 3)) for i in (0, 10, 26, 701)],
+      [0, 10, 26, 701])
+
+
+# ---------------------------------------------------------------------------
+# merge_people: one row per person per chapter
+# ---------------------------------------------------------------------------
+both = merge_people([
+    person("Ada L", "ada@x.io", "Boston", "Speakers", "New", interest="I want to be a speaker",
+           title="Staff Eng", expertise="Agents"),
+    person("Ada Lovelace", "ADA@x.io", "boston", "Organizers", "Accepted",
+           interest="I want to be an organizer/volunteer", expertise="Agents"),
+])
+check("merge collapses one person to one row", len(both), 1)
+check("merge takes the highest-priority role first", both[0]["tabs"], ["Organizers", "Speakers"])
+check("merge keeps the acceptance", both[0]["status"], "Accepted")
+check("merge keeps the speaker's title", both[0]["title"], "Staff Eng")
+check("merge unions the interests", both[0]["interest"],
+      "I want to be an organizer/volunteer · I want to be a speaker")
+check("merge dedupes identical expertise", both[0]["expertise"], "Agents")
+check("merge keeps different cities apart",
+      len(merge_people([person("A", "a@x.io", "Boston"), person("A", "a@x.io", "Berlin")])), 2)
+
+f_acc = crm_fields(both[0], TODAY)
+check("accepted organizer -> Organizer", f_acc["Status"], "Organizer")
+check("accepted organizer -> Trusted", f_acc["Trusted/Regular"], "Yes")
+check("note carries role, status and date",
+      f_acc["Notes (CRM)"], "Intake: Organizer/Speaker · Accepted · 2026-08-06")
+
+f_host = crm_fields(merge_people([person("Bo", "bo@x.io", "B", "Hosts", "Accepted")])[0], TODAY)
+check("accepted host -> Host", f_host["Status"], "Host")
+check("accepted host is not auto-Trusted", f_host["Trusted/Regular"], "")
+
+# Minimal by construction: the automation must not touch Signal or any of the
+# detail columns, so they are absent from the mapping rather than written blank.
+check("only the minimal columns are produced",
+      sorted(f_acc), sorted(sync_crm.CRM_WRITTEN))
+for col in ("Signal", "LinkedIn URL", "Company", "Role / title", "Technical expertise"):
+    check("%r is never written" % col, col in f_acc, False)
+
+
+# ---------------------------------------------------------------------------
+# Attendees: parsing both storage forms
+# ---------------------------------------------------------------------------
+_, _, att = book(sample_row=SAMPLE)
+check("headers resolve by name", att.headers["What brings you here?"], 10)
+check("reads an inline string", att.value(2, "Email"), "ravi@vendor.co")
+check("indexes existing people by email", att.index_by_email(), {"ravi@vendor.co": 2})
+check("row 2 styles are captured for new rows", att.sample[4], "4")
+check("first free row is 3", next(att.free_rows()), 3)
+check("a cleared row becomes free again", next(att.free_rows(also_free={2})), 2)
+
+_, _, shared_att = book(sample_row=None, shared=True)
+check("reads the legacy shared-string header row",
+      sorted(shared_att.headers) == sorted(CRM_HEADERS), True)
+
+try:
+    book(headers=[h for h in CRM_HEADERS if h != "Email"])
+    check("aborts on a missing column", "no error", "ValueError")
+except ValueError as e:
+    check("aborts on a missing column", "Email" in str(e), True)
+
+
+# ---------------------------------------------------------------------------
+# plan_workbook: append, fill blanks, never clobber
+# ---------------------------------------------------------------------------
+names, parts, att = book(sample_row=SAMPLE)
+people = merge_people([person("Ada", "ada@x.io", "Boston", "Organizers", "Accepted",
+                              linkedin="https://li/ada", expertise="Agents, MCP")])
+ops = plan_workbook(att, people, TODAY)
+check("a new person is one op", len(ops), 1)
+check("new person lands on the first free row", ops[0]["rownum"], 3)
+check("new person is flagged as an add", ops[0]["kind"], "add")
+check("interest comes from the survey",
+      ops[0]["sets"]["What brings you here?"], "I want to be an organizer/volunteer")
+check("the survey's detail columns are not written",
+      [c for c in ("Technical expertise", "LinkedIn URL", "Company") if c in ops[0]["sets"]], [])
+
+apply_ops(att, ops)
+check("write landed in the sheet", att.value(3, "Email"), "ada@x.io")
+check("write reused the row-2 column style",
+      att.rows[3].findall(X + "c")[0].get("s"), "3")
+check("existing dropdown cells keep their own style",
+      [c.get("s") for c in att.rows[3].findall(X + "c") if col_of(c.get("r")) == 1], ["5"])
+check("re-planning the same people is a no-op", plan_workbook(att, people, TODAY), [])
+
+# Two new people must not be planned into the same row.
+_, _, att2 = book(sample_row=SAMPLE)
+two = plan_workbook(att2, merge_people([person("A", "a@x.io", "B"),
+                                        person("C", "c@x.io", "B")]), TODAY)
+check("two new people get two rows",
+      sorted(o["rownum"] for o in two if o["kind"] == "add"), [3, 4])
+
+# A human's edits survive; only genuinely blank cells are filled.
+_, _, att3 = book(sample_row=SAMPLE)
+att3.write(3, "Email", "ada@x.io")
+att3.write(3, "Full name", "Ada (call her Addy)")
+att3.write(3, "Notes (CRM)", "Met at the Feb event; will co-host.")
+ops3 = plan_workbook(att3, people, TODAY)
+check("existing person is an update, not an append", ops3[0]["kind"], "fill")
+check("the human's name spelling is kept", "Full name" in ops3[0]["sets"], False)
+check("the human's note is kept", "Notes (CRM)" in ops3[0]["sets"], False)
+check("blank cells are still filled", ops3[0]["sets"]["What brings you here?"],
+      "I want to be an organizer/volunteer")
+
+
+# ---------------------------------------------------------------------------
+# Clearing fixture rows — ONLY the reserved example domains
+# ---------------------------------------------------------------------------
+check("is_dummy catches the shipped sample", sync_crm.is_dummy("sam@example.com"), True)
+check("is_dummy is case-insensitive", sync_crm.is_dummy("Sam@Example.COM"), True)
+# The suffix match is anchored on "@" so look-alike domains are never caught.
+for real in ("ravi@vendor.co", "rahul@aihero.studio", "a@examples.com",
+             "a@notexample.com", "x@example.company", ""):
+    check("is_dummy leaves %r alone" % real, sync_crm.is_dummy(real), False)
+
+_, _, attd = book(sample_row=DUMMY)
+clr = plan_workbook(attd, [], TODAY)
+check("a chapter with no people still clears its dummy row",
+      [(o["kind"], o["rownum"], o["name"]) for o in clr], [("clear", 2, "Sam Taylor")])
+apply_ops(attd, clr)
+check("the dummy row is blank afterwards",
+      [attd.value(2, h) for h in CRM_HEADERS], [""] * len(CRM_HEADERS))
+check("clearing is idempotent", plan_workbook(attd, [], TODAY), [])
+
+# The freed row is reused, so a chapter's first real organizer lands at the top.
+_, _, attr = book(sample_row=DUMMY)
+mixed = plan_workbook(attr, people, TODAY)
+check("clear is planned before the add", [o["kind"] for o in mixed], ["clear", "add"])
+check("the real person reuses the dummy's row", mixed[1]["rownum"], 2)
+apply_ops(attr, mixed)
+check("the reused row holds the real person", attr.value(2, "Email"), "ada@x.io")
+check("no stale dummy text survives the reuse", attr.value(2, "Notes (CRM)"),
+      "Intake: Organizer · Accepted · 2026-08-06")
+check("a wiped-then-reused row keeps nothing from the dummy",
+      attr.value(2, "Full name"), "Ada")
+
+# A real-looking row is never cleared, and is reported instead.
+_, _, attk = book(sample_row=SAMPLE)
+check("a real-looking row is not cleared",
+      [o for o in plan_workbook(attk, [], TODAY) if o["kind"] == "clear"], [])
+check("a real-looking row is reported as pre-existing",
+      sync_crm.preexisting(attk, []), [{"row": 2, "name": "Ravi Menon",
+                                        "email": "ravi@vendor.co"}])
+check("a row this run touches is not reported as pre-existing",
+      sync_crm.preexisting(attk, [{"rownum": 2}]), [])
+# On a settled CRM there are no ops, so without the `people` filter every row the
+# sync itself wrote would be reported back as an unrecognised address to review.
+_, _, atts = book(sample_row=SAMPLE)
+atts.write(3, "Email", "ada@x.io")
+atts.write(3, "Full name", "Ada")
+check("a person the intake expects is not flagged as unrecognised",
+      sync_crm.preexisting(atts, [], people), [{"row": 2, "name": "Ravi Menon",
+                                                "email": "ravi@vendor.co"}])
+check("the expected-person filter is email-based, not row-based",
+      [r["row"] for r in sync_crm.preexisting(atts, [], [])], [2, 3])
+
+# Status: upgrade what the automation wrote, never what a human wrote.
+for before, want in (("", "Organizer"), ("New", "Organizer"), ("Prospect", "Organizer"),
+                     ("Attended", None), ("Declined", None), ("Regular", None),
+                     ("Volunteer", None)):
+    _, _, a = book(sample_row=SAMPLE)
+    a.write(3, "Email", "ada@x.io")
+    if before:
+        a.write(3, "Status", before)
+    got = plan_workbook(a, people, TODAY)
+    got = got[0]["sets"].get("Status") if got else None
+    check("Status %-10r -> %r" % (before, want), got, want)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: the edited workbook is still a readable .xlsx
+# ---------------------------------------------------------------------------
+names, parts, att = book(sample_row=SAMPLE)
+apply_ops(att, plan_workbook(att, people, TODAY))
+att.serialize()
+raw = save_parts(names, parts)
+rt_names, rt_parts = load_parts(raw)
+check("every zip part survives the round-trip", rt_names, names)
+rt = Attendees(rt_parts, sheet_part(rt_parts, "Attendees"))
+check("the new person reads back", rt.value(3, "Full name"), "Ada")
+check("the sample row is untouched", rt.value(2, "Notes (CRM)"), SAMPLE[4])
+check("dimension covers the written rows",
+      ET.fromstring(rt_parts["xl/worksheets/sheet1.xml"]).find(X + "dimension").get("ref"),
+      "A1:K10")
+check("rows stay in ascending order",
+      [int(r.get("r")) for r in rt.data.findall(X + "row")], list(range(1, 11)))
+check("re-serialized XML keeps the default namespace",
+      rt_parts["xl/worksheets/sheet1.xml"].startswith(
+          b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<worksheet'), True)
+
+# A person appended past the end of the pre-created grid.
+names, parts, att = book(sample_row=SAMPLE, blank_rows=1)
+crowd = merge_people([person("P%d" % i, "p%d@x.io" % i, "B") for i in range(4)])
+apply_ops(att, plan_workbook(att, crowd, TODAY))
+att.serialize()
+_, rt_parts = load_parts(save_parts(names, parts))
+rt = Attendees(rt_parts, sheet_part(rt_parts, "Attendees"))
+check("rows are created past the end of the grid",
+      [rt.value(r, "Email") for r in (3, 4, 5, 6)],
+      ["p0@x.io", "p1@x.io", "p2@x.io", "p3@x.io"])
+
+
+# ---------------------------------------------------------------------------
+# The Status dropdown patch
+# ---------------------------------------------------------------------------
+names, parts, att = book(sample_row=SAMPLE)
+part = sheet_part(parts, "Attendees")
+check("dropdown patch reports a change", patch_status_dropdown(parts, part), "patched")
+check('dropdown now offers "Host"', DV_STATUS_NEW.encode() in parts[part], True)
+check("dropdown patch is idempotent", patch_status_dropdown(parts, part), "already")
+names, parts, _ = book(sample_row=SAMPLE, dv=DV_STATUS_NEW)
+check("an already-patched workbook is left alone",
+      patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "already")
+check('"Host" is the only difference from the shipped list',
+      DV_STATUS_NEW.replace("Host,", ""), DV_STATUS_OLD)
+
+# The legacy CRMs escape the formula quotes; matching only `"…"` left every one
+# of them un-patched while the run still reported success.
+names, parts, _ = book(sample_row=SAMPLE)
+part = sheet_part(parts, "Attendees")
+parts[part] = parts[part].replace(('"%s"' % DV_STATUS_OLD).encode(),
+                                  ("&quot;%s&quot;" % DV_STATUS_OLD).encode())
+check("patches the &quot;-escaped legacy spelling",
+      patch_status_dropdown(parts, part), "patched")
+check("legacy patch keeps the escaping",
+      ("&quot;%s&quot;" % DV_STATUS_NEW).encode() in parts[part], True)
+check("legacy patch is idempotent", patch_status_dropdown(parts, part), "already")
+
+names, parts, _ = book(sample_row=SAMPLE, dv="Yes,No")
+check("a workbook with no Status list is reported, not guessed at",
+      patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "absent")
+
+# Regression: serialize() rewrites the sheet part from the element tree, so a
+# dropdown patch applied BEFORE it is silently discarded — the run reports the
+# patch as applied and the uploaded workbook still has the eight-value list.
+# finalize() is the only supported write path precisely to fix the ordering.
+names, parts, att = book(sample_row=SAMPLE)
+part = sheet_part(parts, "Attendees")
+patch_status_dropdown(parts, part)
+att.serialize()
+check("serialize-then-patch is the bug this guards",
+      DV_STATUS_NEW.encode() in parts[part], False)
+
+names, parts, att = book(sample_row=SAMPLE)
+b = sync_crm.Book(folder={"name": "Boston"}, crm={"id": "x", "name": "Boston CRM.xlsx"},
+                  names=names, parts=parts, part=sheet_part(parts, "Attendees"),
+                  att=att, path="/tmp/x.xlsx")
+raw = sync_crm.finalize(b, plan_workbook(att, people, TODAY))
+fin_names, fin_parts = load_parts(raw)
+fin = Attendees(fin_parts, sheet_part(fin_parts, "Attendees"))
+check("finalize keeps the dropdown patch",
+      DV_STATUS_NEW.encode() in fin_parts[sheet_part(fin_parts, "Attendees")], True)
+check("finalize keeps the row writes", fin.value(3, "Email"), "ada@x.io")
+check("finalize returns a complete zip", sorted(fin_names), sorted(names))
+
+
+# ---------------------------------------------------------------------------
+# match_chapters
+# ---------------------------------------------------------------------------
+FOLDERS = [{"id": "f1", "name": "Boston"}, {"id": "f2", "name": "Delhi NCR"},
+           {"id": "f3", "name": "San Francisco"}, {"id": "f4", "name": "Washington DC"},
+           {"id": "f5", "name": "Montréal"}, {"id": "t", "name": "TemplateCity"}]
+
+by_folder, orphans, near = match_chapters(
+    [person("A", "a@x.io", "boston"), person("B", "b@x.io", "Washington, DC"),
+     person("C", "c@x.io", "Montreal"), person("D", "d@x.io", "New Delhi"),
+     person("E", "e@x.io", "San Diego"), person("F", "f@x.io", "Reykjavik"),
+     person("G", "g@x.io", "TemplateCity")], FOLDERS)
+check("exact match, case-folded", [p["name"] for p in by_folder["f1"]], ["A"])
+check("punctuation-folded match", [p["name"] for p in by_folder["f4"]], ["B"])
+check("accent-folded match", [p["name"] for p in by_folder["f5"]], ["C"])
+check("TemplateCity never receives people", "t" in by_folder, False)
+check("near-miss on a shared discriminating token",
+      [(m["city"], m["candidates"]) for m in near], [("New Delhi", ["Delhi NCR"])])
+check("generic tokens do not create a near-miss (San Diego / San Francisco)",
+      sorted(o["city"] for o in orphans), ["Reykjavik", "San Diego", "TemplateCity"])
+
+
+print()
+print("FAILED %d check(s)" % fails if fails else "All checks passed.")
+sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -48,7 +48,8 @@ def make_xlsx(sample_row=None, blank_rows=8, headers=CRM_HEADERS,
         cells = "".join(_c(cell_ref(i, 2), v, "4" if i == 4 else "3")
                         for i, v in enumerate(sample_row) if v)
         rows.append('<row r="2">%s</row>' % cells)
-    # Rows 3.. ship with only the three dropdown columns materialised.
+    # Rows 3.. ship with only the columns the template pre-materialises.
+    # (One dataValidation is declared below, on Status/column D.)
     for r in range(3, 3 + blank_rows):
         rows.append('<row r="%d">%s</row>'
                     % (r, "".join(_c(cell_ref(i, r), None, "5") for i in (1, 2, 3))))
@@ -200,7 +201,7 @@ ops = plan_workbook(att, people, TODAY)
 check("a new person is one op", len(ops), 1)
 check("new person lands on the first free row", ops[0]["rownum"], 3)
 check("new person is flagged as an add", ops[0]["kind"], "add")
-check("interest comes from the survey",
+check("the interest field reaches the CRM cell",
       ops[0]["sets"]["What brings you here?"], "I want to be an organizer/volunteer")
 check("the survey's detail columns are not written",
       [c for c in ("Technical expertise", "LinkedIn URL", "Company") if c in ops[0]["sets"]], [])
@@ -273,6 +274,34 @@ check("a real-looking row is reported as pre-existing",
                                         "email": "ravi@vendor.co"}])
 check("a row this run touches is not reported as pre-existing",
       sync_crm.preexisting(attk, [{"rownum": 2}]), [])
+
+# An intake person really can have an example-domain address — valid_email
+# accepts it. Clearing their row as fixture data while also re-adding them made
+# the plan non-empty forever, so --write's re-verify could never converge and
+# the chapter reported "ops still pending" permanently.
+_, _, attc = book(sample_row=None)
+churn = merge_people([person("Sam Taylor", "sam@example.com", "Boston")])
+attc.write(2, "Email", "sam@example.com")
+attc.write(2, "Full name", "Sam Taylor")
+first = plan_workbook(attc, churn, TODAY)
+check("an intake person is not cleared as fixture data",
+      [o["kind"] for o in first], ["fill"])
+apply_ops(attc, first)
+check("...and the plan converges on the second run",
+      plan_workbook(attc, churn, TODAY), [])
+
+# A fixture row NOT owned by anyone in the plan is still cleared.
+_, _, attu = book(sample_row=DUMMY)
+check("an unowned fixture row is still cleared",
+      [o["kind"] for o in plan_workbook(attu, [], TODAY)], ["clear"])
+
+# A settled CRM must stay settled when the date rolls over — Notes (CRM) embeds
+# `today`, so a loosened leave-populated-alone rule would rewrite every note in
+# every workbook, every day, and never converge.
+_, _, attd2 = book(sample_row=SAMPLE)
+apply_ops(attd2, plan_workbook(attd2, people, TODAY))
+check("a later date does not re-plan a settled CRM",
+      plan_workbook(attd2, people, "2027-01-01"), [])
 # On a settled CRM there are no ops, so without the `people` filter every row the
 # sync itself wrote would be reported back as an unrecognised address to review.
 _, _, atts = book(sample_row=SAMPLE)
@@ -285,15 +314,23 @@ check("the expected-person filter is email-based, not row-based",
       [r["row"] for r in sync_crm.preexisting(atts, [], [])], [2, 3])
 
 # Status: upgrade what the automation wrote, never what a human wrote.
+# Speaker/Host -> Organizer is the case the AUTO_STATUS rule exists for ("a
+# person's role is corrected after re-triage") and was the one it never covered.
 for before, want in (("", "Organizer"), ("New", "Organizer"), ("Prospect", "Organizer"),
+                     ("Speaker", "Organizer"), ("Host", "Organizer"),
+                     ("Organizer", None),
                      ("Attended", None), ("Declined", None), ("Regular", None),
                      ("Volunteer", None)):
     _, _, a = book(sample_row=SAMPLE)
     a.write(3, "Email", "ada@x.io")
     if before:
         a.write(3, "Status", before)
-    got = plan_workbook(a, people, TODAY)
-    got = got[0]["sets"].get("Status") if got else None
+    ops_s = plan_workbook(a, people, TODAY)
+    # Assert an op exists at all: for the protected values the expected result
+    # is None, which an EMPTY ops list also yields — so four of these checks
+    # would pass vacuously if planning stopped emitting ops entirely.
+    check("Status %-10r -> op kinds" % before, [o["kind"] for o in ops_s], ["fill"])
+    got = ops_s[0]["sets"].get("Status") if ops_s else None
     check("Status %-10r -> %r" % (before, want), got, want)
 
 
@@ -405,6 +442,69 @@ check("near-miss on a shared discriminating token",
 check("generic tokens do not create a near-miss (San Diego / San Francisco)",
       sorted(o["city"] for o in orphans), ["Reykjavik", "San Diego", "TemplateCity"])
 
+
+# ---------------------------------------------------------------------------
+# Write guards: the promises that are now structural rather than documented
+# ---------------------------------------------------------------------------
+_, _, attw = book(sample_row=SAMPLE)
+for col in ("Signal", "LinkedIn URL", "Company", "Role / title", "Technical expertise"):
+    try:
+        attw.write(3, col, "x")
+        check("write(%r) is refused" % col, "no error", "ValueError")
+    except ValueError:
+        check("write(%r) is refused" % col, True, True)
+check("write() still accepts a CRM_WRITTEN column",
+      attw.write(3, "Full name", "Ada") or attw.value(3, "Full name"), "Ada")
+# clear() legitimately touches all eleven, including the guarded five.
+attw.clear(3)
+check("clear() may blank the guarded columns",
+      [attw.value(3, h) for h in CRM_HEADERS], [""] * len(CRM_HEADERS))
+
+# A cleared cell must be truly blank, not a zero-length inline string: the
+# latter makes ISBLANK false and COUNTA count it, on row 2 of every workbook.
+_, _, attb = book(sample_row=DUMMY)
+apply_ops(attb, plan_workbook(attb, [], TODAY))
+row2 = [c for c in attb.rows[2].findall(X + "c")]
+check("a cleared cell carries no type attribute",
+      [c.get("t") for c in row2], [None] * len(row2))
+check("a cleared cell has no value child", [len(list(c)) for c in row2], [0] * len(row2))
+check("a cleared cell keeps its style", [c.get("s") for c in row2][0], "3")
+
+# apply_ops must not treat an unrecognised kind as a write.
+_, _, atty = book(sample_row=SAMPLE)
+try:
+    apply_ops(atty, [{"kind": "delete", "rownum": 3, "sets": {"Full name": "X"}}])
+    check("an unknown op kind is refused", "no error", "ValueError")
+except ValueError:
+    check("an unknown op kind is refused", True, True)
+check("...and nothing was written", atty.value(3, "Full name"), "")
+
+# occupied() must consider the columns the automation never writes, or a
+# half-cleaned row hands the next person a stranger's LinkedIn and employer.
+_, _, atto = book(sample_row=SAMPLE)
+atto._write(4, "Company", "Ex-Employer Inc.")
+check("a row with only an unwritten column set is still occupied",
+      atto.occupied(4), True)
+check("...so it is not offered as a free row", next(atto.free_rows()), 3)
+
+# serialize() must refuse a root it cannot find, rather than slicing to the
+# last byte and uploading a 57-byte 'worksheet'.
+_, _, atts2 = book(sample_row=SAMPLE)
+atts2.root.tag = "{http://example.invalid/other}worksheet"
+try:
+    atts2.serialize()
+    check("serialize refuses a non-<worksheet> root", "no error", "ValueError")
+except ValueError as e:
+    check("serialize refuses a non-<worksheet> root", "refusing to write" in str(e), True)
+
+# An alias bound to the spreadsheetml namespace must not displace the default
+# binding — that is what made the root serialize as <x:worksheet>.
+sync_crm.register_namespaces(
+    ('<worksheet xmlns="%s" xmlns:x="%s" />' % (sync_crm._XLNS, sync_crm._XLNS)).encode())
+_, _, atta = book(sample_row=SAMPLE)
+atta.serialize()
+check("an aliased spreadsheetml prefix does not break serialization",
+      atta.parts[atta.part_name].count(b"<worksheet"), 1)
 
 print()
 print("FAILED %d check(s)" % fails if fails else "All checks passed.")


### PR DESCRIPTION
## Summary

Grows `aaif-sync-chapters` from one engine into three. Alongside the existing chapters-feed writer, it now pushes accepted people and their survey interest into each chapter's private CRM, and replaces the Chapters folder's public link-share with per-chapter organizer grants.

All three engines share the same house rules: the intake sheet is only ever **read**, the report is the **default**, and `--write` re-verifies itself.

Both new engines have been run against production. 82 chapter CRMs written and verified; 92 organizer grants applied; the folder's `anyone -> reader` removed.

## Changesets

### 1. `feat(sync-chapters): sync accepted people + survey interest into chapter CRMs`
**Files:** `scripts/sync_crm.py`, `scripts/test_sync_crm.py`, `scripts/sync_chapters.py`

Pushes `Accepted` / `Existing (from MLOps)` people from all three role tabs into their chapter's `<City> CRM.xlsx`, carrying the survey's own "What brings you here?" answer across.

Only 6 of 11 columns are written — `Signal`, `LinkedIn`, `Company`, `Role/title` and `Technical expertise` are absent from the mapping rather than written blank, and `Attendees.write()` now refuses them outright.

The workbooks are stored `.xlsx`, so they're edited as OOXML zip parts, repacking every untouched part byte-for-byte. Values are inline strings, which both Excel and Sheets treat as literal text — a leading `=` can never become a formula.

### 2. `feat(sync-chapters): replace the public link-share with per-chapter access`
**Files:** `scripts/sync_access.py`

`grant` gives each accepted organizer `writer` on their own chapter folder; `lock` removes `anyone:reader` from Chapters/. Grant must precede lock — the public link was every organizer's only access.

Grants are **organizers only**, deliberately narrower than the CRM: a speaker belongs in a chapter's CRM but has no business with write access to its Drive folder.

### 3. `docs(sync-chapters): document the CRM and access engines`
**Files:** `SKILL.md`

### 4–6. Self-review fixes (`c9daf27`, `bcddc86`, `7187ee3`)
**Files:** `scripts/sync_crm.py`, `scripts/sync_access.py`, `scripts/test_sync_crm.py`, **`scripts/test_sync_access.py` (new)**, `SKILL.md`

Six review agents (code-review, silent-failure, test-coverage, comment-accuracy, type-design, security) produced 25 findings; all 25 are fixed. The ones that change behaviour:

- **`serialize()` could upload a 57-byte worksheet.** `find()` returns `-1` on a miss and `body[-1:]` is the last byte. Reachable because `ET.register_namespace` is global state registered at open time but used at write time, while `run()` opens every workbook before serializing the first.
- **`sync_access.py` exited 0 on `VERIFY FAILED`** — `main()`'s return code was discarded. The destructive script could not report failure to anything.
- **`lock` ran after grants failed**, removing the public link that was those organizers' only access. Now gated; **new `--lock-anyway`** flag overrides.
- **`assert_all_accepted()` was blind to role and chapter** — it could not catch the `ACCESS_TABS` escalation documented directly above it.
- **`apply_pins()` granted `anyone:reader` on an unvalidated file id** from a spreadsheet cell, and that grant survives `lock`.
- **`perms()` didn't paginate** — fail-open on the parent, where a truncated read makes `lock` a silent no-op that verifies green.
- **An `@example.com` intake person never converged** — cleared as fixture data *and* re-added, forever.

## Two findings worth reading

**The website does not serve chapter images from Drive.** The feed's `Image` column is full of `lh3.googleusercontent.com` URLs pointing at a `Web Banner.png` inside each chapter folder, so it reads as "80 public Drive images the site serves". It isn't — `aaif.io/community-chapters` renders 26 images, all from `cdn.sanity.io`. A column full of image URLs is not evidence that anything fetches them.

**Drive silently no-ops a child's `anyone:reader` while the parent has one.** It returns `200` with a permission id and stores nothing; the file still reads `inherited: true`. Trusting the "pinned 80 files" report would have taken every chapter image down.

## Test Plan
- [x] `ruff check` clean; `pre-commit run --all-files` clean (15 hooks)
- [x] 138 CRM checks + 41 access checks + 11 sibling suites + 66 pytest
- [x] Live read-only runs: `sync_crm` reports "No changes needed" (idempotent after the production write); `sync_access` reports the full plan and exits 0
- [ ] Reviewer: confirm `ACCESS_TABS` (organizers-only folder access) is the intended policy
- [ ] Reviewer: confirm `CRM_WRITTEN`'s six columns are the right minimal set
- [ ] Reviewer: decide on the deferred collision fix below

## Deferred, deliberately

The security pass found that `match_chapters` builds `{fold_city(name): folder}` via dict comprehension, so two folders folding to one key silently collide and the last wins. A chapter organizer now holds `writer` and can rename their folder, which makes this reachable rather than theoretical.

The fix is not in this PR: `match_chapters` is shared by both new engines, and aborting on a collision changes behaviour for both against live data I have not yet confirmed is collision-free across all 82 folders. It belongs in its own change with a live check, not bundled here.

## Notes for the reviewer

Large diff, split into six independently reviewable commits. `sync_crm.py` carries most of it; roughly a third is the OOXML layer, which has no external dependency (stdlib `zipfile` + `ElementTree`).

The only change to pre-existing code is a backward-compatible `cwd=None` parameter on `_gws()`.

Security review found command injection, XXE, zip-slip, formula injection, XML injection and path traversal all clean — argv lists throughout, no `shell=True`, inline strings, in-memory zip round-trip. The real findings were all authorization-shaped, and exist because this PR introduces writer grants.

_Generated using hero-skills._