### PR TITLE
Activity audit engine + naming-convention sweep + deprecated-room archive sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ backups/*
 .slack-audit-cache/
 slack-members-audit.*
 slack-organizers-audit.*
+slack-activity-audit.*
 
 # Nightly sync runner output (aaif-sync-chapters nightly.py). Same rule as above:
 # the per-engine logs hold the full reports — names, emails, per-person diffs —

--- a/lib/aaif_events/slack.py
+++ b/lib/aaif_events/slack.py
@@ -49,12 +49,16 @@ API = "https://slack.com/api/"
 
 #: The exact set of methods this repo calls. This is deliberately *not* "every
 #: read-only method" — narrowing it to actual callers is a stronger, self-
-#: maintaining invariant. Adding an entry is a real decision, not a formality:
-#: `conversations.history` is read-only and would still falsify the "no message
-#: data" caveat both reports print on their face.
+#: maintaining invariant. Adding an entry is a real decision, not a formality.
+#:
+#: `conversations.history` was added 2026-08-16, when the audits moved to the
+#: AAIF app token, which carries `channels:history`/`groups:history`. That
+#: falsifies the old "no message data" ceiling: activity is now measurable
+#: (see `history_activity()` / audit_activity.py), and reports that still
+#: print the caveat must scope it to runs on the old CLI token.
 ALLOWED_METHODS = frozenset({
     "auth.test",
-    "conversations.list", "conversations.members",
+    "conversations.list", "conversations.members", "conversations.history",
     "users.list", "users.info", "users.lookupByEmail",
 })
 
@@ -331,6 +335,96 @@ def members(api, channel_id):
     """Member ids of one conversation."""
     return list(api.paged("conversations.members", "members",
                           channel=channel_id, limit=1000))
+
+
+#: Message subtypes that are room plumbing, not conversation. A channel whose
+#: recent "messages" are all joins and topic edits has traffic but no talk, and
+#: the distinction is the whole point of measuring activity.
+NOISE_SUBTYPES = frozenset({
+    "channel_join", "channel_leave", "channel_topic", "channel_purpose",
+    "channel_name", "channel_archive", "channel_unarchive",
+    "group_join", "group_leave", "group_topic", "group_purpose", "group_name",
+    "bot_add", "bot_remove", "reminder_add", "tombstone",
+})
+
+
+def history_activity(api, channel_id, oldest, max_scan=5000, include_posters=False):
+    """Activity stats for one conversation. Retains NO message text.
+
+    Needs `channels:history` (public) / `groups:history` (private) — scopes the
+    Slack CLI token never had. Pages newest-first and stops as soon as it has
+    crossed `oldest` (epoch seconds) *and* found the most recent human message,
+    so a dead channel still gets a truthful "last heard from" even when that
+    predates the window.
+
+    Returns a dict of counts and timestamps only:
+
+    - `last_ts` — newest message of any kind, or None for an empty channel.
+    - `last_human_ts` — newest message written by a person (no subtype, or
+      `thread_broadcast`). None means none was found within `max_scan`
+      messages, which for any channel with traffic means "nothing human in a
+      long time", not "never" — `last_human_unknown` says which.
+    - `human_msgs` / `bot_msgs` / `joins` — counts within the window.
+    - `posters` — distinct humans who wrote in the window.
+    - `poster_ids` — those humans' user ids, only when `include_posters` is
+      set. Ids, never message text; the member audit unions them across
+      channels into "people seen posting", which one channel's count cannot
+      answer.
+    - `window_complete` — False when `max_scan` ran out before reaching
+      `oldest`; the window counts are then floors, and callers must say so
+      rather than rank a truncated channel below a fully-scanned one.
+
+    Thread replies are NOT included: `conversations.history` returns only
+    channel-level messages (plus `thread_broadcast`). Every count here is
+    therefore a floor on real conversation, and the reports must say so.
+    """
+    last_ts = None
+    last_human_ts = None
+    human_msgs = bot_msgs = joins = 0
+    posters = set()
+    scanned = 0
+    crossed_oldest = False
+
+    for m in api.paged("conversations.history", "messages",
+                       channel=channel_id, limit=200):
+        ts = float(m["ts"])
+        scanned += 1
+        if last_ts is None:
+            last_ts = ts
+        subtype = m.get("subtype")
+        human = "user" in m and subtype in (None, "thread_broadcast") \
+            and not m.get("bot_id")
+        if human and last_human_ts is None:
+            last_human_ts = ts
+        if ts >= oldest:
+            if human:
+                human_msgs += 1
+                posters.add(m["user"])
+            elif subtype == "bot_message" or m.get("bot_id"):
+                bot_msgs += 1
+            elif subtype in ("channel_join", "group_join"):
+                joins += 1
+        else:
+            crossed_oldest = True
+            if last_human_ts is not None:
+                break
+        if scanned >= max_scan:
+            break
+
+    out = {
+        "last_ts": last_ts,
+        "last_human_ts": last_human_ts,
+        "last_human_unknown": last_human_ts is None and last_ts is not None,
+        "human_msgs": human_msgs,
+        "bot_msgs": bot_msgs,
+        "joins": joins,
+        "posters": len(posters),
+        "window_complete": crossed_oldest or scanned < max_scan,
+        "scanned": scanned,
+    }
+    if include_posters:
+        out["poster_ids"] = sorted(posters)
+    return out
 
 
 def lookup_emails(api, emails, progress=None):

--- a/lib/aaif_events/slack.py
+++ b/lib/aaif_events/slack.py
@@ -72,6 +72,18 @@ MODULE_ERRORS = frozenset({
 })
 
 MAX_ATTEMPTS = 6
+
+
+def _retry_secs(value, default=5):
+    """A usable sleep out of whatever Retry-After held.
+
+    The header may be an HTTP-date or a fractional string; a ValueError here
+    would abort a long paged pull for a condition the retry exists to absorb.
+    """
+    try:
+        return max(1, int(float(value)))
+    except (TypeError, ValueError):
+        return default
 #: Slack's own read timeout is generous; ours bounds a half-open socket so a
 #: 20-minute directory pull cannot hang forever with no output.
 TIMEOUT_S = 30
@@ -163,7 +175,7 @@ class Slack:
             except urllib.error.HTTPError as exc:
                 if exc.code == 429 and attempt < MAX_ATTEMPTS - 1:
                     last = "http_429"
-                    self._sleep(int(exc.headers.get("Retry-After", "5")))
+                    self._sleep(_retry_secs(exc.headers.get("Retry-After")))
                     continue
                 # One vocabulary out of call(): a caller writing `except
                 # SlackError` must not miss the final 429 or a 5xx.
@@ -184,7 +196,7 @@ class Slack:
                 last = "ratelimited"
                 if attempt == MAX_ATTEMPTS - 1:
                     break          # no point sleeping before giving up
-                self._sleep(int(payload.get("retry_after", 5)))
+                self._sleep(_retry_secs(payload.get("retry_after")))
                 continue
             return payload
         raise SlackError(method, "retry_exhausted",
@@ -335,17 +347,6 @@ def members(api, channel_id):
     """Member ids of one conversation."""
     return list(api.paged("conversations.members", "members",
                           channel=channel_id, limit=1000))
-
-
-#: Message subtypes that are room plumbing, not conversation. A channel whose
-#: recent "messages" are all joins and topic edits has traffic but no talk, and
-#: the distinction is the whole point of measuring activity.
-NOISE_SUBTYPES = frozenset({
-    "channel_join", "channel_leave", "channel_topic", "channel_purpose",
-    "channel_name", "channel_archive", "channel_unarchive",
-    "group_join", "group_leave", "group_topic", "group_purpose", "group_name",
-    "bot_add", "bot_remove", "reminder_add", "tombstone",
-})
 
 
 def history_activity(api, channel_id, oldest, max_scan=5000, include_posters=False):

--- a/lib/aaif_events/tests/test_slack.py
+++ b/lib/aaif_events/tests/test_slack.py
@@ -226,3 +226,76 @@ def test_lookup_emails_dedupes_and_skips_blanks(monkeypatch):
 ])
 def test_find_token_walks_arbitrary_shapes(blob, expected):
     assert slack._find_token(blob) == expected
+
+
+# --- history_activity: the classification every activity verdict rests on -----
+class _HistoryApi:
+    """A fake api whose paged() replays canned history messages."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    def paged(self, method, key, **params):
+        assert method == "conversations.history"
+        yield from self._messages
+
+
+def _msg(ts, user=None, subtype=None, bot_id=None):
+    m = {"ts": str(ts)}
+    if user:
+        m["user"] = user
+    if subtype:
+        m["subtype"] = subtype
+    if bot_id:
+        m["bot_id"] = bot_id
+    return m
+
+
+def test_history_activity_classifies_humans_bots_and_joins():
+    api = _HistoryApi([
+        _msg(100, user="U1"),                       # human
+        _msg(90, user="U2", subtype="thread_broadcast"),  # human
+        _msg(80, user="U1", bot_id="B1"),           # bot even with "user"
+        _msg(70, subtype="bot_message", bot_id="B1"),
+        _msg(60, user="U3", subtype="channel_join"),
+        _msg(50, user="U3", subtype="channel_topic"),  # plumbing: no bucket
+    ])
+    out = slack.history_activity(api, "C1", oldest=10, include_posters=True)
+    assert (out["human_msgs"], out["bot_msgs"], out["joins"]) == (2, 2, 1)
+    assert out["posters"] == 2
+    assert out["poster_ids"] == ["U1", "U2"]
+    assert out["last_human_ts"] == 100.0
+    assert out["window_complete"] is True
+
+
+def test_history_activity_dead_channel_reports_last_human_beyond_window():
+    api = _HistoryApi([
+        _msg(30, subtype="bot_message", bot_id="B1"),   # in window
+        _msg(5, user="U1"),                             # human, BEFORE oldest
+    ])
+    out = slack.history_activity(api, "C1", oldest=10)
+    assert out["human_msgs"] == 0                       # window is truthful
+    assert out["last_human_ts"] == 5.0                  # but the answer exists
+    assert out["last_human_unknown"] is False
+    assert out["window_complete"] is True
+
+
+def test_history_activity_truncation_is_a_floor_not_a_measurement():
+    api = _HistoryApi([_msg(100 - i, user="U1") for i in range(10)])
+    out = slack.history_activity(api, "C1", oldest=1, max_scan=3)
+    assert out["scanned"] == 3
+    assert out["window_complete"] is False
+    assert out["human_msgs"] == 3
+
+
+def test_history_activity_empty_channel():
+    out = slack.history_activity(_HistoryApi([]), "C1", oldest=10)
+    assert out["last_ts"] is None
+    assert out["last_human_unknown"] is False
+    assert "poster_ids" not in out
+
+
+def test_retry_secs_never_raises():
+    assert [slack._retry_secs(v) for v in
+            ("Fri, 21 Aug 2026 07:28:00 GMT", None, "", "2.5", "30", -3)] \
+        == [5, 5, 5, 2, 30, 1]

--- a/skills/aaif-audit-slack/SKILL.md
+++ b/skills/aaif-audit-slack/SKILL.md
@@ -140,7 +140,7 @@ columns on the AAIF Community Chapters List**, read straight off the sheet by
 
 | Column | Was | Means |
 |---|---|---|
-| `Slack Channel` | `public` | the chapter's own channel, where the slug convention doesn't hold (`Denver → colorado`, `Munich → munchen`, `Washington DC → washington-dc-the-capital`) |
+| `Slack Channel` | `public` | the chapter's own channel, where the slug convention doesn't hold (`San Francisco → bay-area`, `Madrid → españa`) |
 | `Organizer Channel` | `organizers` | its organizer channel, where not named `<city>-organizers` |
 | `Country Channel` | `regional` | a channel that *serves* the city without being its own (`Chennai → india`, `Lagos → africa`). Reported as **regional only**, never counted as chapter coverage — a member there has no local room. |
 

--- a/skills/aaif-audit-slack/SKILL.md
+++ b/skills/aaif-audit-slack/SKILL.md
@@ -140,7 +140,7 @@ columns on the AAIF Community Chapters List**, read straight off the sheet by
 
 | Column | Was | Means |
 |---|---|---|
-| `Slack Channel` | `public` | the chapter's own channel, where the slug convention doesn't hold (`San Francisco → bay-area`, `Madrid → españa`) |
+| `Slack Channel` | `public` | the chapter's own channel, where the slug convention doesn't hold (`San Francisco → bay-area`; NOT `Madrid → españa` — that's a country room, and filing it here falsely reports coverage) |
 | `Organizer Channel` | `organizers` | its organizer channel, where not named `<city>-organizers` |
 | `Country Channel` | `regional` | a channel that *serves* the city without being its own (`Chennai → india`, `Lagos → africa`). Reported as **regional only**, never counted as chapter coverage — a member there has no local room. |
 

--- a/skills/aaif-audit-slack/SKILL.md
+++ b/skills/aaif-audit-slack/SKILL.md
@@ -6,16 +6,20 @@ argument-hint: '[organizers|members|both] [--refresh] [--out NAME] [--no-pdf]'
 
 # AAIF Slack Audit
 
-Two engines over one workspace, same house rules — **everything is read-only**,
-and neither engine can measure message activity (see the ceiling below).
+Three engines over one workspace, same house rules — **everything is read-only**.
 
 | Engine | Script | Answers |
 |---|---|---|
 | Organizers | `audit_organizers.py` | does each chapter have a home, and are the people we accepted in it? |
 | Members | `audit_members.py` | what does the workspace look like to an ordinary member? |
+| Activity | `audit_activity.py` | who is actually talking, where — last human message and message volume per channel |
 
 Run whichever the user asked for. "Audit Slack" with no side named means **both**
-— run the organizer engine first; it is the one with decisions attached.
+of the first two — run the organizer engine first; it is the one with decisions
+attached. The activity engine needs a history-scoped token (see the ceiling
+below) and answers questions about dead channels, engagement and posting volume;
+its cache also feeds the member report's "posted recently" figure, so run it
+before the member engine when both are wanted.
 
 > **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
 > file goes through the `gws` CLI, driven from Python. **Prefer native Google
@@ -47,13 +51,18 @@ printed.
 
 # The ceiling — state this in any summary you write
 
-**Neither engine can measure activity.** The Slack CLI token carries no
+**Which ceiling applies depends on the token.** The Slack CLI token carries no
 `channels:history` and no `search:read`, and `conversations.history` returns
-`missing_scope` even for public channels. *Last message posted*, *messages per
-week* and *is this channel alive* are **unreadable**, not merely unmeasured.
-(`lib/aaif_events/slack.py` holds the authoritative scope list, and
-`Slack.scopes()` reports the live one — trust those over any list written down
-here or there.)
+`missing_scope` even for public channels — on that token, *last message posted*
+and *is this channel alive* are **unreadable**, and the organizer/member reports
+print exactly that. The **AAIF app token** (`AAIF_SLACK_WRITE_TOKEN` in the
+user's `.env`, added 2026-08-16) DOES carry `channels:history`/`groups:history`
+— `conversations.history` is in the client's allowlist for it, and
+`audit_activity.py` is the engine built on it. Even then the numbers are
+**floors**: thread replies are invisible to `conversations.history`, and the
+reports say so on their face. (`lib/aaif_events/slack.py` holds the
+authoritative scope list, and `Slack.scopes()` reports the live one — trust
+those over any list written down here or there.)
 
 Both engines check their required scopes **before** collecting anything —
 including `groups:read`, which the private-channel half of `conversations.list`
@@ -100,6 +109,13 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/audit_organizers.py
 
 Writes `slack-organizers-audit.html` + `.pdf`, and a machine-readable
 `audit.json` in the cache directory.
+
+`--planned-ok` exists for the **pre-provisioning** state: the Chapters List
+names the channel each chapter *will* have before `provision_channels.py` has
+created it, and without the flag every such name aborts the run as a
+rename/archive bug. With it, they are downgraded to "planned" in the
+data-quality notes and the chapter truthfully reports as having no channel.
+Drop the flag once provisioning has run, so the abort protects the map again.
 
 | Source | Read | Used for |
 |---|---|---|
@@ -242,6 +258,33 @@ email-domain breakdown · the limits, restated on the page.
 - **Zero guest accounts is a governance fact, not a bug** — but it means every
   member can be added to any private channel, which is why the organizer
   channels need care. The two engines meet on this point.
+
+---
+
+# 3. Activity engine
+
+Per live channel: last *human* message (plumbing subtypes and bots excluded),
+message volume, distinct posters and join noise over a trailing window
+(`--days`, default 90). **No message text is ever retained** — timestamps,
+counts and poster ids only, in the same 0600 cache as everything else.
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/audit_activity.py
+```
+
+Writes `slack-activity-audit.html` + `.pdf`. Reuses the shared channel cache;
+its per-channel pulls are resumable within a UTC day, so an interrupted sweep
+continues instead of restarting. When `audit.json` from the organizer engine is
+present, the report includes a per-chapter activity table joined from it.
+
+## Reading the results
+
+- **Every count is a floor.** Thread replies are invisible except broadcasts; a
+  channel that lives in threads under-counts. The page states this.
+- **A truncated scan is marked**, not ranked as fully measured.
+- **The member report picks up this engine's cache** and turns the union of
+  poster ids into "posted in the last N days" — writers only, so it is an
+  engagement floor, never a lurker count.
 
 ---
 

--- a/skills/aaif-audit-slack/scripts/audit_activity.py
+++ b/skills/aaif-audit-slack/scripts/audit_activity.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Audit real message activity per channel: the number the other two can't see.
+
+The organizer and member audits ran on the Slack CLI token, which has no
+history scope, so both print "activity is unreadable" on their face. The AAIF
+app token carries `channels:history` / `groups:history`, and this script is
+the extension that note in audit_members.py asks for: for every live channel
+the token can see, the date of the last *human* message and the volume of
+conversation in a trailing window.
+
+Everything here is read-only, and **no message text is retained** — the cache
+and the report hold timestamps and counts only (see
+`aaif_events.slack.history_activity`). The channel list is reused from the
+shared audit cache.
+
+Known floors, stated on the page rather than papered over:
+
+- Thread replies are invisible to `conversations.history` (except broadcasts),
+  so every count is a floor on real conversation.
+- Private channels are limited to those the token owner belongs to.
+- A channel whose scan hit the message cap before crossing the window is
+  reported as truncated, not ranked as if fully measured.
+"""
+
+import argparse
+import datetime as dt
+import html
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib"))
+
+from aaif_events import jsoncache  # noqa: E402
+from aaif_events import report_style as rs  # noqa: E402
+from aaif_events.slack import Slack, channels, history_activity  # noqa: E402
+
+e = html.escape
+
+#: Buckets for "days since the last human message". Order is render order.
+AGE_BUCKETS = (("this week", 0, 7), ("this month", 8, 31),
+               ("this quarter", 32, 92), ("this year", 93, 365),
+               ("1-2 years", 366, 730), ("over 2 years", 731, 10 ** 9))
+
+
+def cached_channels(api, cache_dir, refresh, team_id):
+    path = os.path.join(cache_dir, "channels.json")
+    data = jsoncache.read(path, refresh, team_id, note=print)
+    if data is not None:
+        print("  reusing channel list (%d, %s)" % (len(data), jsoncache.age(path)))
+        return data
+    print("  fetching channels ...")
+    data = channels(api)
+    jsoncache.write(path, data, team_id)
+    return data
+
+
+def chapter_channel_names(cache_dir):
+    """{channel name: city} for channels the organizer audit tied to a chapter.
+
+    Read from the organizer audit's own output, so the two reports can never
+    disagree about which channel is whose. Empty when that audit hasn't run —
+    the chapter section is then omitted rather than re-derived badly here.
+    """
+    path = os.path.join(cache_dir, "audit.json")
+    data = jsoncache.read(path)
+    if data is None:
+        return {}
+    out = {}
+    for c in data.get("chapters", []):
+        for key in ("public", "organizers_channel", "regional"):
+            if c.get(key):
+                out.setdefault(c[key], c["city"])
+    return out
+
+
+def collect(api, live, cache_dir, days, refresh, team_id, now_ts):
+    """Per-channel activity stats, resumable: partial pulls are cached.
+
+    Activity data ages, so entries are reused only within the same UTC day
+    unless --refresh forces a full re-pull — fresh enough for a report, cheap
+    enough that an interrupted 15-minute sweep resumes instead of restarting.
+    """
+    path = os.path.join(cache_dir, "activity.json")
+    stats = (jsoncache.read(path, refresh, team_id, note=print)
+             if not refresh else None) or {}
+    today = dt.datetime.fromtimestamp(now_ts, dt.timezone.utc).date().isoformat()
+    stats = {k: v for k, v in stats.items() if v.get("day") == today}
+    if stats:
+        print("  resuming: %d channels already pulled today" % len(stats))
+
+    oldest = now_ts - days * 86400
+    todo = [c for c in live if c["id"] not in stats]
+    for i, c in enumerate(todo, 1):
+        # poster_ids feed audit_members' "people seen posting" union — ids
+        # only, in the same 0600 cache that already holds the full directory.
+        rec = history_activity(api, c["id"], oldest, include_posters=True)
+        rec["day"] = today
+        rec["window_days"] = days
+        stats[c["id"]] = rec
+        if i % 20 == 0 or i == len(todo):
+            jsoncache.write(path, stats, team_id)
+            print("    %d/%d channels ..." % (i, len(todo)), flush=True)
+    jsoncache.write(path, stats, team_id)
+    return stats
+
+
+def build_report(live, stats, chapter_of, days, today):
+    def age_days(ts):
+        return int((today.timestamp() - ts) // 86400)
+
+    rows = []
+    for c in live:
+        s = stats[c["id"]]
+        rows.append({**c, **s,
+                     "age": age_days(s["last_human_ts"]) if s["last_human_ts"] else None,
+                     "city": chapter_of.get(c["name"])})
+
+    talked = [r for r in rows if r["human_msgs"]]
+    silent_window = [r for r in rows if not r["human_msgs"] and r["window_complete"]]
+    truncated = [r for r in rows if not r["window_complete"]]
+    never_seen = [r for r in rows if r["last_human_ts"] is None]
+
+    age_rows = [(lbl, sum(1 for r in rows if r["age"] is not None and lo <= r["age"] <= hi))
+                for lbl, lo, hi in AGE_BUCKETS]
+    age_rows.append(("no human message found", len(never_seen)))
+    got = sum(n for _, n in age_rows)
+    if got != len(rows):
+        raise SystemExit("ABORT: the last-message histogram accounts for %d of %d "
+                         "channels — the buckets are wrong." % (got, len(rows)))
+
+    busiest = sorted(talked, key=lambda r: -r["human_msgs"])[:15]
+    busy_html = "".join(
+        '<tr><td><code class="chan">#%s</code>%s</td><td>%s</td>'
+        '<td>%d</td><td>%d</td></tr>'
+        % (e(r["name"]), " <span class=\"pill pill-mute\">%s</span>" % e(r["city"]) if r["city"] else "",
+           format(r["human_msgs"], ",") + ("+" if not r["window_complete"] else ""),
+           r["posters"], r["num_members"] or 0)
+        for r in busiest)
+
+    chap = sorted((r for r in rows if r["city"]), key=lambda r: (r["age"] is None, r["age"] or 0))
+    chap_html = "".join(
+        '<tr><td>%s</td><td><code class="chan">#%s</code></td><td>%s</td>'
+        '<td>%d</td><td>%d</td></tr>'
+        % (e(r["city"]), e(r["name"]),
+           ("no human message found" if r["age"] is None
+            else "today" if r["age"] == 0 else "%d days ago" % r["age"]),
+           r["human_msgs"], r["posters"])
+        for r in chap)
+
+    quiet_chap = [r for r in chap if r["age"] is None or r["age"] > 92]
+    todo = []
+    if quiet_chap:
+        todo.append((
+            "Check on %d chapter channels silent for a quarter or more" % len(quiet_chap),
+            "No human has posted in over 90 days in: "
+            + ", ".join("#%s" % r["name"] for r in quiet_chap[:12])
+            + (" and more" if len(quiet_chap) > 12 else "")
+            + ". A silent room greets every newcomer the chapter sends there.",
+            "1 hour", "Community leadership", "now"))
+    old = [r for r in rows if r["age"] is not None and r["age"] > 730 and not r["city"]]
+    if old:
+        todo.append((
+            "Review %d non-chapter channels with no human message in 2+ years" % len(old),
+            "Candidates for archiving; each one adds noise to channel browsing "
+            "for every member. This report names them; archiving stays a human call.",
+            "2 hours", "Workspace admin", "next"))
+
+    stamp = today.strftime("%-d %B %Y")
+    pct = lambda n: "%d%%" % round(100 * n / (len(rows) or 1))  # noqa: E731
+    body = f"""
+<header>
+  <div class="eyebrow">Channel-activity Slack audit &middot; {stamp}</div>
+  <h1>Who is actually talking, where</h1>
+  <p class="lede">For every live channel the audit token can see: when a person last posted, and how
+  much conversation the last {days} days held. This is the measurement the other two audits could
+  not make — their token had no history scope. No message text was retained.</p>
+</header>
+
+<div class="caveat"><strong>Every count is a floor.</strong> Thread replies are invisible to
+<code class="chan">conversations.history</code>, so a channel that lives in threads under-counts
+here. Private channels are limited to the {sum(1 for r in rows if r["is_private"])} the token
+owner belongs to. {len(truncated)} very busy channel(s) hit the scan cap and are marked
+&ldquo;+&rdquo;.</div>
+
+<section>
+  <div class="eyebrow">The numbers</div>
+  <div class="stats">
+    <div class="stat"><span class="v">{len(rows)}</span><span class="k">Live channels measured</span></div>
+    <div class="stat s-ok"><span class="v">{pct(len(talked))}</span><span class="k">Had a human message in {days} days</span></div>
+    <div class="stat s-warn"><span class="v">{pct(len(silent_window))}</span><span class="k">Silent all window</span></div>
+    <div class="stat s-bad"><span class="v">{len(never_seen)}</span><span class="k">No human message found at all</span></div>
+  </div>
+</section>
+
+<section>
+  <div class="eyebrow">Last human message</div>
+  {rs.bars(age_rows)}
+</section>
+
+<section>
+  <div class="eyebrow">Busiest channels, last {days} days</div>
+  <div class="tablewrap"><table><thead><tr><th>Channel</th><th class="n">Human msgs</th>
+  <th class="n">People</th><th class="n">Members</th></tr></thead>{busy_html}</table></div>
+</section>
+
+{('<section><div class="eyebrow">Chapter channels</div>'
+  '<div class="tablewrap"><table><thead><tr><th>Chapter</th><th>Channel</th>'
+  '<th>Last human message</th><th class="n">Msgs (%d d)</th><th class="n">People</th>'
+  '</tr></thead>%s</table></div></section>' % (days, chap_html))
+ if chap else ''}
+
+<section>
+  <div class="eyebrow">What to do</div>
+  {rs.actions(todo) if todo else '<p>Nothing urgent: no chapter channel has gone quiet.</p>'}
+</section>
+"""
+    return rs.page("Slack channel activity — %s" % stamp, body)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="slack-activity-audit")
+    ap.add_argument("--cache", default=".slack-audit-cache")
+    ap.add_argument("--days", type=int, default=90,
+                    help="trailing window for message counts (default 90)")
+    ap.add_argument("--refresh", action="store_true",
+                    help="re-pull every channel even if pulled today")
+    ap.add_argument("--no-pdf", action="store_true")
+    args = ap.parse_args()
+
+    # The report names channels and how dead they are; the cache holds only
+    # counts. Same public-repo rule as the other two audits regardless.
+    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html", args.out + ".pdf")
+    os.makedirs(args.cache, exist_ok=True)
+    os.chmod(args.cache, 0o700)
+
+    api = Slack()
+    api.require_scopes("channels:read", "groups:read",
+                       "channels:history", "groups:history")
+    who = api.ok("auth.test")
+    team_id = who.get("team_id")
+    print("workspace: %s (%s)" % (who.get("team"), team_id))
+
+    chans = cached_channels(api, args.cache, args.refresh, team_id)
+    live = sorted((c for c in chans if not c["is_archived"]),
+                  key=lambda c: -(c["num_members"] or 0))
+    print("  %d live channels to measure (~3s each on first pull)" % len(live))
+
+    now = dt.datetime.now(dt.timezone.utc)
+    stats = collect(api, live, args.cache, args.days, args.refresh,
+                    team_id, now.timestamp())
+
+    html_doc = build_report(live, stats, chapter_channel_names(args.cache),
+                            args.days, now)
+    html_path = args.out + ".html"
+    with open(html_path, "w", encoding="utf-8") as fh:
+        fh.write(html_doc)
+    os.chmod(html_path, 0o600)
+    print("wrote %s" % html_path)
+    if not args.no_pdf:
+        print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),
+                                     os.path.abspath(args.out + ".pdf")))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-audit-slack/scripts/audit_activity.py
+++ b/skills/aaif-audit-slack/scripts/audit_activity.py
@@ -84,7 +84,10 @@ def collect(api, live, cache_dir, days, refresh, team_id, now_ts):
     stats = (jsoncache.read(path, refresh, team_id, note=print)
              if not refresh else None) or {}
     today = dt.datetime.fromtimestamp(now_ts, dt.timezone.utc).date().isoformat()
-    stats = {k: v for k, v in stats.items() if v.get("day") == today}
+    # Same day AND same window: a 90-day count rendered under a --days 30
+    # headline is a wrong number that looks fully measured.
+    stats = {k: v for k, v in stats.items()
+             if v.get("day") == today and v.get("window_days") == days}
     if stats:
         print("  resuming: %d channels already pulled today" % len(stats))
 

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -4,9 +4,10 @@
 Collects channel metadata and the full user directory, then renders a
 self-contained HTML report and (unless --no-pdf) a PDF beside it.
 
-Everything here is read-only. Nothing measures message activity — the audit
-token has no history or search scope — and the report says so on its face
-rather than dressing up a proxy as engagement.
+Everything here is read-only, and this engine reads no messages itself. When
+audit_activity.py's cache is present it reports a posted-recently FLOOR from
+that sweep's poster ids; without it, the report says on its face that nothing
+measures message activity rather than dressing up a proxy as engagement.
 """
 
 import argparse
@@ -395,7 +396,10 @@ def main():
     if act:
         ids = {u for rec in act.values() for u in rec.get("poster_ids", ())}
         if ids:
-            days = next(iter(act.values())).get("window_days", 90)
+            # The widest window present. Entries can disagree only when a
+            # stale file mixes sweeps; every count is still within max(N)
+            # days, so the "posted in the last N days" floor stays truthful.
+            days = max(rec.get("window_days", 90) for rec in act.values())
             activity = {"poster_ids": ids, "days": days, "channels": len(act),
                         "age": jsoncache.age(act_path)}
             print("  activity sweep found: %d channels, %d distinct posters"

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -62,7 +62,7 @@ def cached(path, build, refresh=False, label="", team_id=None):
     return data
 
 
-def build_report(chans, directory, today):
+def build_report(chans, directory, today, activity=None):
     def age(epoch):
         if not epoch:
             return None
@@ -153,7 +153,50 @@ def build_report(chans, directory, today):
     unconf_unknown = sum(1 for u in active if u["is_email_confirmed"] is None)
     guests = sum(1 for u in active if u["is_restricted"] or u["is_ultra_restricted"])
 
+    # Measured engagement, when the activity sweep has run on a history-scoped
+    # token. `posted` counts active humans seen writing a channel-level message
+    # in the window — a FLOOR: thread-only repliers, readers and invisible
+    # private rooms are all missed, and the page must say so where it shows the
+    # number, not in a footnote.
+    posted = None
+    if activity and activity.get("poster_ids"):
+        posted = sum(1 for u in active if u["id"] in activity["poster_ids"])
+
     stamp = today.strftime("%-d %B %Y")
+    if posted is None:
+        caveat = """
+<div class="caveat"><strong>What this cannot tell you: message activity.</strong>
+The audit token has no <code class="chan">channels:history</code> and no
+<code class="chan">search:read</code>, so <em>last message posted</em> is unreadable and no
+figure below is derived from one. The channel <code class="chan">updated</code> field is not
+a substitute — a bulk migration reset it in blocks. For real activity use the admin
+<strong>Analytics &rarr; Channels / Members</strong> CSV export.</div>"""
+        activity_stat = ""
+        activity_limit = ("<li><strong>No message data.</strong> Nothing here measures whether "
+                          "a channel is <em>talking</em> — only whether it exists, who is in "
+                          "it, and how it is described.</li>")
+        activity_foot = "No message content was read, and none could be."
+    else:
+        caveat = f"""
+<div class="caveat"><strong>Message activity is measured — as a floor.</strong> The
+&ldquo;posted recently&rdquo; figure comes from sweeping
+<code class="chan">conversations.history</code> across {activity["channels"]} live channels
+({activity["age"]}). It counts people who <em>wrote a channel-level message</em>: thread-only
+replies are invisible to the API, private channels are limited to the audit account's
+{len(priv)}, and readers leave no trace. For last-active dates that include readers, the admin
+<strong>Analytics &rarr; Members</strong> CSV export remains the authority.</div>"""
+        activity_stat = (
+            '<div class="stat s-warn"><span class="v">%s</span>'
+            '<span class="k">Posted in last %d days (floor)</span></div>'
+            % (format(posted, ","), activity["days"]))
+        activity_limit = ("<li><strong>Posting is the only activity measured.</strong> "
+                          "%s of %s active humans were seen writing in %d days — a floor "
+                          "that misses thread replies, invisible private rooms and every "
+                          "silent reader.</li>"
+                          % (format(posted, ","), format(len(active), ","), activity["days"]))
+        activity_foot = ("Message timestamps and author ids were read via "
+                         "<code class=\"chan\">conversations.history</code>; "
+                         "no message text was retained.")
     body = f"""
 <header>
   <div class="eyebrow">Member-side workspace audit &middot; {stamp}</div>
@@ -163,12 +206,7 @@ def build_report(chans, directory, today):
   behind the {len(active):,}-member headline are real, active people.</p>
 </header>
 
-<div class="caveat"><strong>What this cannot tell you: message activity.</strong>
-The audit token has no <code class="chan">channels:history</code> and no
-<code class="chan">search:read</code>, so <em>last message posted</em> is unreadable and no
-figure below is derived from one. The channel <code class="chan">updated</code> field is not
-a substitute — a bulk migration reset it in blocks. For real activity use the admin
-<strong>Analytics &rarr; Channels / Members</strong> CSV export.</div>
+{caveat}
 
 <section>
   <div class="eyebrow">Channels</div>
@@ -230,6 +268,7 @@ a substitute — a bulk migration reset it in blocks. For real activity use the 
     <div class="stat s-warn"><span class="v">{len(deact):,}</span><span class="k">Deactivated</span></div>
     <div class="stat"><span class="v">{len(bots)}</span><span class="k">Bots &amp; apps</span></div>
     <div class="stat"><span class="v">{sum(1 for u in active if u['is_admin'])}</span><span class="k">Admins</span></div>
+    {activity_stat}
   </div>
   <div class="two" style="margin-top:22px">
     <div class="card"><h3>How real the roster is</h3>
@@ -268,8 +307,7 @@ a substitute — a bulk migration reset it in blocks. For real activity use the 
   <div class="eyebrow">Honest limits</div>
   <h2>What this report is not built on</h2>
   <ul class="plain">
-    <li><strong>No message data.</strong> Nothing here measures whether a channel is
-    <em>talking</em> — only whether it exists, who is in it, and how it is described.</li>
+    {activity_limit}
     <li><strong>Private channels are undercounted.</strong> Only the {len(priv)} the audit account
     belongs to were visible. Probing other people's memberships does not help:
     <code class="chan">users.conversations</code> filters results to the caller's own visibility.
@@ -282,7 +320,7 @@ a substitute — a bulk migration reset it in blocks. For real activity use the 
 <code class="chan">conversations.list</code>
 ({len(chans)} conversations, public and private, archived included) and
 <code class="chan">users.list</code> ({len(directory):,} accounts).
-No message content was read, and none could be.</footer>
+{activity_foot}</footer>
 """
     return rs.page("Slack Members Audit", body)
 
@@ -346,7 +384,25 @@ def main():
             "every count on the page. Re-run with --refresh."
             % (active_humans, general["name"], general["num_members"]))
 
-    html_doc = build_report(chans, directory, dt.datetime.now(dt.timezone.utc))
+    # Engagement, when audit_activity.py has run on a history-scoped token:
+    # union its per-channel poster ids into "people seen posting". Entries
+    # without poster_ids come from a pre-poster-ids pull and contribute
+    # nothing; if none carry ids, the report falls back to the no-message-data
+    # framing rather than printing a zero that means "not measured".
+    activity = None
+    act_path = os.path.join(args.cache, "activity.json")
+    act = jsoncache.read(act_path, team_id=team_id, note=print)
+    if act:
+        ids = {u for rec in act.values() for u in rec.get("poster_ids", ())}
+        if ids:
+            days = next(iter(act.values())).get("window_days", 90)
+            activity = {"poster_ids": ids, "days": days, "channels": len(act),
+                        "age": jsoncache.age(act_path)}
+            print("  activity sweep found: %d channels, %d distinct posters"
+                  % (len(act), len(ids)))
+
+    html_doc = build_report(chans, directory, dt.datetime.now(dt.timezone.utc),
+                            activity)
     html_path = args.out + ".html"
     # Explicit UTF-8: channel and person names carry accents and the page uses
     # em dashes; the locale default would mangle or refuse them.

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -350,8 +350,8 @@ def main():
     team_id = who.get("team_id")
     print("workspace: %s (%s)" % (who.get("team"), team_id))
     if "channels:history" in have:
-        print("  note: this token HAS channels:history — the report's 'no message data'")
-        print("        caveat is now false and the script should be extended.")
+        print("  note: this token has channels:history — run audit_activity.py "
+              "first and the report includes measured posting activity.")
 
     chans = cached(os.path.join(args.cache, "channels.json"),
                    lambda: channels(api), args.refresh, "channel list", team_id)

--- a/skills/aaif-audit-slack/scripts/audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/audit_organizers.py
@@ -336,7 +336,8 @@ def _resolve_alias(city, table, by_name):
 
     `how` is one of: "" (the map was silent), "known-none", "alias", or
     "alias-missing:<name>". Callers must run assert_aliases_resolve() to rule
-    out the last, which is always a configuration bug.
+    out the last, which is always a configuration bug — or, pre-provisioning,
+    mark_planned_aliases() to downgrade it to "planned:<name>".
     """
     if city not in table:
         return None, ""
@@ -465,6 +466,30 @@ def assert_aliases_resolve(rows, source=CHAPTERS_TAB):
             "reported as having no channel at all."
             % (len(broken), source,
                "\n  ".join("%s -> #%s" % (c, n) for c, n in broken), NO_RESOURCE))
+
+
+def mark_planned_aliases(rows):
+    """Downgrade unresolvable aliases to "planned" instead of aborting.
+
+    Before provision_channels.py has run, the Chapters List names the channel
+    each chapter *will* have (`sync_resources.py --plan` fills it ahead of
+    creation), so a name that does not resolve is the unexecuted plan, not a
+    rename/archive bug. Only reachable via --planned-ok; the default abort
+    stays, because once provisioning has run a missing alias IS a
+    configuration bug again.
+
+    The chapter is still reported as having no channel — that is the truthful
+    current state — but the report's data-quality notes list these as planned
+    rather than letting them blend into "nobody ever made a room".
+    """
+    planned = []
+    for r in rows:
+        for k in ("public_how", "organizers_how", "regional_how"):
+            if r[k].startswith("alias-missing:"):
+                name = r[k].split(":", 1)[1]
+                r[k] = "planned:" + name
+                planned.append((r["city"], name))
+    return planned
 
 
 def build_audit(rows, people, slack_ids, membership, directory, staff_domain):
@@ -747,6 +772,19 @@ def render(audit, orphans, dupes, today):
         notes.append("<li><strong>%d chapters were matched by a curated alias</strong> rather than "
                      "by name, so their coverage is only as good as the Chapters List: %s.</li>"
                      % (len(aliased), ", ".join(e(c["city"]) for c in aliased)))
+    planned = sorted({(c["city"], c[k].split(":", 1)[1])
+                      for c in audit
+                      for k in ("public_how", "organizers_how", "regional_how")
+                      if c[k].startswith("planned:")})
+    if planned:
+        planned_cities = sorted({city for city, _ in planned})
+        notes.append("<li><strong>%d channels named on the Chapters List do not exist yet</strong> "
+                     "— they are the provisioning plan (run with --planned-ok), not renames. The "
+                     "%d chapters counting on them are reported above as having no channel, which "
+                     "is the current truth: %s. Re-run without the flag once "
+                     "provision_channels.py has created them.</li>"
+                     % (len(planned), len(planned_cities),
+                        ", ".join(e(c) for c in planned_cities)))
     cand = [c for c in audit if not c["public"] and c["public_candidates"]]
     if cand:
         notes.append("<li><strong>%d chapters have near-miss channels</strong> that were NOT "
@@ -869,6 +907,9 @@ def main():
     ap.add_argument("--cache", default=".slack-audit-cache")
     ap.add_argument("--refresh", action="store_true", help="re-fetch even if cached")
     ap.add_argument("--no-pdf", action="store_true")
+    ap.add_argument("--planned-ok", action="store_true",
+                    help="pre-provisioning: treat sheet-named channels that do "
+                         "not exist yet as planned instead of aborting")
     args = ap.parse_args()
 
     cfg = load_config()
@@ -916,7 +957,13 @@ def main():
               % (len(chans), cache_age(chan_path)))
 
     rows = match_channels(chapters, chans, cfg)
-    assert_aliases_resolve(rows)
+    if args.planned_ok:
+        planned = mark_planned_aliases(rows)
+        if planned:
+            print("  %d sheet-named channel(s) do not exist yet — treated as "
+                  "planned, not as renames" % len(planned))
+    else:
+        assert_aliases_resolve(rows)
     print("  matched: %d own channel, %d organizers channel"
           % (sum(1 for r in rows if r["public"]),
              sum(1 for r in rows if r["organizers_channel"])))

--- a/skills/aaif-audit-slack/scripts/test_audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/test_audit_organizers.py
@@ -343,6 +343,7 @@ def test_header_index_aborts_on_missing_and_duplicate():
 
 def _row(city, public=None, org=None):
     return {"city": city, "regional": None, "public_how": "", "organizers_how": "",
+            "regional_how": "",
             "public": public, "public_id": "C1", "public_members": 5,
             "public_candidates": [], "organizers_channel": org,
             "organizers_id": "C2", "organizers_channel_members": 3,

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -645,26 +645,23 @@ to be created.
 Naming, and the one rule that is not obvious:
 
 - **The organizer channel follows the chapter's OWN channel, not the city slug.**
-  Munich's room is `#munchen`, so its organizers belong in `#munchen-organizers` —
-  `munich-organizers` would name a room after a chapter that, in Slack, does not
-  go by that name. This inherits legacy names too, deliberately:
-  `#washington-dc-the-capital-organizers`, `#frankfurt_main-organizers`.
+  SF's room is `#bay-area`, so its organizers belong in `#bay-area-organizers` —
+  `san-francisco-organizers` would name a room after a chapter that, in Slack,
+  does not go by that name.
 - **Every chapter gets one**, including those with no accepted organizer yet (26 as of 2026-08-11), so
   the room is ready for a chapter's first organizer rather than something someone
   has to remember to create.
-- A **filled cell is never re-planned.** That is what protects the
-  local-language names (`#munchen`, `#españa`, `#medellín`) and the deliberate
-  multi-chapter rooms (`#bay-area` for SF + Silicon Valley, `#españa` for Madrid,
-  Bilbao and Logroño), which the `<city>` convention cannot express at all.
+- A **filled cell is never re-planned.** That is what protects `#españa` and the
+  deliberate multi-chapter room `#bay-area` (SF + Silicon Valley), which the
+  `<city>` convention cannot express at all.
 
-## Why the sheet is inconsistent, and why that is correct
+## Why one channel name is still not `<city>`, and why that is correct
 
-Some chapters (14 as of 2026-08-11) point at a channel that is not `<city>`. None is an oversight, and
-`KEPT_NON_CONVENTIONAL` in the script records why: local-language names, one room
-deliberately serving several chapters, a channel whose scope is wider than the
-chapter's (`#colorado` for Denver, `#delhi` for Delhi NCR), and legacy platform
-prefixes nobody will re-join under a new name. Renaming them would move thousands
-of members for cosmetic consistency.
+The 2026-08-17 naming sweep renamed the legacy meetup-era, wider-scope and
+local-language channels to the convention (a rename keeps members and history,
+so nothing was lost — even `#munchen` and `#medellín` fell to typability). One
+survivor remains, recorded in `KEPT_NON_CONVENTIONAL`: `#bay-area`, one room
+deliberately serving two chapters.
 
 ### A country room is not a chapter room
 
@@ -727,9 +724,10 @@ readers resolve columns by header name, but see the Notes below.
 > them, which is the actual argument for the move. Treat a seeded cell as a
 > proposal until someone who knows the chapter confirms it. The ones worth a
 > second look, because the channel name shares nothing with the chapter name:
-> Denver → `#colorado`, Munich → `#munchen`, Bengaluru → `#bangalore`,
 > Madrid/Bilbao/Logroño → `#españa` (one channel, three chapters), San Francisco
-> and Silicon Valley → `#bay-area`, Washington DC → `#washington-dc-the-capital`.
+> and Silicon Valley → `#bay-area`. (The 2026-08-17 sweep renamed the rest of
+> this list — `#colorado`, `#munchen`, `#bangalore`,
+> `#washington-dc-the-capital` — onto the convention.)
 
 ## Creating the planned channels (`provision_channels.py`)
 

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -659,9 +659,11 @@ Naming, and the one rule that is not obvious:
 
 The 2026-08-17 naming sweep renamed the legacy meetup-era, wider-scope and
 local-language channels to the convention (a rename keeps members and history,
-so nothing was lost — even `#munchen` and `#medellín` fell to typability). One
-survivor remains, recorded in `KEPT_NON_CONVENTIONAL`: `#bay-area`, one room
-deliberately serving two chapters.
+so nothing was lost — even `#munchen` and `#medellín` fell to typability; a few
+renames are still pending behind invisible squatters, see
+`provision_channels.CHANNEL_RENAMES`). One survivor remains, recorded in
+`KEPT_NON_CONVENTIONAL`: `#bay-area`, one room deliberately serving two
+chapters.
 
 ### A country room is not a chapter room
 
@@ -678,10 +680,13 @@ Watch for this shape whenever one channel serves several chapters — a shared
 *chapter* room and a *country* room look identical on the sheet and mean opposite
 things.
 
-The **one** rename is `RENAMES`: `#bangalore` → `#bengaluru`, because
-Bangalore is the city's superseded name rather than a local variant. It is a
-*rename*, which keeps the members and the history — never a create, which
-would split the chapter across two rooms.
+The sheet-side `RENAMES` map repoints cells whose channel took a new name
+(`#bangalore` → `#bengaluru` was the first; the London and Bay Area organizer
+consolidations followed). Always a *rename* on the Slack side, which keeps the
+members and the history — never a create, which would split the chapter across
+two rooms. The much larger Slack-side queue lives in
+`provision_channels.CHANNEL_RENAMES`; the two maps stopped being mirror images
+once the 2026-08-17 sweep's sheet cells were edited directly.
 
 A dead Slack token skips the three channel columns and still reports the folder
 column; the report says which half was skipped, so an empty channel section is
@@ -692,8 +697,8 @@ name a channel** (whitespace, `/`, `:`, `#`, `@` or `,` in it — a pasted URL,
 an email address, a sentence) is reported as malformed and counts as drift.
 "Filled" otherwise reads as healthy forever: Montréal's `Slack Channel` cell
 held a copy of its Drive folder URL and every count said the chapter was mapped.
-The character list is deliberately minimal so `#españa`, `#medellín` and
-`#frankfurt_main-organizers` are never flagged.
+The character list is deliberately minimal so the accented `#españa` is never
+flagged.
 
 ## One-time migration (`migrate_resource_columns.py`)
 
@@ -725,9 +730,10 @@ readers resolve columns by header name, but see the Notes below.
 > proposal until someone who knows the chapter confirms it. The ones worth a
 > second look, because the channel name shares nothing with the chapter name:
 > Madrid/Bilbao/Logroño → `#españa` (one channel, three chapters), San Francisco
-> and Silicon Valley → `#bay-area`. (The 2026-08-17 sweep renamed the rest of
-> this list — `#colorado`, `#munchen`, `#bangalore`,
-> `#washington-dc-the-capital` — onto the convention.)
+> and Silicon Valley → `#bay-area`. (The rest of this list — `#colorado`,
+> `#munchen`, `#washington-dc-the-capital`, and 2026-08-10's `#bangalore` —
+> has been renamed onto the convention, a few entries still pending behind
+> invisible squatters.)
 
 ## Creating the planned channels (`provision_channels.py`)
 
@@ -743,19 +749,28 @@ It does **not** share the audit's Slack client. `lib/aaif_events/slack.py` refus
 any method outside `ALLOWED_METHODS`, and that refusal is why a typo in a
 30k-member workspace cannot post, invite or archive — widening it for one script
 that runs once would remove the guarantee from every audit. So this file carries
-its own small write client, with its own two-method allowlist.
+its own small write client, with its own allowlist.
 
-What it will never do: **archive or delete** anything, **invite** anyone
+What it will never do: **delete** anything, **invite** anyone
 (`Organizer Handles` says who belongs where; a human does the inviting, because a
 script mass-inviting 100 people to 100 channels is indistinguishable from an
 attack and cannot be undone), or create a channel the sheet does not name.
 
+It **can archive — but only rooms a rename already retired** (authorised
+2026-08-17). The deprecated-room sweep closes `*-deprecated` rooms only: public
+ones get a farewell pointer post first (no post → no archive), private ones are
+archived only once every member is already in the recorded successor room, and
+a `-deprecated` room queued for a rename back into service is skipped. A room
+with no recorded successor is reported, never archived.
+
 Renames run **before** creates — creating `#bengaluru` first would take the name
 and strand `#bangalore`'s members in the old room.
 
-Two prerequisites, neither in place by default: a token with `channels:write`
-and `groups:write` (the user-token scopes for create/rename; the audit token has
-read scopes only), and `--i-have-approval` alongside `--write`.
+Two prerequisites, neither in place by default: a token with `channels:write`,
+`groups:write` and `chat:write` (user-token scopes for create/rename and the
+farewell pointer; `channels:join` is worth adding so the sweep can join a
+public room before posting in it — the audit token has read scopes only), and
+`--i-have-approval` alongside `--write`.
 
 ## Adding organizers to their channel (`invite_organizers.py`)
 

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -110,10 +110,30 @@ CHANNEL_RENAMES = {
     "london-organizers": "london-organizers-deprecated",
     "london-meetup-organizers": "london-organizers",
     "bay-area-sf-organizers": "bay-area-organizers",
-    # Austin's PUBLIC room stays #austin-area (it predates AAIF and holds the
-    # members), but the organizer room was freshly created 2026-08-16 with no
-    # history to lose, so it takes the plain city name the user asked for.
+    # The organizer room was freshly created 2026-08-16 with no history to
+    # lose, so it takes the plain city name the user asked for. (Blocked until
+    # the invisible #austin-organizers squatter is deprecated.)
     "austin-area-organizers": "austin-organizers",
+    # 2026-08-17 naming-convention sweep (user-decided): city channels take the
+    # plain city name, organizer rooms take <city>-organizers. #bay-area and
+    # #munchen are deliberate keeps.
+    # NOT "meetup-seattle": "seattle" — a live #seattle (135 members, 2022)
+    # already IS the city room; #meetup-seattle (41, 2023) merges into it below.
+    # APPLIED 2026-08-17 and removed from this map (empty junk rooms were
+    # recreated under the freed old names before the sheet caught up, and
+    # re-planning an applied rename against a junk-held old name refuses the
+    # whole run): meetup-barcelona→barcelona, colorado→denver,
+    # frankfurt_main→frankfurt(+-organizers), nyc→new-york,
+    # nyc-chapter-leads→new-york-organizers, portland-oregon→portland,
+    # washington-dc-the-capital-organizers→washington-dc-organizers.
+    # STILL PENDING below — each target name is held by an INVISIBLE private
+    # room, so they fail with name_taken (non-fatal) until those are
+    # deprecated via the admin UI:
+    "meetup-seattle-organizers": "seattle-organizers",
+    "meetup-barcelona-organizers": "barcelona-organizers",
+    "washington-dc-the-capital": "washington-dc",
+    "portland-oregon-organizers": "portland-organizers",
+    "austin-area": "austin",
 }
 
 #: Merges: the room is retired and its chapter moves to another room. Distinct
@@ -123,6 +143,11 @@ CHANNEL_RENAMES = {
 CHANNEL_MERGES = {
     "southbay-chapter-leads": {"into": "bay-area-organizers",
                                "retire_as": "southbay-chapter-leads-deprecated"},
+    # Seattle had two public rooms; the older, larger #seattle wins and the
+    # meetup-era one is retired. Its members are not carried — the country and
+    # #general posts point everyone at the surviving room.
+    "meetup-seattle": {"into": "seattle",
+                       "retire_as": "meetup-seattle-deprecated"},
 }
 
 

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -110,6 +110,10 @@ CHANNEL_RENAMES = {
     "london-organizers": "london-organizers-deprecated",
     "london-meetup-organizers": "london-organizers",
     "bay-area-sf-organizers": "bay-area-organizers",
+    # Austin's PUBLIC room stays #austin-area (it predates AAIF and holds the
+    # members), but the organizer room was freshly created 2026-08-16 with no
+    # history to lose, so it takes the plain city name the user asked for.
+    "austin-area-organizers": "austin-organizers",
 }
 
 #: Merges: the room is retired and its chapter moves to another room. Distinct

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -19,7 +19,11 @@ this one file.
 
 ## What it will not do
 
-- **Never archives or deletes.** Nothing here removes a room people are in.
+- **Archives only rooms a rename already retired** — the deprecated-room sweep
+  (authorised 2026-08-17) closes `*-deprecated` rooms only, public ones only
+  after a farewell pointer post lands, private ones only once every member is
+  already in the successor. Nothing here deletes, and nothing archives a room
+  under its working name.
 - **Never invites.** This script builds rooms; it does not put people in them.
   Inviting lives in `invite_organizers.py`, deliberately separate: it needs
   different scopes, and it is less reversible than anything here. A channel can
@@ -88,17 +92,31 @@ API = "https://slack.com/api/"
 #: (`prune_organizers.py`), which refuses to act on anything but an explicit
 #: keep-list. Read that file before assuming it is safe to call from elsewhere.
 #:
-#: Still absent, and to stay absent: `conversations.archive` (nothing here
-#: destroys a room — deprecation is a rename, which is reversible) and
-#: `chat.postMessage` (nothing here speaks as a human in a community channel).
+#: `conversations.archive` and `chat.postMessage` were deliberately absent
+#: until 2026-08-17, when archiving retired rooms was authorised. Both are
+#: reachable from exactly one place — the deprecated-room sweep in main() —
+#: and under guards that keep the original fears fenced:
+#:
+#: - archive refuses any channel whose name does not end `-deprecated`, so the
+#:   only rooms it can close are ones a rename already retired on purpose;
+#: - postMessage is used solely to leave the farewell pointer in the room being
+#:   archived (public rooms only — a pointer nobody can follow into a private
+#:   room helps no one), never to speak anywhere else.
+#:
+#: `conversations.join` is here because a user token cannot post in a public
+#: channel it has not joined; it is only ever called on a room about to be
+#: archived, so the membership is momentary by construction.
 WRITE_METHODS = frozenset({"conversations.create", "conversations.rename",
-                           "conversations.invite", "conversations.kick"})
+                           "conversations.invite", "conversations.kick",
+                           "conversations.archive", "conversations.join",
+                           "chat.postMessage"})
 
 #: Scopes each write needs. Checked up front so a missing scope fails before the
 #: first channel rather than half way through the batch.
 # `channels:write` is the USER-token scope for conversations.create/rename;
 # `channels:manage` is its bot-token sibling and never appears on a user token.
-NEEDED_SCOPES = ("channels:write", "groups:write")
+# `chat:write` is for the deprecated-sweep's farewell pointer, nothing else.
+NEEDED_SCOPES = ("channels:write", "groups:write", "chat:write")
 
 #: Slack renames: the room keeps its identity, members and history, and takes a
 #: new name. ORDER IS COMPUTED, not written here — see order_renames(). Two of
@@ -115,8 +133,8 @@ CHANNEL_RENAMES = {
     # the invisible #austin-organizers squatter is deprecated.)
     "austin-area-organizers": "austin-organizers",
     # 2026-08-17 naming-convention sweep (user-decided): city channels take the
-    # plain city name, organizer rooms take <city>-organizers. #bay-area and
-    # #munchen are deliberate keeps.
+    # plain city name, organizer rooms take <city>-organizers. #bay-area is a
+    # deliberate keep.
     # NOT "meetup-seattle": "seattle" — a live #seattle (135 members, 2022)
     # already IS the city room; #meetup-seattle (41, 2023) merges into it below.
     # APPLIED 2026-08-17 and removed from this map (empty junk rooms were
@@ -128,18 +146,49 @@ CHANNEL_RENAMES = {
     # washington-dc-the-capital-organizers→washington-dc-organizers.
     # STILL PENDING below — each target name is held by an INVISIBLE private
     # room, so they fail with name_taken (non-fatal) until those are
-    # deprecated via the admin UI:
+    # deprecated via the admin UI. (NOT meetup-barcelona-organizers ->
+    # barcelona-organizers: its "squatter" turned out to be the REAL organizer
+    # room — 2024, 16 members — so the freshly provisioned 3-member room merges
+    # into it instead; see CHANNEL_MERGES.)
     "meetup-seattle-organizers": "seattle-organizers",
-    "meetup-barcelona-organizers": "barcelona-organizers",
     "washington-dc-the-capital": "washington-dc",
+    # Austin's REAL room (76 members, 2023) was hand-renamed to -deprecated in
+    # the admin UI on 2026-08-17 while #austin was still squatted, and the
+    # sheet's stale `austin-area` cell then made a --write run create a junk
+    # room under the freed name (archived 2026-08-18). This entry is the
+    # recovery: the moment the #austin squatter is cleared, the real room takes
+    # the city name — and its presence stops plan() from CREATING #austin
+    # first, which would re-run the same accident under the new name.
+    "austin-area-deprecated": "austin",
     "portland-oregon-organizers": "portland-organizers",
-    "austin-area": "austin",
+    # 2026-08-19 (user-decided, revised same day): country-named chapters
+    # become capital-city chapters — but #switzerland (80) and #scotland (71)
+    # STAY as country rooms; fresh #bern and #edinburgh city rooms are created
+    # from the sheet instead, and only the ORGANIZER rooms take city names.
+    # Utah is a state, not a country room worth keeping: the room itself
+    # renames. Scotland/Utah's organizer rooms are invisible squatters, so
+    # their -organizers rooms are fresh creates from the sheet, not renames.
+    "switzerland-organizers": "bern-organizers",
+    "utah": "salt-lake-city",
     # 2026-08-17 round two (user-decided): ASCII beats the accent for
     # typability (the #españa precedent notwithstanding), and Delhi NCR is
     # the chapter's actual name. Their organizer-room twins are invisible
     # squatters, so fresh rooms are created via the sheet instead.
     "medellín": "medellin",
     "delhi": "delhi-ncr",
+    # Sydney needs NO rename, after two wrong answers in one day (2026-08-17).
+    # #aaifsydney looked mergeable (small, meetup-era name), then looked like
+    # the real chapter room (all the recent activity) — its own message history
+    # settled it: a TEMPORARY event-coordination room with external sponsor
+    # folk in it, to be left alone under its own name. #sydney (2022, 57
+    # members) stays the city room; #sydney-organizers is planned from the
+    # sheet and currently blocked by an invisible private squatter.
+    # 2026-08-17 (user-decided): the last local-language keep falls too —
+    # English/ASCII wins for the same typability reason as medellin. The
+    # organizer room was deprecated by hand in the admin UI
+    # (#munchen-organizers-deprecated, 4 members to invite into the fresh
+    # #munich-organizers the sheet now plans).
+    "munchen": "munich",
 }
 
 #: Merges: the room is retired and its chapter moves to another room. Distinct
@@ -149,15 +198,91 @@ CHANNEL_RENAMES = {
 CHANNEL_MERGES = {
     "southbay-chapter-leads": {"into": "bay-area-organizers",
                                "retire_as": "southbay-chapter-leads-deprecated"},
-    # Seattle had two public rooms; the older, larger #seattle wins and the
-    # meetup-era one is retired. Its members are not carried — the country and
-    # #general posts point everyone at the surviving room.
-    "meetup-seattle": {"into": "seattle",
-                       "retire_as": "meetup-seattle-deprecated"},
-    # Pre-existing Sydney room bypassed by the sheet's #sydney (2026-08-17).
-    "aaifsydney": {"into": "sydney",
-                   "retire_as": "aaifsydney-deprecated"},
+    # meetup-seattle -> seattle APPLIED and removed 2026-08-17: the retired room
+    # is #meetup-seattle-deprecated, and a junk #meetup-seattle recreated under
+    # the freed name (since archived) was matching this entry and would have
+    # been "retired" into a name_taken failure.
+    # The aaifsydney -> sydney merge that used to sit here was REVERSED
+    # 2026-08-17: #aaifsydney is the active room (see CHANNEL_RENAMES), so the
+    # merge became a name swap and the entry had to go — left in place it would
+    # have re-retired the room the swap just promoted, under its old id.
+    # Provisioning created this 2026-08-16 while Barcelona's real organizer
+    # room (#barcelona-organizers, 2024, 16 members) was an invisible private
+    # channel. Once revealed, the real room wins; the fresh room's 3 members
+    # are invited across.
+    "meetup-barcelona-organizers": {
+        "into": "barcelona-organizers",
+        "retire_as": "meetup-barcelona-organizers-deprecated"},
 }
+
+#: Where each retired room's people should go — the deprecated-room sweep
+#: refuses to archive a room it cannot leave a forwarding address for. Public
+#: rooms point at the chapter's PUBLIC channel (a pointer into a private room
+#: is a door nobody can open); private rooms name the private successor, used
+#: for the membership-coverage check rather than a post.
+DEPRECATED_POINTERS = {
+    "london-organizers-deprecated": "london",
+    "meetup-seattle-deprecated": "seattle",
+    "southbay-chapter-leads-deprecated": "bay-area-organizers",
+    "luxembourg-organizers-deprecated": "luxembourg-organizers",
+    "munchen-organizers-deprecated": "munich-organizers",
+    "meetup-barcelona-organizers-deprecated": "barcelona-organizers",
+}
+
+FAREWELL = ("This channel is retired. The community now lives in <#%s> — "
+            "see you there! (This room will be archived; its history stays "
+            "searchable.)")
+
+
+def plan_archives(api, by_name, live, self_id):
+    """What the deprecated-room sweep would do: [(name, action, detail)].
+
+    action is 'archive' (public: post pointer first), 'blocked' or 'skip'.
+    The rules differ by room type, deliberately:
+
+    - **Public**: post the farewell pointer, then archive. Members chose a
+      public room and can follow a pointer with one click; mass-inviting them
+      anywhere is not this script's call.
+    - **Private**: archive only when every member is already in the successor
+      room (the token's own account excepted). A private room's members were
+      curated, so archiving out from under someone who has not been moved yet
+      would cut an organizer off from their chapter. Stragglers are counted
+      and named as the reason, and inviting them stays invite_organizers.py's
+      intake-gated job.
+    """
+    plans = []
+    for name in sorted(live):
+        if not name.endswith("-deprecated"):
+            continue
+        if name in CHANNEL_RENAMES:
+            # Queued to be renamed back into service (e.g. Austin's real room,
+            # parked at -deprecated while a squatter holds its city name) —
+            # not a room to close, whatever its name says today.
+            plans.append((name, "skip", "pending rename to #%s — not retired"
+                          % CHANNEL_RENAMES[name]))
+            continue
+        target = DEPRECATED_POINTERS.get(name)
+        if not target:
+            plans.append((name, "blocked", "no recorded successor — add it to "
+                          "DEPRECATED_POINTERS or archive by hand"))
+            continue
+        if target not in by_name or by_name[target]["is_archived"]:
+            plans.append((name, "blocked", "successor #%s is not live" % target))
+            continue
+        room = by_name[name]
+        if not room.get("is_private"):
+            plans.append((name, "archive", "public; pointer post -> #%s, then "
+                          "archive" % target))
+            continue
+        members = set(slackmod.members(api, room["id"])) - {self_id}
+        stragglers = members - set(slackmod.members(api, by_name[target]["id"]))
+        if stragglers:
+            plans.append((name, "blocked", "%d member(s) not yet in #%s — "
+                          "invite them across first" % (len(stragglers), target)))
+        else:
+            plans.append((name, "archive", "private; all members already in "
+                          "#%s" % target))
+    return plans
 
 
 def order_renames(renames, live):
@@ -247,8 +372,14 @@ def call_write(token, method, **params):
     return {"ok": False, "error": "ratelimited"}
 
 
-def plan(tables, live):
+def plan(tables, live, all_names=None):
     """Return (creates, renames, merges, already, blocked).
+
+    `all_names` is every channel name INCLUDING archived ones (defaults to
+    `live`). Applied-rename detection must use it: once the deprecated-room
+    sweep archives #london-organizers-deprecated, that name stops being live,
+    and a live-only check would re-plan the London chain's first step —
+    renaming the REAL organizer room to -deprecated.
 
     `creates` is [(name, is_private, why)]. A name is planned exactly once even
     when several chapters share it — #india serves six, and asking Slack to
@@ -282,9 +413,15 @@ def plan(tables, live):
     # applied when its old name is another rename's target (the map itself
     # re-occupied it); a target squatted by anything else still blocks, because
     # that genuinely is a room the plan cannot account for.
+    # The target-exists check runs against ALL names, not just live ones: an
+    # archived room holding the target is the same evidence of "applied" (the
+    # sweep archives retired rooms), and a not-yet-applied rename into an
+    # archived name would only ever answer name_taken anyway.
+    if all_names is None:
+        all_names = live
     retaken = set(CHANNEL_RENAMES.values())
     wanted = {o: n for o, n in CHANNEL_RENAMES.items()
-              if o in live and not (n in live and o in retaken)}
+              if o in live and not (n in all_names and o in retaken)}
     renames, blocked = order_renames(wanted, live)
     merges = [(o, m) for o, m in sorted(CHANNEL_MERGES.items()) if o in live]
     return creates, renames, blocked, merges, already
@@ -306,7 +443,11 @@ def main():
     live = {c["name"] for c in chans if not c["is_archived"]}
     by_name = {c["name"]: c for c in chans}
     _, tables = ao.read_chapters()
-    creates, renames, blocked, merges, already = plan(tables, live)
+    creates, renames, blocked, merges, already = plan(tables, live, set(by_name))
+    # Only rooms ALREADY deprecated at plan time: one this run retires still
+    # has its people, so it waits for the next run — by which point they have
+    # had the pointer, or (private) have been invited across.
+    archives = plan_archives(api, by_name, live, who.get("user_id"))
 
     print("Already exist: %d" % len(already))
     print("\nTo CREATE (%d):" % len(creates))
@@ -325,6 +466,9 @@ def main():
     for old, m in merges:
         print("  #%s -> into #%s, retired as #%s"
               % (old, m["into"], m["retire_as"]))
+    print("\nDeprecated-room sweep (%d):" % len(archives))
+    for name, action, detail in archives:
+        print("  #%-38s %-8s %s" % (name, action.upper(), detail))
 
     if not a.write:
         print("\nReport only. Nothing was sent to Slack.")
@@ -406,6 +550,31 @@ def main():
                   "members into #%s)" % (old, m["retire_as"], m["into"]))
         else:
             failed.append("retire %s: %s" % (old, r.get("error")))
+
+    for name, action, detail in archives:
+        if action != "archive":
+            continue
+        # Belt to the planner's braces: this is the only call site of
+        # conversations.archive, and it must stay impossible to point at a
+        # room a rename did not first retire on purpose.
+        assert name.endswith("-deprecated"), name
+        room = by_name[name]
+        if not room.get("is_private"):
+            if not room.get("is_member"):
+                call_write(token, "conversations.join", channel=room["id"])
+            p = call_write(token, "chat.postMessage", channel=room["id"],
+                           text=FAREWELL % by_name[DEPRECATED_POINTERS[name]]["id"])
+            if not p.get("ok"):
+                failed.append("farewell post in %s: %s — NOT archived (a room "
+                              "must not close without its forwarding address)"
+                              % (name, p.get("error")))
+                continue
+        r = call_write(token, "conversations.archive", channel=room["id"])
+        if r.get("ok"):
+            done += 1
+            print("archived #%s" % name)
+        else:
+            failed.append("archive %s: %s" % (name, r.get("error")))
 
     print("\n%d applied, %d failed." % (done, len(failed)))
     for f in failed:

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -58,6 +58,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -179,18 +180,33 @@ def write_token():
 
 
 def call_write(token, method, **params):
-    """POST a write method. Refuses anything outside WRITE_METHODS."""
+    """POST a write method. Refuses anything outside WRITE_METHODS.
+
+    Retries rate limits (and only rate limits): a 130-create burst trips
+    Slack's limiter partway through, and without this the tail of the batch
+    fails for a reason that fixes itself. Honouring Retry-After is what the
+    read client does too; every other error still returns to the caller.
+    """
     if method not in WRITE_METHODS:
         raise ValueError("%s is not a sanctioned write method." % method)
-    req = urllib.request.Request(
-        API + method, data=urllib.parse.urlencode(params).encode(),
-        headers={"Authorization": "Bearer " + token,
-                 "Content-Type": "application/x-www-form-urlencoded"})
-    try:
-        with urllib.request.urlopen(req, timeout=30) as response:
-            return json.loads(response.read())
-    except urllib.error.HTTPError as exc:
-        return {"ok": False, "error": "http_%d" % exc.code}
+    for attempt in range(5):
+        req = urllib.request.Request(
+            API + method, data=urllib.parse.urlencode(params).encode(),
+            headers={"Authorization": "Bearer " + token,
+                     "Content-Type": "application/x-www-form-urlencoded"})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                payload = json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 429 and attempt < 4:
+                time.sleep(int(exc.headers.get("Retry-After", "10")))
+                continue
+            return {"ok": False, "error": "http_%d" % exc.code}
+        if not payload.get("ok") and payload.get("error") == "ratelimited" and attempt < 4:
+            time.sleep(int(payload.get("retry_after", 10)))
+            continue
+        return payload
+    return {"ok": False, "error": "ratelimited"}
 
 
 def plan(tables, live):
@@ -201,12 +217,17 @@ def plan(tables, live):
     create it six times would be five errors and one channel.
     """
     creates, already, seen = [], [], set()
+    # A name a rename will free INTO is satisfied by that rename, not by a
+    # create: renames run first, so `conversations.create` would answer
+    # name_taken — the right room exists, but the run reads as failed.
+    rename_targets = {n for o, n in CHANNEL_RENAMES.items() if o in live}
 
     def want(name, private, why):
         if not name or name == NO_RESOURCE or name in seen:
             return
         seen.add(name)
-        (already if name in live else creates).append((name, private, why))
+        (already if name in live or name in rename_targets
+         else creates).append((name, private, why))
 
     for table, private, label in (("public", False, "chapter channel"),
                                   ("organizers", True, "organizer channel"),
@@ -215,8 +236,17 @@ def plan(tables, live):
             want(name, private, "%s for %s" % (label, city))
 
     # Only rename what is actually there: a rename already applied is a no-op,
-    # not an error to re-attempt every run.
-    wanted = {o: n for o, n in CHANNEL_RENAMES.items() if o in live}
+    # not an error to re-attempt every run. One subtlety makes that harder than
+    # `o in live`: after a CHAIN applies (#london-organizers moved away, then
+    # #london-meetup-organizers took its name), the old name is live AGAIN —
+    # held by the right room. Re-planning it would report the chain as blocked
+    # and refuse the whole run. So a rename whose target exists is treated as
+    # applied when its old name is another rename's target (the map itself
+    # re-occupied it); a target squatted by anything else still blocks, because
+    # that genuinely is a room the plan cannot account for.
+    retaken = set(CHANNEL_RENAMES.values())
+    wanted = {o: n for o, n in CHANNEL_RENAMES.items()
+              if o in live and not (n in live and o in retaken)}
     renames, blocked = order_renames(wanted, live)
     merges = [(o, m) for o, m in sorted(CHANNEL_MERGES.items()) if o in live]
     return creates, renames, blocked, merges, already
@@ -303,7 +333,18 @@ def main():
         else:
             # One bad name must not abandon the batch — a public form feeds these
             # city names, so a rejected slug is normal input, not a crash.
-            failed.append("create %s: %s" % (name, r.get("error")))
+            err = r.get("error")
+            if err == "name_taken":
+                # The plan only sees private channels the token owner is in, so
+                # name_taken on a "missing" channel means the room EXISTS as a
+                # private channel this token cannot see. The fix is an invite
+                # for the token owner, never a create — say so, or every rerun
+                # reads as the same mysterious failure.
+                failed.append("create %s: name_taken — exists as a private "
+                              "channel this token is not in; needs an invite, "
+                              "not a create" % name)
+            else:
+                failed.append("create %s: %s" % (name, err))
 
     # Retirements LAST, and only after their target VERIFIABLY exists: the
     # members of a retired room have not been invited across yet (that is

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -134,6 +134,12 @@ CHANNEL_RENAMES = {
     "washington-dc-the-capital": "washington-dc",
     "portland-oregon-organizers": "portland-organizers",
     "austin-area": "austin",
+    # 2026-08-17 round two (user-decided): ASCII beats the accent for
+    # typability (the #españa precedent notwithstanding), and Delhi NCR is
+    # the chapter's actual name. Their organizer-room twins are invisible
+    # squatters, so fresh rooms are created via the sheet instead.
+    "medellín": "medellin",
+    "delhi": "delhi-ncr",
 }
 
 #: Merges: the room is retired and its chapter moves to another room. Distinct
@@ -148,6 +154,9 @@ CHANNEL_MERGES = {
     # #general posts point everyone at the surviving room.
     "meetup-seattle": {"into": "seattle",
                        "retire_as": "meetup-seattle-deprecated"},
+    # Pre-existing Sydney room bypassed by the sheet's #sydney (2026-08-17).
+    "aaifsydney": {"into": "sydney",
+                   "retire_as": "aaifsydney-deprecated"},
 }
 
 

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -44,11 +44,15 @@ this one file.
 
 ## Prerequisites, neither of which is in place by default
 
-1. A token with `channels:write` (public) and `groups:write` (private), in
-   `$AAIF_SLACK_WRITE_TOKEN`. The Slack CLI's own token is read-only and its
-   scopes cannot be widened, so this is a separate app token — run the script
-   without it for the four setup steps. **Whoever's token it is joins every
-   channel it creates.**
+1. A token with `channels:write` (public), `groups:write` (private) and
+   `chat:write` (the deprecated sweep's farewell pointer), in
+   `$AAIF_SLACK_WRITE_TOKEN`. `channels:join` is also worth requesting: the
+   farewell post needs membership in the room being archived, and without the
+   scope a join fails and that room's archive is skipped (reported, not
+   silent). The Slack CLI's own token is read-only and its scopes cannot be
+   widened, so this is a separate app token — run the script without it for
+   the four setup steps. **Whoever's token it is joins every channel it
+   creates.**
 2. `--i-have-approval`, on top of `--write`. Two flags, because this is the one
    irreversible-ish action in the repo and a mistyped `--write` elsewhere is
    merely a spreadsheet edit.
@@ -80,11 +84,11 @@ from aaif_events import slack as slackmod  # noqa: E402
 API = "https://slack.com/api/"
 
 #: The complete set of write methods this script may call — the same
-#: allowlist discipline as the read-only client, for the same reason. Note what
+#: allowlist discipline as the read-only client, for the same reason.
 #: `conversations.invite` and `conversations.kick` are here rather than in the
-#: scripts that use them because call_write() is the single chokepoint all three
-#: go through — an allowlist split across files is one that can disagree with
-#: itself.
+#: scripts that use them because call_write() is the single chokepoint every
+#: write goes through — an allowlist split across files is one that can
+#: disagree with itself.
 #:
 #: `conversations.kick` was deliberately absent until 2026-08-10, when removing
 #: non-organizers from organizer channels was authorised. It is the only entry
@@ -136,7 +140,8 @@ CHANNEL_RENAMES = {
     # plain city name, organizer rooms take <city>-organizers. #bay-area is a
     # deliberate keep.
     # NOT "meetup-seattle": "seattle" — a live #seattle (135 members, 2022)
-    # already IS the city room; #meetup-seattle (41, 2023) merges into it below.
+    # already IS the city room; #meetup-seattle (41, 2023) was merged into it
+    # (applied 2026-08-17 and removed; see the note in CHANNEL_MERGES).
     # APPLIED 2026-08-17 and removed from this map (empty junk rooms were
     # recreated under the freed old names before the sheet caught up, and
     # re-planning an applied rename against a junk-held old name refuses the
@@ -332,7 +337,8 @@ def write_token():
             "cannot be widened, so writes use a separate app token:\n"
             "  1. api.slack.com/apps -> Create New App -> From scratch\n"
             "  2. OAuth & Permissions -> User Token Scopes: channels:write, "
-            "groups:write,\n     channels:write.invites, groups:write.invites\n"
+            "groups:write,\n     chat:write, channels:join, "
+            "channels:write.invites, groups:write.invites\n"
             "  3. Install to Workspace, copy the User OAuth Token (xoxp-...)\n"
             "  4. export %s='xoxp-...'\n\n"
             "Use a USER token, not a bot token: the creator of a channel joins "
@@ -362,18 +368,32 @@ def call_write(token, method, **params):
                 payload = json.loads(response.read())
         except urllib.error.HTTPError as exc:
             if exc.code == 429 and attempt < 4:
-                time.sleep(int(exc.headers.get("Retry-After", "10")))
+                time.sleep(_retry_secs(exc.headers.get("Retry-After")))
                 continue
             return {"ok": False, "error": "http_%d" % exc.code}
         if not payload.get("ok") and payload.get("error") == "ratelimited" and attempt < 4:
-            time.sleep(int(payload.get("retry_after", 10)))
+            time.sleep(_retry_secs(payload.get("retry_after")))
             continue
         return payload
     return {"ok": False, "error": "ratelimited"}
 
 
+def _retry_secs(value, default=10):
+    """A usable sleep out of whatever Retry-After held.
+
+    The header is allowed to be an HTTP-date, and fractional strings appear in
+    the wild; a ValueError here would abort a mutation batch partway through
+    and take the applied/failed summary with it — the exact loss the retry
+    exists to prevent.
+    """
+    try:
+        return max(1, int(float(value)))
+    except (TypeError, ValueError):
+        return default
+
+
 def plan(tables, live, all_names=None):
-    """Return (creates, renames, merges, already, blocked).
+    """Return (creates, renames, blocked, merges, already, applied).
 
     `all_names` is every channel name INCLUDING archived ones (defaults to
     `live`). Applied-rename detection must use it: once the deprecated-room
@@ -422,9 +442,15 @@ def plan(tables, live, all_names=None):
     retaken = set(CHANNEL_RENAMES.values())
     wanted = {o: n for o, n in CHANNEL_RENAMES.items()
               if o in live and not (n in all_names and o in retaken)}
+    # What the filter above classified as applied is REPORTED, never silently
+    # dropped: the classification is an inference, and an entry it swallows by
+    # mistake would otherwise vanish from the plan with no trace — the chain
+    # step that was meant to free a name simply never appearing anywhere.
+    applied = sorted((o, n) for o, n in CHANNEL_RENAMES.items()
+                     if o in live and o not in wanted)
     renames, blocked = order_renames(wanted, live)
     merges = [(o, m) for o, m in sorted(CHANNEL_MERGES.items()) if o in live]
-    return creates, renames, blocked, merges, already
+    return creates, renames, blocked, merges, already, applied
 
 
 def main():
@@ -443,7 +469,8 @@ def main():
     live = {c["name"] for c in chans if not c["is_archived"]}
     by_name = {c["name"]: c for c in chans}
     _, tables = ao.read_chapters()
-    creates, renames, blocked, merges, already = plan(tables, live, set(by_name))
+    creates, renames, blocked, merges, already, applied = plan(
+        tables, live, set(by_name))
     # Only rooms ALREADY deprecated at plan time: one this run retires still
     # has its people, so it waits for the next run — by which point they have
     # had the pointer, or (private) have been invited across.
@@ -460,6 +487,11 @@ def main():
     if blocked:
         print("\n  BLOCKED (%d) — target name is held and nothing frees it:" % len(blocked))
         for old, new in blocked:
+            print("    #%s -> #%s" % (old, new))
+    if applied:
+        print("\n  Classified as already applied (old name re-occupied by the "
+              "map itself, %d):" % len(applied))
+        for old, new in applied:
             print("    #%s -> #%s" % (old, new))
     print("\nTo MERGE (%d) — the room is retired, members are invited across by"
           "\ninvite_organizers.py (a rename would NOT carry them):" % len(merges))
@@ -536,7 +568,10 @@ def main():
     # this set is.
     renamed_to = {new for old, new in renames
                   if not any(f.startswith("rename %s:" % old) for f in failed)}
-    live_names = set(by_name) | renamed_to | created_names
+    # `live`, not `set(by_name)`: an ARCHIVED room holding the target name is
+    # not a room members can be pointed at, and archived junk under a wanted
+    # name has already happened twice on this estate.
+    live_names = live | renamed_to | created_names
     for old, m in merges:
         if m["into"] not in live_names:
             failed.append("retire %s: target #%s does not exist (its rename or "
@@ -556,12 +591,25 @@ def main():
             continue
         # Belt to the planner's braces: this is the only call site of
         # conversations.archive, and it must stay impossible to point at a
-        # room a rename did not first retire on purpose.
-        assert name.endswith("-deprecated"), name
+        # room a rename did not first retire on purpose. A hard raise, not an
+        # assert — `python -O` strips asserts, and this is the one guard
+        # between a planner bug and closing a live room.
+        if not name.endswith("-deprecated"):
+            raise RuntimeError("archive sweep reached a non-deprecated room: "
+                               "#%s" % name)
         room = by_name[name]
         if not room.get("is_private"):
-            if not room.get("is_member"):
-                call_write(token, "conversations.join", channel=room["id"])
+            # `is_member` reflects the READ token's account; the write token
+            # may differ, and joining an already-joined room is a harmless
+            # `already_in_channel`. So always join, and treat only a real
+            # failure as one — otherwise a missing `channels:join` scope
+            # surfaces later as a baffling not_in_channel on the farewell.
+            j = call_write(token, "conversations.join", channel=room["id"])
+            if not j.get("ok") and j.get("error") not in (
+                    "already_in_channel", "method_not_supported_for_channel_type"):
+                failed.append("join %s: %s — cannot post the farewell, NOT "
+                              "archived" % (name, j.get("error")))
+                continue
             p = call_write(token, "chat.postMessage", channel=room["id"],
                            text=FAREWELL % by_name[DEPRECATED_POINTERS[name]]["id"])
             if not p.get("ok"):

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -70,13 +70,10 @@ FOLDER_COLUMN = "Chapter Folder"
 CHANNEL_COLUMNS = ("Slack Channel", "Organizer Channel", "Country Channel")
 HANDLES_COLUMN = "Organizer Handles"
 
-#: Channels whose current name is kept even though it is not `<city>`. Decided
-#: 2026-08-10, and the reasoning matters more than the list — these are NOT
-#: oversights to tidy up later:
+#: Channels whose current name is kept even though it is not `<city>`. The
+#: reasoning matters more than the list — these are NOT oversights to tidy up
+#: later:
 #:
-#: - **Local-language names are correct**: `#munchen` (München), `#medellín`.
-#:   The convention is ASCII-folded English; the community's own name for itself
-#:   wins.
 #: - **One room deliberately serves several chapters**: `#bay-area` (San
 #:   Francisco + Silicon Valley, 782 members). The `<city>` convention cannot
 #:   express this, and splitting it would empty a working room into two.
@@ -86,21 +83,16 @@ HANDLES_COLUMN = "Organizer Handles"
 #: The two cases look identical from the sheet (one channel, several chapters)
 #: and are not: a shared *chapter* room means those chapters have a home together,
 #: a *country* room means none of them has a local home at all.
-#: - **The channel's scope is wider than the chapter's**: `#colorado` for Denver,
-#:   `#delhi` for Delhi NCR.
-#: - **Legacy platform prefixes** that nobody is going to re-join under a new
-#:   name: `#meetup-barcelona`, `#austin-area`, `#portland-oregon`,
-#:   `#frankfurt_main`, `#nyc`, `#washington-dc-the-capital`, `#meetup-seattle`.
 #:
-#: Renaming any of these would move ~2,100 people for cosmetic consistency. The
-#: engine simply never proposes for a filled cell, so this constant is
-#: documentation rather than logic — but it is the answer to "why is this sheet
-#: inconsistent", which is otherwise re-litigated every time someone reads it.
-KEPT_NON_CONVENTIONAL = (
-    "munchen", "medellín", "bay-area", "colorado", "delhi",
-    "meetup-barcelona", "austin-area", "portland-oregon", "frankfurt_main",
-    "nyc", "washington-dc-the-capital", "meetup-seattle",
-)
+#: The 2026-08-10 list was much longer (`#munchen`, `#medellín`, `#colorado`,
+#: `#delhi`, and seven legacy meetup-era prefixes). The 2026-08-17 naming sweep
+#: reversed that call: those rooms were RENAMED to the convention via
+#: provision_channels.CHANNEL_RENAMES — a rename keeps members and history, so
+#: "moving people" was never actually the cost. Even the local-language keeps
+#: fell to typability (#munchen -> #munich, #medellín -> #medellin); `#españa`,
+#: a country channel, is now the only accented survivor. Only the entry above
+#: survived on its merits.
+KEPT_NON_CONVENTIONAL = ("bay-area",)
 
 #: Country -> the channel that serves it, where that channel is not named after
 #: the country in ASCII English. Without this the engine plans a brand-new
@@ -355,9 +347,8 @@ def plan_channels(chapters, chans, ao):
       no accepted organizer yet. The room is then ready for a chapter's first
       organizer instead of being a thing someone has to remember to create, and
       the naming stays uniform across the estate.
-    - **A cell that already names something is never touched**, including the
-      local-language names (`#munchen`, `#españa`, `#medellín`, `#bangalore`) and
-      the deliberate multi-chapter rooms (`#bay-area`, `#españa`). The convention
+    - **A cell that already names something is never touched**, including
+      `#españa` and the deliberate multi-chapter room `#bay-area`. The convention
       is for chapters that have nothing, not a reason to rename a working room.
     """
     live = {c["name"] for c in chans if not c["is_archived"]}
@@ -375,11 +366,11 @@ def plan_channels(chapters, chans, ao):
                             "why": "exists" if slug in live else "TO CREATE"})
         if not ch["current"]["Organizer Channel"]:
             # Derived from the chapter's OWN channel, not from the city slug.
-            # Munich's room is #munchen, so its organizers belong in
-            # #munchen-organizers — `munich-organizers` would be a channel named
-            # after a chapter that, in Slack, does not go by that name. The
-            # public cell wins because it is the name the community actually
-            # answers to, including every local-language and legacy one.
+            # SF's room is #bay-area, so its organizers belong in
+            # #bay-area-organizers — `san-francisco-organizers` would be a
+            # channel named after a chapter that, in Slack, does not go by that
+            # name. The public cell wins because it is the name the community
+            # actually answers to.
             base = slug if public == NO_RESOURCE else public
             name = organizer_name(base)
             planned.append({"row": ch["row"], "city": ch["city"],
@@ -480,8 +471,8 @@ def propose_organizer_alignment(chapters, live):
     """Repoint a PLANNED organizer channel at the chapter's real channel name.
 
     Fixes cells written before the organizer name was derived from the public
-    channel rather than the city slug — `munich-organizers` becomes
-    `munchen-organizers`, because #munchen is what that chapter is actually
+    channel rather than the city slug — `san-francisco-organizers` becomes
+    `bay-area-organizers`, because #bay-area is what that chapter is actually
     called.
 
     The safety rule is narrow and load-bearing: **only a cell naming a channel
@@ -555,7 +546,7 @@ def _candidates(city, chans, suffixes, ao):
 # ----------------------------------------------------------------------------
 
 #: Characters a Slack channel name can never contain. Deliberately minimal — the
-#: local-language names (#españa, #medellín, #munchen) must never be flagged —
+#: local-language name #españa must never be flagged —
 #: but enough to catch a URL, an email address or a sentence pasted into the
 #: wrong column. The "filled" count treats any non-blank cell as healthy, so
 #: without this check a pasted Drive URL reads as a mapped channel forever

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -31,13 +31,17 @@ def check(label, got, want):
 check("invite goes through the same allowlist as create/rename",
       "conversations.invite" in prov.WRITE_METHODS, True)
 # The absences are the point. `conversations.kick` joined the allowlist on
-# 2026-08-10 when pruning was authorised; archive and postMessage did not, and
-# the difference is real — a rename is reversible, destroying a room or speaking
-# in one is not.
-for forbidden in ("conversations.archive", "chat.postMessage",
-                  "conversations.leave", "conversations.delete"):
+# 2026-08-10 when pruning was authorised; archive, join and postMessage joined
+# on 2026-08-17 for the deprecated-room sweep (archive refuses non-`-deprecated`
+# names; postMessage exists only for the farewell pointer). Deleting a room —
+# the one truly unrecoverable act — stays out, as does leave.
+for forbidden in ("conversations.leave", "conversations.delete"):
     check("%s stays out of the allowlist" % forbidden,
           forbidden in prov.WRITE_METHODS, False)
+for sanctioned in ("conversations.archive", "chat.postMessage",
+                   "conversations.join"):
+    check("%s is reachable for the deprecated sweep" % sanctioned,
+          sanctioned in prov.WRITE_METHODS, True)
 
 
 def refuses(method):
@@ -49,7 +53,7 @@ def refuses(method):
 
 
 check("call_write refuses a method outside the allowlist",
-      refuses("conversations.archive"), True)
+      refuses("conversations.delete"), True)
 check("kick is reachable, but only through the one chokepoint",
       "conversations.kick" in prov.WRITE_METHODS, True)
 

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -153,12 +153,16 @@ check("the failure names the person's id, not the whole channel",
 # --- rename ordering: the London chain is the case that breaks naive order ----
 # Alphabetically london-meetup-organizers sorts BEFORE london-organizers, so an
 # unordered pass tries to take a name that is still occupied -> name_taken.
-_live = {"bangalore", "london-organizers", "london-meetup-organizers",
-         "bay-area-sf-organizers"}
-_ordered, _blocked = prov.order_renames(prov.CHANNEL_RENAMES, _live)
+# A FIXED map (the London chain plus one free rename), not the production
+# CHANNEL_RENAMES: that map changes several times a day, and the property
+# under test — chain ordering — must not silently change with the data.
+_chain = {"bangalore": "bengaluru",
+          "london-organizers": "london-organizers-deprecated",
+          "london-meetup-organizers": "london-organizers"}
+_live = {"bangalore", "london-organizers", "london-meetup-organizers"}
+_ordered, _blocked = prov.order_renames(_chain, _live)
 check("nothing is blocked", _blocked, [])
-check("every rename is scheduled exactly once",
-      len(_ordered), len(prov.CHANNEL_RENAMES))
+check("every rename is scheduled exactly once", len(_ordered), len(_chain))
 _pos = {old: i for i, (old, _) in enumerate(_ordered)}
 check("the occupant moves out before the new name is taken",
       _pos["london-organizers"] < _pos["london-meetup-organizers"], True)
@@ -185,6 +189,171 @@ check("deprecated rooms are marked 'deprecated'",
       all(v.endswith("-deprecated") for v in
           [prov.CHANNEL_RENAMES["london-organizers"],
            prov.CHANNEL_MERGES["southbay-chapter-leads"]["retire_as"]]), True)
+
+
+# --- plan(): applied-rename detection and create suppression -------------------
+# Synthetic maps throughout: the production CHANNEL_RENAMES changes daily and
+# these properties must not drift with it. Patch, test, restore.
+def _with_maps(renames, merges, fn):
+    saved = prov.CHANNEL_RENAMES, prov.CHANNEL_MERGES
+    prov.CHANNEL_RENAMES, prov.CHANNEL_MERGES = renames, merges
+    try:
+        return fn()
+    finally:
+        prov.CHANNEL_RENAMES, prov.CHANNEL_MERGES = saved
+
+
+_TABLES = {"public": {}, "organizers": {}, "regional": {}}
+
+# The London shape after the chain applied AND the sweep archived the parked
+# room: old name live again (held by the promoted room), target name exists
+# only among ARCHIVED names. Re-planning it would rename the real room away.
+_c, _r, _b, _m, _a, _applied = _with_maps(
+    {"old-organizers": "old-organizers-deprecated",
+     "meetup-organizers": "old-organizers"}, {},
+    lambda: prov.plan(_TABLES, live={"old-organizers"},
+                      all_names={"old-organizers", "old-organizers-deprecated"}))
+check("an applied chain is not re-planned against the real room", _r, [])
+check("and nothing is blocked by it", _b, [])
+check("the applied classification is reported, not swallowed",
+      _applied, [("old-organizers", "old-organizers-deprecated")])
+
+# A genuine squatter: the old name is nobody's rename target, so target-exists
+# means blocked — never silently treated as applied.
+_c, _r, _b, _m, _a, _applied = _with_maps(
+    {"utah": "salt-lake-city"}, {},
+    lambda: prov.plan(_TABLES, live={"utah", "salt-lake-city"},
+                      all_names={"utah", "salt-lake-city"}))
+check("a squatted target still blocks", _b, [("utah", "salt-lake-city")])
+check("a blocked rename is not reported as applied", _applied, [])
+
+# A name a pending rename frees INTO is satisfied by the rename, not created.
+_tables2 = {"public": {"Bern": "bern"}, "organizers": {}, "regional": {}}
+_c, _r, _b, _m, _a, _applied = _with_maps(
+    {"old-bern": "bern"}, {},
+    lambda: prov.plan(_tables2, live={"old-bern"}, all_names={"old-bern"}))
+check("a rename-freed name is not also created", _c, [])
+check("it counts as already satisfied", [n for n, _p, _w in _a], ["bern"])
+check("and the rename itself is planned", _r, [("old-bern", "bern")])
+
+# all_names defaults to live — pre-existing behavior unchanged.
+_c, _r, _b, _m, _a, _applied = _with_maps(
+    {"a": "b"}, {}, lambda: prov.plan(_TABLES, live={"a"}))
+check("all_names defaults to live", _r, [("a", "b")])
+
+
+# --- plan_archives(): the only gate before a room is closed --------------------
+def _chan(name, private=False, archived=False, members=()):
+    return {"name": name, "id": "C-" + name, "is_private": private,
+            "is_archived": archived, "_members": list(members)}
+
+
+def _plan_archives(chans, pointers, renames=None):
+    by_name = {c["name"]: c for c in chans}
+    live = {c["name"] for c in chans if not c["is_archived"]}
+    saved = (prov.DEPRECATED_POINTERS, prov.CHANNEL_RENAMES,
+             prov.slackmod.members)
+    prov.DEPRECATED_POINTERS = pointers
+    prov.CHANNEL_RENAMES = renames or {}
+    prov.slackmod.members = lambda api, cid: next(
+        c["_members"] for c in chans if c["id"] == cid)
+    try:
+        return prov.plan_archives(None, by_name, live, "U-ME")
+    finally:
+        (prov.DEPRECATED_POINTERS, prov.CHANNEL_RENAMES,
+         prov.slackmod.members) = saved
+
+
+check("a room not named -deprecated is never planned",
+      _plan_archives([_chan("x-old"), _chan("x")], {"x-old": "x"}), [])
+check("a -deprecated room queued for a rename is skipped, not archived",
+      _plan_archives([_chan("y-deprecated"), _chan("y")],
+                     {"y-deprecated": "y"}, renames={"y-deprecated": "y2"}),
+      [("y-deprecated", "skip", "pending rename to #y2 — not retired")])
+check("no recorded successor blocks",
+      [p[:2] for p in _plan_archives([_chan("z-deprecated")], {})],
+      [("z-deprecated", "blocked")])
+check("an archived successor blocks",
+      [p[:2] for p in _plan_archives(
+          [_chan("w-deprecated"), _chan("w", archived=True)],
+          {"w-deprecated": "w"})],
+      [("w-deprecated", "blocked")])
+check("a public room archives with a pointer",
+      [p[:2] for p in _plan_archives(
+          [_chan("p-deprecated", members=["U1"]), _chan("p")],
+          {"p-deprecated": "p"})],
+      [("p-deprecated", "archive")])
+check("a private room with a straggler blocks",
+      [p[:2] for p in _plan_archives(
+          [_chan("q-deprecated", private=True, members=["U1", "U2"]),
+           _chan("q", private=True, members=["U1"])],
+          {"q-deprecated": "q"})],
+      [("q-deprecated", "blocked")])
+check("a covered private room archives, with the token's own seat excused",
+      [p[:2] for p in _plan_archives(
+          [_chan("s-deprecated", private=True, members=["U1", "U-ME"]),
+           _chan("s", private=True, members=["U1"])],
+          {"s-deprecated": "s"})],
+      [("s-deprecated", "archive")])
+
+
+# --- call_write: retry only what fixes itself ----------------------------------
+check("a malformed Retry-After falls back instead of crashing",
+      [prov._retry_secs(v) for v in
+       ("Fri, 21 Aug 2026 07:28:00 GMT", None, "", "1.5", "30", -3)],
+      [10, 10, 10, 1, 30, 1])
+
+
+def _fake_urlopen_seq(responses):
+    """Each call pops the next payload; records how many calls were made."""
+    import io, json as _json  # noqa: E401
+
+    calls = []
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def opener(req, timeout=None):
+        calls.append(req)
+        return _Resp(_json.dumps(responses[min(len(calls) - 1,
+                                               len(responses) - 1)]).encode())
+    return opener, calls
+
+
+_saved_urlopen, _saved_sleep = prov.urllib.request.urlopen, prov.time.sleep
+try:
+    _sleeps = []
+    prov.time.sleep = _sleeps.append
+    _open, _calls = _fake_urlopen_seq([{"ok": False, "error": "ratelimited",
+                                        "retry_after": 2},
+                                       {"ok": True}])
+    prov.urllib.request.urlopen = _open
+    check("ratelimited retries and honours retry_after",
+          (prov.call_write("t", "conversations.rename", channel="C1",
+                           name="n"), len(_calls), _sleeps),
+          ({"ok": True}, 2, [2]))
+
+    _open, _calls = _fake_urlopen_seq([{"ok": False, "error": "name_taken"}])
+    prov.urllib.request.urlopen = _open
+    check("any other error returns to the caller without a retry",
+          (prov.call_write("t", "conversations.rename", channel="C1",
+                           name="n"), len(_calls)),
+          ({"ok": False, "error": "name_taken"}, 1))
+
+    _open, _calls = _fake_urlopen_seq([{"ok": False, "error": "ratelimited",
+                                        "retry_after": 1}])
+    prov.urllib.request.urlopen = _open
+    check("a permanent rate limit gives up after five attempts",
+          (prov.call_write("t", "conversations.rename", channel="C1",
+                           name="n").get("error"), len(_calls)),
+          ("ratelimited", 5))
+finally:
+    prov.urllib.request.urlopen = _saved_urlopen
+    prov.time.sleep = _saved_sleep
 
 if FAILS:
     print("\nFAIL (%d)" % len(FAILS))


### PR DESCRIPTION
## What

The Slack audits moved to the AAIF app token (the CLI token expired), which carries `channels:history`/`groups:history` — so the old "activity is unreadable" ceiling no longer holds. The first provisioning runs then drove a full naming-convention reconciliation of the chapter channel estate, and the branch grew the automation that finishes it.

### Activity audit (original scope)
- **New engine** `audit_activity.py`: per live channel, last *human* message, trailing-window volume, distinct posters, bot/join noise. No message text retained — timestamps, counts and poster ids only. Resumable within a UTC day; renders the house-style HTML+PDF.
- **`lib/aaif_events/slack.py`**: `conversations.history` in `ALLOWED_METHODS` + `history_activity()` collector.
- **Member report** unions the activity cache's poster ids into a measured "posted in last N days" floor; **organizer report** gains `--planned-ok`.

### Naming-convention sweep (2026-08-17..19)
- `CHANNEL_RENAMES`/`CHANNEL_MERGES` reworked through three rounds of live reconciliation: legacy meetup-era prefixes, local-language names (`munchen→munich`, `medellín→medellin`), Austin junk-room recovery, Barcelona's real organizer room adopted via merge, Sydney investigated and deliberately left alone, capital-city chapters (Bern/Edinburgh/Salt Lake City — `#switzerland`/`#scotland` stay as country rooms).
- `KEPT_NON_CONVENTIONAL` is down to `bay-area`; both SKILL.mds updated to match.

### Deprecated-room archive sweep (new capability)
- `conversations.archive`/`join` and `chat.postMessage` join the write allowlist under tight guards: only `*-deprecated` rooms, public rooms only after a farewell pointer post lands, private rooms only when every member is already in the recorded successor, pending-rename rooms skipped, no-successor rooms reported never archived.
- Applied-rename detection counts archived names as evidence (and reports what it classified as applied), so the sweep can't cause a finished chain to re-plan against a real room.

### Self-review hardening
- Merge-target existence check ignores archived rooms; join failures are named instead of surfacing as `not_in_channel`; `Retry-After` parsed defensively in both clients; archive guard is a hard raise; activity cache reuse matches `--days`.

## Changesets
1. `feat(audit-slack)`: activity engine on the app token, plus provisioning fixes
2. `chore(audit-slack)` + 3 × `feat(sync-chapters)`: rename sweeps rounds one–three
3. `feat(sync-chapters)`: deprecated-room sweep + naming-queue updates
4. `docs(sync-chapters)`: KEPT_NON_CONVENTIONAL down to bay-area
5. `fix(audit-slack)`: `_row` fixture `regional_how`
6. `fix` + `docs(skills)` + `test`: self-review findings — sweep robustness, cache windows, operator contract, 20 new test cases

## Testing
- `PYTHONPATH=lib python -m pytest lib/aaif_events/tests -q` — 126 passed
- All skill test scripts pass; `pre-commit run --all-files` clean; `claude plugin validate` passes
- Live: full-workspace sweeps ran against MLOps.community across three days; provisioning re-runs converge (renames idempotent, failures correctly classified); the archive sweep closed 3 rooms with farewell pointers in production

_Generated using hero-skills._

🤖 Generated with [Claude Code](https://claude.com/claude-code)