### PR TITLE
Gall Stereographic map fit, channels:write scope fix, and Luma hold-back on the feed write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 __pycache__/
 *.pyc
 .DS_Store

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -84,6 +84,17 @@ The projection is calibrated to the **current** `image18.png` world map: it is a
 sub-pixel accuracy (mean residual 0.64 px), so no per-city overrides are needed
 anywhere. If the template's map image ever changes, refit (see below).
 
+Two consequences of dropping the override table:
+
+- **Every city now needs coordinates** — geocoding, or `--lat`/`--lon`. The
+  former override cities (Seoul, Sydney, Melbourne, Shanghai) used to be
+  placeable with no network at all; now they hit the geocoder like everyone
+  else, and if it is down the fallback above applies to them too.
+- **Decks placed under the old projection sit a few px off the fitted position**
+  (the pre-Stuttgart chapters, and the template's own hand-placed SF dot, ~9 px).
+  A small dot delta against an old deck is the fit being *right*, not a
+  regression — see the validate note below.
+
 ## Procedure
 
 1. **Confirm the city name and slug with the user.** Ask for the exact display
@@ -151,6 +162,10 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/create_chapter.py \
     --city "Los Angeles" --lat 34.05 --lon -118.24 --rebrand-local /path/to/template-copy
 # then compare paragraph text against the real Los Angeles chapter, and open
 # slide 5 of the rebranded Slides.pptx to confirm the dot moved (+map dot).
+# EXPECTED: the dot sits ~8-15 px from the existing chapter's — old decks were
+# placed by the pre-2026-07-30 anchors/overrides projection. Judge the dot
+# against the COASTLINE, not the old deck, and never "fix" the projection back
+# toward a hand-placed dot.
 python3 ${CLAUDE_SKILL_DIR}/scripts/test_create_chapter.py   # unit tests
 ```
 

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -79,10 +79,10 @@ The slide-5 network-map dot is placed from the city's latitude/longitude:
   override was given, the dot is left at San Francisco and a warning is printed. The
   chapter is still created; just fix slide 5's dot manually (or re-run with `--lat`/`--lon`).
 
-The projection is calibrated to the **current** `image18.png` world map. East-Asia /
-Oceania cities are drawn distorted and use a per-city `PIXEL_OVERRIDES` table in the
-script (seeded with Seoul, Sydney, Melbourne). If a new such city lands off, add an
-override (see Verify) and re-run.
+The projection is calibrated to the **current** `image18.png` world map: it is a
+**Gall Stereographic** projection, fitted against Natural Earth coastlines to
+sub-pixel accuracy (mean residual 0.64 px), so no per-city overrides are needed
+anywhere. If the template's map image ever changes, refit (see below).
 
 ## Procedure
 
@@ -113,10 +113,10 @@ override (see Verify) and re-run.
    folder URL to the user. If the Luma page wasn't live, remind them to create it.
    Open slide 5 ("THE NETWORK") of `Event Template/Slides.pptx` and confirm the
    green dot sits on the correct city (the `Slides.pptx` line shows `+map dot` when
-   it was moved). If the city is in **East Asia / Oceania** and the dot looks off,
-   add a `PIXEL_OVERRIDES` entry in `create_chapter.py` (pixel coords on the
-   1123×794 `image18.png`) and re-run. To recalibrate against a render, export
-   slide 5 to PNG via the Slides API (see the tooling rule at the top of this file):
+   it was moved). A misplaced dot means the coordinates were wrong (re-run with
+   `--lat`/`--lon`) or the map art changed (refit the projection — see below). To
+   check against a render, export slide 5 to PNG via the Slides API (see the
+   tooling rule at the top of this file):
    ```bash
    PYTHONPATH=lib python3 -c "
    from aaif_events.slides_export import render_slide_png
@@ -132,14 +132,17 @@ robust to OOXML run-splitting. The `SF`-abbreviation casing is decided by the
 surrounding words. The Drive layer uses `gws` (`files.copy`, `create`, `get`,
 `update`).
 
-The slide-5 map dot is placed by `reposition_map_marker` using a lat/lon →
-pixel projection (`lon2x` linear; `lat2y` piecewise-linear via `LAT_ANCHORS`;
-`PIXEL_OVERRIDES` for the distorted western Pacific). The anchors are calibrated
-to the current `image18.png`; **if the template's map image changes, recalibrate**
-by rendering slide 5 to PDF (see Verify) and adjusting `LAT_ANCHORS` / `lon2x` /
-overrides until candidate dots sit on the coastlines. `scripts/test_create_chapter.py`
-covers the San Francisco self-check, the label offset, the override table, and the
-2-shapes-or-raise guard.
+The slide-5 map dot is placed by `reposition_map_marker` using a lat/lon → pixel
+**Gall Stereographic** projection (`lon2x` linear in longitude; `lat2y` linear in
+`(1 + √2/2)·tan(lat/2)`), fitted 2026-07-30 against Natural Earth 110m coastlines
+composited over `image18.png` (mean residual 0.64 px). **If the template's map
+image changes, refit**: composite the transparent PNG over `#F6F5F1`, build a
+distance transform of the drawn pixels, and optimize (scale_x, scale_y, offset_x,
+offset_y, central meridian) per candidate projection family by Nelder-Mead to
+minimise the mean distance from projected coastline vertices (lat > -60; the map
+omits Antarctica) to the nearest drawn pixel. `scripts/test_create_chapter.py`
+covers the San Francisco calibration lock, the label offset, monotonicity/canvas
+bounds, and the 2-shapes-or-raise guard.
 
 To validate the engine after any edit, rebrand a throwaway copy of the template
 and diff it against an existing chapter (the canonical end-state):

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -24,7 +24,7 @@ Usage:
   # Test the text engine on a local folder of .pptx/.docx/.xlsx (no Drive):
   python create_chapter.py --city "Los Angeles" --rebrand-local ./somedir
 """
-import argparse, html, json, os, re, subprocess, sys, time, unicodedata, urllib.error, urllib.parse, urllib.request, zipfile
+import argparse, html, json, math, os, re, subprocess, sys, time, unicodedata, urllib.error, urllib.parse, urllib.request, zipfile
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
 TEMPLATE_FOLDER = "1PHvEgqnHo0RrsFyA47O9iRJGaKehC8Eg"   # the "TemplateCity" folder
@@ -194,50 +194,27 @@ LABEL_DX, LABEL_DY = -425196, 224028   # label-corner minus dot-corner (SF templ
 # by the dot's 155448x155448 ext (its signature).
 DOT_EXT_RE = re.compile(r'<a:ext cx="%d" cy="%d"\s*/>' % (DOT_SIZE, DOT_SIZE))
 
-# Longitude: linear (verified on SF, London, Gibraltar, Tokyo).
+# The map is a Gall Stereographic projection, fitted 2026-07-30 against Natural
+# Earth 110m coastlines composited over the drawn map (mean residual 0.64 px —
+# sub-pixel over every coastline vertex, lat > -60; the map omits Antarctica).
+# x is linear in longitude; y is linear in the Gall ordinate
+# (1 + sqrt(2)/2) * tan(lat/2). No per-city overrides are needed anywhere.
 def lon2x(lon):
-    return 2.676 * lon + 516.3
-
-# Latitude: NONLINEAR (the map compresses toward the poles) — piecewise-linear.
-LAT_ANCHORS = [(64.8, 205), (51.5, 253), (37.77, 311), (25.1, 345),
-               (0.0, 398), (-34.8, 525), (-55.9, 597)]
+    return 497.6001 + 2.447111 * lon
 
 def lat2y(lat):
-    a = LAT_ANCHORS
-    if lat >= a[0][0]:
-        (l0, y0), (l1, y1) = a[0], a[1]
-    elif lat <= a[-1][0]:
-        (l0, y0), (l1, y1) = a[-2], a[-1]
-    else:
-        for i in range(len(a) - 1):
-            if a[i][0] >= lat >= a[i + 1][0]:
-                (l0, y0), (l1, y1) = a[i], a[i + 1]
-                break
-    return y0 + (lat - l0) / (l1 - l0) * (y1 - y0)
+    return 437.1541 - 192.9697 * (1 + math.sqrt(2) / 2) * math.tan(math.radians(lat) / 2)
 
-# The western Pacific is drawn distorted: Sydney (~151°E) and Melbourne (~145°E)
-# are dragged WEST to nearly Tokyo's x, so a separable lon/lat projection can't
-# place East-Asia/Oceania. (Tokyo itself IS placed correctly by the linear
-# formula and needs no override — it's only the landmark showing how far west the
-# others land.) Separately, Shanghai (~121°E) IS placed almost correctly by the
-# linear formula but lands ~8px offshore; its override only nudges it west onto the
-# Chinese coast — a small cosmetic fix, not the gross Oceania distortion above.
-# Keep a per-city pixel override table for the cities that need it.
-PIXEL_OVERRIDES = {"Seoul": (822, 305), "Sydney": (870, 512), "Melbourne": (836, 543),
-                   "Shanghai": (833, 330)}
-
-def project_city(name, lat, lon):
-    """Map a city to (x, y) pixels on image18.png. Overridden cities take their
-    pixel from the table and IGNORE lat/lon (the map is non-separable there)."""
-    if name in PIXEL_OVERRIDES:
-        return PIXEL_OVERRIDES[name]
+def project_city(lat, lon):
+    """Map a city's coordinates to (x, y) pixels on image18.png."""
     return lon2x(lon), lat2y(lat)
 
 def marker_offsets(name, lat, lon):
     """Return (dot_off, label_off) in EMU for a city, matching the SF template's
-    relative label placement. Self-check: San Francisco (37.77, -122.42)
-    reproduces the real template/chapter dot off (4074942, 2650779)."""
-    px, py = project_city(name, lat, lon)
+    relative label placement. (The template's own hand-placed SF dot sits ~9 px
+    west of the fitted position, so this does NOT reproduce it exactly — the
+    coastline fit wins; see the projection note above.)"""
+    px, py = project_city(lat, lon)
     cx = MAP_OFF[0] + px * (MAP_EXT[0] / MAP_PX[0])   # dot CENTER, EMU
     cy = MAP_OFF[1] + py * (MAP_EXT[1] / MAP_PX[1])
     dot_off = (round(cx - DOT_SIZE / 2), round(cy - DOT_SIZE / 2))
@@ -346,15 +323,6 @@ def resolve_latlon(name, lat, lon):
               "value and geocoding %r instead." % name)
     return geocode_city(name)
 
-def map_dot_latlon(name, lat, lon):
-    """Coordinates to feed the slide-5 map-dot placement, or None to leave the dot
-    at San Francisco. Fixed-pixel-override cities are placed by NAME (project_city
-    ignores lat/lon for them), so they're placeable WITHOUT geocoding: return a
-    sentinel instead of gating them on a network lookup that can't change where the
-    dot lands. Explicit --lat/--lon still short-circuit to resolve_latlon."""
-    if name in PIXEL_OVERRIDES and not (lat is not None and lon is not None):
-        return (0.0, 0.0)   # value unused by project_city; just marks the dot placeable
-    return resolve_latlon(name, lat, lon)
 
 # ----------------------------------------------------------------------------
 # Drive helpers (via the gws CLI)
@@ -499,20 +467,11 @@ def main():
     print("Upper: %s" % upper)
     print("Slug : aaif-%s  ->  https://luma.com/aaif-%s" % (slug, slug))
 
-    # Coordinates for the slide-5 network-map dot (explicit -> pixel-override
-    # sentinel -> geocode -> none). Fixed-pixel cities place by name, so they never
-    # get the "stays at San Francisco" warning just because geocoding was skipped.
-    pixel_override = name in PIXEL_OVERRIDES
-    latlon = map_dot_latlon(name, a.lat, a.lon)
-    if pixel_override and not (a.lat is not None and a.lon is not None):
-        print("Coords: -- (fixed pixel override for %s; lat/lon not needed)" % name)
-    elif latlon:
+    # Coordinates for the slide-5 network-map dot (explicit -> geocode -> none).
+    latlon = resolve_latlon(name, a.lat, a.lon)
+    if latlon:
         src = "override" if (a.lat is not None and a.lon is not None) else "geocoded"
         print("Coords: %.4f, %.4f (%s)" % (latlon[0], latlon[1], src))
-        if pixel_override:
-            print("Note: %s has a fixed pixel override for the slide-5 map dot; the "
-                  "coordinates above do NOT position it (--lat/--lon ignored for "
-                  "placement)." % name)
     else:
         print("Coords: --")
         print("WARNING: could not resolve coordinates for %r; the slide-5 map dot "

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -179,8 +179,8 @@ def residual_tokens(path):
 # The template's world map (ppt/media/image18.png, 1123x794 px) carries a green
 # "you-are-here" dot + a "<CITY> · TONIGHT" label, both parked at San Francisco.
 # rebrand_file fixes the label *text*; this moves the green shapes to the new city.
-# The projection anchors/overrides below are calibrated to the *current* image18.png
-# — if the template's map image changes, recalibrate (see SKILL.md "Verify").
+# The projection constants below are fitted to the *current* image18.png — if
+# the template's map image changes, refit (see SKILL.md).
 # ----------------------------------------------------------------------------
 SLIDE5 = "ppt/slides/slide5.xml"
 GREEN = "14964A"                       # AAIF green fill on both marker shapes
@@ -209,7 +209,7 @@ def project_city(lat, lon):
     """Map a city's coordinates to (x, y) pixels on image18.png."""
     return lon2x(lon), lat2y(lat)
 
-def marker_offsets(name, lat, lon):
+def marker_offsets(lat, lon):
     """Return (dot_off, label_off) in EMU for a city, matching the SF template's
     relative label placement. (The template's own hand-placed SF dot sits ~9 px
     west of the fitted position, so this does NOT reproduce it exactly — the
@@ -221,7 +221,7 @@ def marker_offsets(name, lat, lon):
     label_off = (dot_off[0] + LABEL_DX, dot_off[1] + LABEL_DY)
     return dot_off, label_off
 
-def reposition_map_marker(path, city, lat, lon):
+def reposition_map_marker(path, lat, lon):
     """Move the green dot + its label on slide 5 of a .pptx to (lat, lon).
 
     Returns the number of shapes moved (2 on success) or 0 when there is nothing
@@ -237,7 +237,7 @@ def reposition_map_marker(path, city, lat, lon):
             return 0
         xml = z.read(SLIDE5).decode("utf-8")
 
-    dot_off, label_off = marker_offsets(city, lat, lon)
+    dot_off, label_off = marker_offsets(lat, lon)
     off_re = re.compile(r'<a:off x="-?\d+" y="-?\d+"\s*/>')   # tolerate a re-saved " />"
     sp_re = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)      # slide 5 shapes are flat
 
@@ -431,7 +431,7 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent=""):
                     # the new city when we have coordinates (rebrand_file only fixed
                     # the label text). Gate the upload on either change.
                     if cname == "Slides.pptx" and ctx.get("latlon"):
-                        moved = reposition_map_marker(tmp, ctx["name"], *ctx["latlon"])
+                        moved = reposition_map_marker(tmp, *ctx["latlon"])
                     else:
                         moved = 0
                     if n or moved:
@@ -485,7 +485,7 @@ def main():
                 if os.path.splitext(f)[1].lower() in MIME_BY_EXT:
                     p = os.path.join(root, f)
                     n = rebrand_file(p, name, upper, slug)
-                    moved = reposition_map_marker(p, name, *latlon) \
+                    moved = reposition_map_marker(p, *latlon) \
                         if f == "Slides.pptx" and latlon else 0
                     left = residual_tokens(p)
                     if left:

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -122,20 +122,17 @@ class TestProjection(unittest.TestCase):
         # NOTE this is ~9 px east of the template's hand-placed SF dot — the fit
         # wins. If this fails, the projection constants were edited; recalibrate
         # against the coastlines (see SKILL.md), don't just repin the value.
-        dot_off, _ = cc.marker_offsets("San Francisco", 37.77, -122.42)
+        dot_off, _ = cc.marker_offsets(37.77, -122.42)
         self.assertEqual(dot_off, (4119719, 2715465))
 
     def test_label_keeps_template_offset_from_dot(self):
-        dot_off, label_off = cc.marker_offsets("New York", 40.71, -74.01)
+        dot_off, label_off = cc.marker_offsets(40.71, -74.01)
         self.assertEqual(label_off[0] - dot_off[0], cc.LABEL_DX)
         self.assertEqual(label_off[1] - dot_off[1], cc.LABEL_DY)
 
-    def test_gall_reference_points(self):
-        # The Gall ordinate is 0 at the equator and lon2x is linear, so the
-        # intercepts are hit exactly.
-        self.assertAlmostEqual(cc.lat2y(0.0), 437.1541, places=6)
-        self.assertAlmostEqual(cc.lon2x(0.0), 497.6001, places=6)
-        self.assertAlmostEqual(cc.lon2x(100.0) - cc.lon2x(0.0), 244.7111, places=4)
+    # (No literal re-pins of the fitted constants beyond the SF calibration
+    # lock above: a second copy of the numbers just makes a legitimate refit
+    # touch more magic literals, and invites the repin the lock forbids.)
 
     def test_lat2y_is_monotonic_north_up(self):
         # y decreases as latitude increases (row 0 is the top of the image).
@@ -160,11 +157,11 @@ class TestReposition(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, slide5(DOT_SP, LABEL_SP, OTHER_SP))
-            moved = cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+            moved = cc.reposition_map_marker(p, 40.71, -74.01)
             self.assertEqual(moved, 2)
             self.assertIsNone(zipfile.ZipFile(p).testzip())
 
-            dot_off, label_off = cc.marker_offsets("New York", 40.71, -74.01)
+            dot_off, label_off = cc.marker_offsets(40.71, -74.01)
             got = offsets_by_shape(p)
             self.assertEqual(got["dot"], dot_off)
             self.assertEqual(got["label"], label_off)      # label detected despite xml:space
@@ -174,20 +171,20 @@ class TestReposition(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, slide_xml=None)  # no slide 5 at all
-            self.assertEqual(cc.reposition_map_marker(p, "New York", 40.71, -74.01), 0)
+            self.assertEqual(cc.reposition_map_marker(p, 40.71, -74.01), 0)
 
     def test_no_green_shapes_returns_zero(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, slide5(OTHER_SP))  # shapes present, none green
-            self.assertEqual(cc.reposition_map_marker(p, "New York", 40.71, -74.01), 0)
+            self.assertEqual(cc.reposition_map_marker(p, 40.71, -74.01), 0)
 
     def test_guard_raises_when_not_exactly_two_green(self):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, slide5(DOT_SP, OTHER_SP))  # only 1 green shape
             with self.assertRaises(RuntimeError):
-                cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+                cc.reposition_map_marker(p, 40.71, -74.01)
 
     def test_guard_raises_when_both_green_match_dot_ext(self):
         # Identity, not count: two square green shapes -> both classified as dot,
@@ -199,7 +196,7 @@ class TestReposition(unittest.TestCase):
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, two_dots)
             with self.assertRaises(RuntimeError):
-                cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+                cc.reposition_map_marker(p, 40.71, -74.01)
 
     def test_guard_raises_when_neither_green_matches_dot_ext(self):
         # Both green shapes are wide -> both classified as label, zero dots -> raise.
@@ -209,7 +206,7 @@ class TestReposition(unittest.TestCase):
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, two_labels)
             with self.assertRaises(RuntimeError):
-                cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+                cc.reposition_map_marker(p, 40.71, -74.01)
 
     def test_off_regex_tolerates_respaced_selfclose(self):
         # A deck re-saved as '<a:off ... />' (space before />) must still move.
@@ -218,7 +215,7 @@ class TestReposition(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, respaced)
-            self.assertEqual(cc.reposition_map_marker(p, "New York", 40.71, -74.01), 2)
+            self.assertEqual(cc.reposition_map_marker(p, 40.71, -74.01), 2)
 
     def test_rewrite_preserves_other_zip_members(self):
         # A non-slide5 binary member (like image18.png) must round-trip byte-identical.
@@ -227,7 +224,7 @@ class TestReposition(unittest.TestCase):
             p = os.path.join(d, "Slides.pptx")
             make_pptx(p, slide5(DOT_SP, LABEL_SP),
                       extra={"ppt/media/image18.png": blob})
-            cc.reposition_map_marker(p, "New York", 40.71, -74.01)
+            cc.reposition_map_marker(p, 40.71, -74.01)
             with zipfile.ZipFile(p) as z:
                 self.assertEqual(z.read("ppt/media/image18.png"), blob)
                 self.assertIn("[Content_Types].xml", z.namelist())

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -116,46 +116,43 @@ class TestTransformText(unittest.TestCase):
 
 
 class TestProjection(unittest.TestCase):
-    def test_sf_selfcheck_matches_real_deck(self):
-        # Ground truth: the real San Francisco chapter deck's dot sits at exactly
-        # this offset. The projection must reproduce it (this is the calibration
-        # reference — do NOT replace it with a guessed value).
+    def test_sf_calibration_lock(self):
+        # Calibration lock for the fitted Gall Stereographic constants: the SF
+        # dot offset under the 2026-07-30 coastline fit (mean residual 0.64 px).
+        # NOTE this is ~9 px east of the template's hand-placed SF dot — the fit
+        # wins. If this fails, the projection constants were edited; recalibrate
+        # against the coastlines (see SKILL.md), don't just repin the value.
         dot_off, _ = cc.marker_offsets("San Francisco", 37.77, -122.42)
-        self.assertEqual(dot_off, (4074942, 2650779))
+        self.assertEqual(dot_off, (4119719, 2715465))
 
     def test_label_keeps_template_offset_from_dot(self):
         dot_off, label_off = cc.marker_offsets("New York", 40.71, -74.01)
         self.assertEqual(label_off[0] - dot_off[0], cc.LABEL_DX)
         self.assertEqual(label_off[1] - dot_off[1], cc.LABEL_DY)
 
-    def test_pixel_override_wins_over_formula(self):
-        # Overridden cities ignore lat/lon entirely.
-        self.assertEqual(cc.project_city("Seoul", 0.0, 0.0), (822, 305))
-        self.assertEqual(cc.project_city("Sydney", 99.0, 99.0), (870, 512))
+    def test_gall_reference_points(self):
+        # The Gall ordinate is 0 at the equator and lon2x is linear, so the
+        # intercepts are hit exactly.
+        self.assertAlmostEqual(cc.lat2y(0.0), 437.1541, places=6)
+        self.assertAlmostEqual(cc.lon2x(0.0), 497.6001, places=6)
+        self.assertAlmostEqual(cc.lon2x(100.0) - cc.lon2x(0.0), 244.7111, places=4)
 
-    def test_every_override_pixel_is_within_the_map(self):
-        # A transposed or fat-fingered override (e.g. (3833, 330)) would place the
-        # dot off-canvas and be placed silently. Guard the whole table at once.
+    def test_lat2y_is_monotonic_north_up(self):
+        # y decreases as latitude increases (row 0 is the top of the image).
+        lats = [-55, -34, 0, 25, 37.77, 51.5, 64.8]
+        ys = [cc.lat2y(lat) for lat in lats]
+        self.assertEqual(ys, sorted(ys, reverse=True))
+
+    def test_far_flung_cities_land_on_the_canvas(self):
+        # Cities at the map's extremes (including the ones the old model needed
+        # per-pixel overrides for) must all project inside the 1123x794 image.
         w, h = cc.MAP_PX
-        for city, (x, y) in cc.PIXEL_OVERRIDES.items():
-            self.assertTrue(0 <= x <= w, "%s x=%d out of 0..%d" % (city, x, w))
-            self.assertTrue(0 <= y <= h, "%s y=%d out of 0..%d" % (city, y, h))
-
-    def test_lat2y_hits_every_anchor_exactly(self):
-        for lat, y in cc.LAT_ANCHORS:
-            self.assertAlmostEqual(cc.lat2y(lat), y, places=6, msg="anchor %s" % lat)
-
-    def test_lat2y_interpolates_and_covers_southern_hemisphere(self):
-        # Midpoint of the (0.0, 398) -> (-34.8, 525) segment (a formula-driven
-        # southern city like Cape Town lands here; SH is otherwise all overrides).
-        self.assertAlmostEqual(cc.lat2y(-17.4), (398 + 525) / 2, places=3)
-        self.assertTrue(398 < cc.lat2y(-33.9) < 525)  # Cape Town, interpolated
-
-    def test_lat2y_extrapolates_past_the_end_anchors(self):
-        # Beyond the anchor range it extrapolates (does NOT clamp): a far-north
-        # city projects above the top anchor's y, a far-south one below the last.
-        self.assertLess(cc.lat2y(70.0), cc.LAT_ANCHORS[0][1])
-        self.assertGreater(cc.lat2y(-60.0), cc.LAT_ANCHORS[-1][1])
+        for city, lat, lon in [("Seoul", 37.57, 126.98), ("Sydney", -33.87, 151.21),
+                               ("Melbourne", -37.81, 144.96), ("Shanghai", 31.23, 121.47),
+                               ("Reykjavik", 64.15, -21.94), ("Wellington", -41.29, 174.78)]:
+            x, y = cc.project_city(lat, lon)
+            self.assertTrue(0 <= x <= w, "%s x=%.1f out of 0..%d" % (city, x, w))
+            self.assertTrue(0 <= y <= h, "%s y=%.1f out of 0..%d" % (city, y, h))
 
 
 class TestReposition(unittest.TestCase):
@@ -172,15 +169,6 @@ class TestReposition(unittest.TestCase):
             self.assertEqual(got["dot"], dot_off)
             self.assertEqual(got["label"], label_off)      # label detected despite xml:space
             self.assertEqual(got["other"], (111111, 222222))  # untouched
-
-    def test_uses_pixel_override_when_present(self):
-        with tempfile.TemporaryDirectory() as d:
-            p = os.path.join(d, "Slides.pptx")
-            make_pptx(p, slide5(DOT_SP, LABEL_SP))
-            # Seoul's lat/lon are deliberately wrong; the override must win.
-            cc.reposition_map_marker(p, "Seoul", 0.0, 0.0)
-            expected_dot, _ = cc.marker_offsets("Seoul", 0.0, 0.0)
-            self.assertEqual(offsets_by_shape(p)["dot"], expected_dot)
 
     def test_absent_slide5_returns_zero(self):
         with tempfile.TemporaryDirectory() as d:
@@ -267,33 +255,6 @@ class TestResolveLatlon(unittest.TestCase):
             self.assertIsNone(cc.resolve_latlon("Tatooine", None, None))
         finally:
             cc.geocode_city = orig
-
-
-class TestMapDotLatlon(unittest.TestCase):
-    def test_override_city_is_placeable_without_geocoding(self):
-        # An override city (placed by name) must stay placeable even if geocoding
-        # would fail — and must NOT hit the network to decide that.
-        calls = []
-        orig = cc.geocode_city
-        cc.geocode_city = lambda name, **kw: calls.append(name) or None
-        try:
-            self.assertIsNotNone(cc.map_dot_latlon("Shanghai", None, None))
-            self.assertEqual(calls, [])   # no geocode call for a fixed-pixel city
-        finally:
-            cc.geocode_city = orig
-
-    def test_non_override_ungeocodable_still_none(self):
-        orig = cc.geocode_city
-        cc.geocode_city = lambda name, **kw: None
-        try:
-            self.assertIsNone(cc.map_dot_latlon("Tatooine", None, None))
-        finally:
-            cc.geocode_city = orig
-
-    def test_explicit_latlon_wins_even_for_override_city(self):
-        # Passing both coords short-circuits to resolve_latlon (no network), so the
-        # user's values flow through unchanged (project_city still ignores them).
-        self.assertEqual(cc.map_dot_latlon("Shanghai", 31.23, 121.47), (31.23, 121.47))
 
 
 class _FakeResp:

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -192,9 +192,13 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
   removed; same exceptions as `aaif-create-chapter`, e.g. Denver → `aaif-colorado`).
   `Country`, `Generated Geolocation`, `Summary` and `Image` are left **blank for a
   human** — the report names them; the row isn't site-ready until they're filled.
-  The report says whether the Luma page is live, and **`--write` refuses to create
-  a row whose page isn't live** (its CTA would point at a 404) unless you pass
-  `--allow-missing-luma`. Page creation is manual, and a net-new city still needs
+  The report says whether the Luma page is live, and **`--write` holds back a
+  row whose page isn't live** (its CTA would point at a 404) unless you pass
+  `--allow-missing-luma` — the adds and the live rows still land, the held
+  cities are named in the output and re-propose on every run (the write exits
+  `2`, the shared drift code, until their pages exist). Held rows never leave a
+  blank row in the feed: the written rows are renumbered onto consecutive rows.
+  Page creation is manual, and a net-new city still needs
   its Drive folder/assets: run **`aaif-create-chapter`** for it as the follow-up.
 - Duplicate intake rows for the same person+city are deduped (first wins, reported).
   Duplicate **chapter** rows (two rows for one city) are reported too — only the
@@ -751,9 +755,9 @@ attack and cannot be undone), or create a channel the sheet does not name.
 Renames run **before** creates — creating `#bengaluru` first would take the name
 and strand `#bangalore`'s members in the old room.
 
-Two prerequisites, neither in place by default: a token with `channels:manage`
-and `groups:write` (the audit token has read scopes only), and `--i-have-approval`
-alongside `--write`.
+Two prerequisites, neither in place by default: a token with `channels:write`
+and `groups:write` (the user-token scopes for create/rename; the audit token has
+read scopes only), and `--i-have-approval` alongside `--write`.
 
 ## Adding organizers to their channel (`invite_organizers.py`)
 

--- a/skills/aaif-sync-chapters/scripts/nightly.py
+++ b/skills/aaif-sync-chapters/scripts/nightly.py
@@ -14,8 +14,10 @@ Exit-code convention, in two scopes that deliberately differ:
 
   Engines: 0 = in sync, OR --write applied and verified (a `Verified:` line on
            stdout is what separates those two); 2 = a report proposed changes,
-           or coverage was involuntarily partial (`PARTIAL:` line); anything
-           else = failure.
+           a --write held back or left pending work (sync_chapters holds new
+           rows whose Luma page is not live — it may still have written the
+           rest, which the `Verified:` line in its log records), or coverage
+           was involuntarily partial (`PARTIAL:` line); anything else = failure.
   Runner:  0 = every engine in sync; 2 = drift found, writes applied, or
            partial coverage anywhere; 1 = any engine failed.
 
@@ -60,7 +62,10 @@ def classify(code, wrote_marker, write_mode, partial_marker=False):
     """Map an engine's exit code (+ two log markers) onto one of five outcomes.
 
     'Verified:' only ever follows an applied write, so it tells "--write had
-    nothing to do" apart from "--write wrote". 'PARTIAL:' means the engine
+    nothing to do" apart from "--write wrote". Exit 2 in write mode means work
+    is still pending (e.g. sync_chapters held back a row with no live Luma
+    page) and classifies as DRIFT even when part of the run wrote — the drift
+    is what needs eyes, and the log's 'Verified:' line records the write. 'PARTIAL:' means the engine
     involuntarily skipped part of its coverage (today: sync_resources' Slack
     half on a dead token) — it wins over in-sync/drift because a half-checked
     night must never read as a healthy one, but never over FAILED, which is
@@ -151,8 +156,14 @@ def main():
               "the pipeline's report modes are read-only and independent.")
         return 1
     notes = []
-    if DRIFT in results or WROTE in results:
-        notes.append("changes were applied and verified" if a.write
+    # WROTE and DRIFT are separate notes: a write run can exit 2 without having
+    # written anything (every proposal held back), and "changes were applied"
+    # for that night would mask a chapter stuck behind a missing Luma page.
+    if WROTE in results:
+        notes.append("changes were applied and verified")
+    if DRIFT in results:
+        notes.append("drift remains — an engine held back or re-proposed "
+                     "changes; read its log" if a.write
                      else "drift — run the flagged engine(s) with --write after review")
     if PARTIAL in results:
         notes.append("PARTIAL coverage — Slack was unavailable, the channel "

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -40,7 +40,7 @@ this one file.
 
 ## Prerequisites, neither of which is in place by default
 
-1. A token with `channels:manage` (public) and `groups:write` (private), in
+1. A token with `channels:write` (public) and `groups:write` (private), in
    `$AAIF_SLACK_WRITE_TOKEN`. The Slack CLI's own token is read-only and its
    scopes cannot be widened, so this is a separate app token — run the script
    without it for the four setup steps. **Whoever's token it is joins every
@@ -95,7 +95,9 @@ WRITE_METHODS = frozenset({"conversations.create", "conversations.rename",
 
 #: Scopes each write needs. Checked up front so a missing scope fails before the
 #: first channel rather than half way through the batch.
-NEEDED_SCOPES = ("channels:manage", "groups:write")
+# `channels:write` is the USER-token scope for conversations.create/rename;
+# `channels:manage` is its bot-token sibling and never appears on a user token.
+NEEDED_SCOPES = ("channels:write", "groups:write")
 
 #: Slack renames: the room keeps its identity, members and history, and takes a
 #: new name. ORDER IS COMPUTED, not written here — see order_renames(). Two of
@@ -165,7 +167,7 @@ def write_token():
             "No write token. The Slack CLI token is read-only and its scopes "
             "cannot be widened, so writes use a separate app token:\n"
             "  1. api.slack.com/apps -> Create New App -> From scratch\n"
-            "  2. OAuth & Permissions -> User Token Scopes: channels:manage, "
+            "  2. OAuth & Permissions -> User Token Scopes: channels:write, "
             "groups:write,\n     channels:write.invites, groups:write.invites\n"
             "  3. Install to Workspace, copy the User OAuth Token (xoxp-...)\n"
             "  4. export %s='xoxp-...'\n\n"

--- a/skills/aaif-sync-chapters/scripts/prune_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/prune_organizers.py
@@ -64,7 +64,11 @@ import audit_organizers as ao  # noqa: E402
 from aaif_events import slack as slackmod  # noqa: E402
 
 KEEPLIST_TAB = "Organizer Keeplist"
-NEEDED_SCOPES = ("channels:manage", "groups:write")
+# `channels:write` is the USER-token scope for conversations.kick on public
+# channels; `channels:manage` is its bot-token sibling and never appears on a
+# user token (same trap provision_channels.py documents — this is the token
+# it shares, via write_token).
+NEEDED_SCOPES = ("channels:write", "groups:write")
 
 #: Channels that were public and therefore accumulated general members. Recorded
 #: so the report can say *why* a channel has 30 strangers in it, rather than

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -521,6 +521,29 @@ def new_row_values(n, layout):
         vals[layout["index"][name]] = v
     return vals
 
+def partition_new_rows(new_rows, last_row, allow_missing):
+    """Split proposed new rows into (write, held) and renumber the written ones.
+
+    A city whose Luma page is not live is HELD BACK, never written — its CTA
+    would point at a 404 — but it must not block the rows and adds that ARE
+    ready: page creation is manual and can lag a decision by weeks, so one
+    pending city used to freeze every other chapter's sync. "unknown" is held
+    too: a page we could not verify gets a human look, not a published button.
+
+    The written rows are renumbered onto consecutive rows after last_row, so a
+    held city never leaves a blank row in the middle of the feed. Rows are
+    copied, not mutated — the caller's proposal still describes what the report
+    showed. --allow-missing-luma writes everything, dead CTAs included.
+    """
+    if allow_missing:
+        write, held = [dict(n) for n in new_rows], []
+    else:
+        write = [dict(n) for n in new_rows if n.get("luma") == "live"]
+        held = [n for n in new_rows if n.get("luma") != "live"]
+    for i, n in enumerate(write):
+        n["row"] = last_row + 1 + i
+    return write, held
+
 def assert_rows_unchanged(adds, new_rows, layout):
     """Re-read the City column and confirm the proposal's row numbers still mean
     what they meant when it was computed.
@@ -586,16 +609,20 @@ def main():
     # Luma page creation is manual, so "absent" is the NORMAL state for a net-new
     # city — without this gate the common path publishes a "Stay Updated" button
     # pointing at a 404, and the only warning is one line of per-city output.
-    stale = [n for n in state.new_rows if n.get("luma") != "live"]
-    if stale and not a.allow_missing_luma:
-        sys.exit("ABORT: %d new row(s) have no live Luma page: %s.\nTheir CTA would "
-                 "point at a 404. Create the pages first, or re-run with "
-                 "--allow-missing-luma if that's intended."
-                 % (len(stale), ", ".join(n["city"] for n in stale)))
+    to_write, held = partition_new_rows(state.new_rows, state.last_row,
+                                        a.allow_missing_luma)
+    if held:
+        print("\nHELD BACK %d new row(s) with no live Luma page (their CTA would "
+              "point at a 404): %s.\nCreate the page(s) and re-run, or re-run with "
+              "--allow-missing-luma if a dead CTA is intended."
+              % (len(held), ", ".join(n["city"] for n in held)))
+    if not state.adds and not to_write:
+        print("Nothing else to write — every proposed change is held back.")
+        return 2
 
     print("\nApplying %d cell update(s) + %d new row(s) in one batchUpdate..."
-          % (len(state.adds), len(state.new_rows)))
-    n = apply_changes(state.adds, state.new_rows, state.layout)
+          % (len(state.adds), len(to_write)))
+    n = apply_changes(state.adds, to_write, state.layout)
     print("Wrote %d range(s)." % n)
 
     print("\nRe-verifying...")
@@ -606,13 +633,23 @@ def main():
     except (Exception, SystemExit) as e:
         sys.exit("WRITE WAS APPLIED (%d range(s)) but verification could not run: %s\n"
                  "Re-run without --write to confirm the sheet state." % (n, e))
-    if after.adds or after.new_rows:
+    # Held-back rows are EXPECTED to re-propose — the verify's question is "did
+    # everything we actually wrote land", not "is the sheet fully in sync".
+    held_cities = {fold_city(h["city"]) for h in held}
+    leftover_rows = [x for x in after.new_rows
+                     if fold_city(x["city"]) not in held_cities]
+    if after.adds or leftover_rows:
         print("VERIFY FAILED — still out of sync after write:")
         for x in after.adds:
             print("  row %d %s: + %s" % (x["row"], x["city"], "; ".join(x["names"])))
-        for x in after.new_rows:
+        for x in leftover_rows:
             print("  new row %s: %s" % (x["city"], "; ".join(x["names"])))
         sys.exit(1)
+    if held:
+        # Exit 2, the shared drift code: the held rows are still pending work,
+        # and a wrapper (nightly.py) must keep seeing them until the pages exist.
+        print("Verified: a fresh run proposes only the %d held-back row(s)." % len(held))
+        return 2
     print("Verified: a fresh run proposes zero changes.")
     return 0
 

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -609,6 +609,12 @@ def main():
     # Luma page creation is manual, so "absent" is the NORMAL state for a net-new
     # city — without this gate the common path publishes a "Stay Updated" button
     # pointing at a 404, and the only warning is one line of per-city output.
+    # print_report already stamped n["luma"]; the loop below keeps the partition
+    # correct even if a future path reaches here without printing the report,
+    # where a missing key would silently hold every row.
+    for n in state.new_rows:
+        if "luma" not in n:
+            n["luma"] = luma_status(n["slug"])
     to_write, held = partition_new_rows(state.new_rows, state.last_row,
                                         a.allow_missing_luma)
     if held:
@@ -622,6 +628,11 @@ def main():
 
     print("\nApplying %d cell update(s) + %d new row(s) in one batchUpdate..."
           % (len(state.adds), len(to_write)))
+    # The report above printed pre-partition row numbers; holding a row shifts
+    # everything after it, so name the FINAL rows — an operator filling the
+    # blank editorial cells must be pointed at the row the city actually got.
+    for nr in to_write:
+        print("  writing %s at row %d" % (nr["city"], nr["row"]))
     n = apply_changes(state.adds, to_write, state.layout)
     print("Wrote %d range(s)." % n)
 
@@ -635,9 +646,21 @@ def main():
                  "Re-run without --write to confirm the sheet state." % (n, e))
     # Held-back rows are EXPECTED to re-propose — the verify's question is "did
     # everything we actually wrote land", not "is the sheet fully in sync".
+    # Matching held rows by city name alone is churn-fragile: an intake edit
+    # that respells a held city during the multi-minute run window would miss
+    # held_cities and indict a write that fully succeeded. So a re-proposed row
+    # that STILL has no live Luma page is also expected — this run could never
+    # have written it, whatever it is called now. (Checked only when something
+    # was held; with --allow-missing-luma nothing is, and the verify stays
+    # strict.)
     held_cities = {fold_city(h["city"]) for h in held}
-    leftover_rows = [x for x in after.new_rows
-                     if fold_city(x["city"]) not in held_cities]
+    still_held, leftover_rows = [], []
+    for x in after.new_rows:
+        if fold_city(x["city"]) in held_cities or \
+                (held and luma_status(x["slug"]) != "live"):
+            still_held.append(x)
+        else:
+            leftover_rows.append(x)
     if after.adds or leftover_rows:
         print("VERIFY FAILED — still out of sync after write:")
         for x in after.adds:
@@ -648,7 +671,10 @@ def main():
     if held:
         # Exit 2, the shared drift code: the held rows are still pending work,
         # and a wrapper (nightly.py) must keep seeing them until the pages exist.
-        print("Verified: a fresh run proposes only the %d held-back row(s)." % len(held))
+        # Count what the re-read actually proposes, not len(held) — a held row
+        # deleted from the intake during the run would overstate pending work.
+        print("Verified: a fresh run proposes only held-back row(s) "
+              "(%d still pending)." % len(still_held))
         return 2
     print("Verified: a fresh run proposes zero changes.")
     return 0

--- a/skills/aaif-sync-chapters/scripts/test_nightly.py
+++ b/skills/aaif-sync-chapters/scripts/test_nightly.py
@@ -33,6 +33,11 @@ check("report mode, exit 1 -> failed",
       nightly.classify(1, wrote_marker=False, write_mode=False), nightly.FAILED)
 check("write mode, exit 0 with Verified marker -> wrote+verified",
       nightly.classify(0, wrote_marker=True, write_mode=True), nightly.WROTE)
+# sync_chapters --write exits 2 when it held back a row with no live Luma page —
+# possibly after writing the rest. The pending work is what needs eyes, so DRIFT
+# wins even over the wrote-marker; the log's Verified: line records the write.
+check("write mode, exit 2 -> drift, even when part of the run wrote",
+      nightly.classify(2, wrote_marker=True, write_mode=True), nightly.DRIFT)
 check("write mode, exit 0 without marker -> nothing needed doing",
       nightly.classify(0, wrote_marker=False, write_mode=True), nightly.IN_SYNC)
 check("write mode, nonzero is failed even if the marker printed "

--- a/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
@@ -308,5 +308,35 @@ check("report mode, drift -> exit 2",
 check("write mode with nothing to do -> exit 0",
       exit_code([], [], ["--write"]), 0)
 
+# --- partition_new_rows: a city with no live Luma page holds back, not aborts ---
+# One pending page used to sys.exit the whole write, freezing every OTHER
+# chapter's sync behind a manual step that can lag by weeks.
+def nrow(row, city, luma=None):
+    d = {"row": row, "city": city, "names": ["A"], "slug": fold_city(city)}
+    if luma is not None:
+        d["luma"] = luma
+    return d
+
+_rows = [nrow(82, "Pune", "absent"), nrow(83, "Boston", "live"),
+         nrow(84, "Oslo", "unknown"), nrow(85, "Kyoto", "live")]
+_write, _held = sync_chapters.partition_new_rows(_rows, 81, False)
+check("only live rows are written",
+      [n["city"] for n in _write], ["Boston", "Kyoto"])
+check("absent and unknown are both held",
+      [n["city"] for n in _held], ["Pune", "Oslo"])
+check("written rows are renumbered compactly after last_row (no blank gap)",
+      [n["row"] for n in _write], [82, 83])
+check("the caller's proposal is not mutated",
+      [n["row"] for n in _rows], [82, 83, 84, 85])
+check("a row that never got a luma status is held, not written",
+      sync_chapters.partition_new_rows([nrow(82, "Pune")], 81, False),
+      ([], [nrow(82, "Pune")]))
+_write, _held = sync_chapters.partition_new_rows(_rows, 81, True)
+check("--allow-missing-luma writes everything",
+      ([n["city"] for n in _write], _held),
+      (["Pune", "Boston", "Oslo", "Kyoto"], []))
+check("--allow-missing-luma still renumbers from last_row",
+      [n["row"] for n in _write], [82, 83, 84, 85])
+
 print()
 sys.exit("FAIL: %d test(s) failed" % fails if fails else None)


### PR DESCRIPTION
Three self-contained fixes, one per commit:

## 1. create-chapter: Gall Stereographic map projection
The slide-5 network-map dot is now placed by a Gall Stereographic projection fitted against Natural Earth 110m coastlines composited over `image18.png` (mean residual 0.64 px). Replaces the piecewise-linear `LAT_ANCHORS` and the `PIXEL_OVERRIDES` table entirely — East Asia / Oceania cities land correctly from lat/lon alone. SKILL.md documents the refit procedure for when the map art changes.

## 2. sync-chapters: provision_channels scope check fixed
`channels:manage` is the bot-token sibling of `channels:write` and never appears on a user token, so the up-front scope check rejected every valid user token. Script + SKILL.md prerequisites corrected; `.env` (where the write token lives locally) added to `.gitignore`.

## 3. sync-chapters: hold back new rows with no live Luma page
One pending Luma page used to `sys.exit` the whole chapters-feed write, freezing every other chapter's sync behind a manual step that can lag by weeks. `partition_new_rows()` now splits the proposal: adds and live new rows land; not-live (and unverifiable) cities are held back, named in the output, and re-propose every run — the write exits `2`, the shared drift code, until their pages exist. Held rows never leave a blank row in the feed (written rows are renumbered onto consecutive rows), `--allow-missing-luma` keeps its force-through meaning, and the post-write verify expects held rows to re-propose.

## Testing
- `PYTHONPATH=lib pytest lib/aaif_events/tests`: 121 passed
- all 19 `skills/*/scripts/test_*.py`: pass (7 new tests for `partition_new_rows`)
- `pre-commit run --all-files`: pass; `claude plugin validate .`: pass
- live run: `sync_chapters.py --write` with only Stuttgart pending (Luma not live) holds it back, writes nothing else (nothing else pending), exits 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)