### PR TITLE
Self-serve organizer policy, qualified-slug channel estate, erstwhile guard

### DIFF
--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aaif-sync-chapters
-description: Push intake decisions out of the Intake Ops sheet — accepted organizers onto the Chapters List and into each chapter's About doc, accepted people plus their survey interest into their chapter's Attendee CRM, per-chapter Drive access to replace the folder's public link-share, and each chapter's Drive folder and Slack channels onto the Chapters List resource map. Reports & proposes by default; only writes on explicit approval. Use when asked to sync organizers/chapters/CRMs, push intake decisions to the chapters list, update a chapter's About doc organizers, add intake people to a chapter's CRM, give organizers access to their own chapter, or record which Slack channel and Drive folder a chapter uses.
+description: Push intake decisions out of the Intake Ops sheet — accepted organizers onto the Chapters List and into each chapter's About doc, intake people plus their survey interest into their chapter's Attendee CRM (accepted people always; organizer candidates only where the chapter is big enough to self-serve), per-chapter Drive access to replace the folder's public link-share, and each chapter's Drive folder and Slack channels onto the Chapters List resource map. Reports & proposes by default; only writes on explicit approval. Use when asked to sync organizers/chapters/CRMs, push intake decisions to the chapters list, update a chapter's About doc organizers, add intake people to a chapter's CRM, give organizers access to their own chapter, or record which Slack channel and Drive folder a chapter uses.
 argument-hint: "[chapters|about|crm|access|resources|nightly] [--write]"
 ---
 
@@ -13,7 +13,7 @@ ever read**, the report is the default, and `--write` re-verifies itself:
 |---|---|---|---|
 | Chapters feed | `sync_chapters.py` | **accepted organizer names** | the public Chapters List sheet |
 | About docs | `sync_about.py` | **accepted organizer names** | each chapter folder's `About.docx` |
-| Chapter CRMs | `sync_crm.py` | **accepted people + their survey interest** | each chapter's private `<City> CRM.xlsx` |
+| Chapter CRMs | `sync_crm.py` | **accepted + pipeline people (self-serve policy) + their survey interest** | each chapter's private `<City> CRM.xlsx` |
 | Chapter access | `sync_access.py` | **per-chapter Drive grants** | the Chapters folder's sharing |
 | Resource map | `sync_resources.py` | **Drive folder + Slack channels** | the Chapters List resource columns |
 
@@ -323,16 +323,29 @@ Every chapter folder under the **Chapters** Drive folder
 `Attendees` tab is the chapter's private people database. `sync_crm.py` fills it
 from the intake and carries each person's survey interest across.
 
-**This CRM is the onboarding list.** It decides who gets access to a chapter's
-Drive folder, so a person reaches it after a **decision**, not on submitting the
-form. Only `Accepted` and `Existing (from MLOps)` sync. This is an allowlist:
-every other status on the intake dropdown is held back and reported, by
-construction — see `aaif-triage-intake` for the current set rather than trusting
-an enumeration here, which would rot the next time the dropdown changes.
+**Who syncs — the self-serve organizer policy (2026-08).**
 
-> As of 2026-08 that means **organizers only** — the Hosts and Speakers tabs have
-> never been triaged off `New` (0 of 26 and 0 of 55). Both start flowing the
-> moment someone accepts them; nothing in the engine needs to change for that.
+- `Accepted` and `Existing (from MLOps)` people always sync, all three role tabs.
+- **Hosts and speakers still in the pipeline** (`New` / blank / `In progress` /
+  `Tentative` / `Interviewing`) sync too, so a chapter sees its candidate venues
+  and talks without waiting on central triage.
+- **Organizers still in the pipeline** sync **only into a self-serve chapter** —
+  one with **4+ accepted organizers** (`SELF_SERVE_MIN`), not counting AAIF ops
+  people (`AAIF_OPS_NAMES`: Rahul, Demetrios, Ijeoma). Those chapters run their
+  own interviews and grow their own team; below the threshold, organizer
+  approval stays with AAIF ops and the candidates are held back and reported
+  ("Held" line; `--verbose` names them).
+- `Denied` / `Inactive` / `Duplicate` never sync. Both status sets are
+  **allowlists** in `sync_crm.py` (`SYNC_STATUSES`, `PIPELINE_STATUSES`), so a
+  new dropdown value syncs nobody until it's placed — fail closed.
+
+A pipeline person lands as `Prospect` (organizers) or their role status
+(hosts/speakers), never `Trusted/Regular`. Acceptance upgrades the row in place
+on a later run. **Drive access still keys off acceptance** — `sync_access.py`
+reads the intake with the accepted-only default, so a Prospect in the CRM gets
+no folder grant. One gap to know about: a Prospect whose intake row is later
+`Denied` stays in the CRM (the engine never deletes people) and shows up under
+"Already in a CRM and NOT touched" — remove that row by hand.
 
 **Keep it minimal.** Only six of the eleven columns are ever written. `Signal`,
 `LinkedIn URL`, `Company`, `Role / title` and `Technical expertise` still exist
@@ -369,9 +382,9 @@ are being onboarded (see the sharing note at the end of this section).
 | CRM column | Filled from |
 |---|---|
 | `Full name` | role tab `Name` / `Full name` |
-| `Trusted/Regular` | `Yes` for an organizer — they're on the team, not a guest to triage |
-| `Status` | `Organizer` / `Speaker` / `Host` (everyone syncing is already accepted) |
-| `Notes (CRM)` | provenance — `Intake: Organizer · Accepted · 2026-08-07` |
+| `Trusted/Regular` | `Yes` for an **accepted** organizer — they're on the team, not a guest to triage |
+| `Status` | the accepted role (`Organizer` / `Speaker` / `Host`); a pipeline organizer is `Prospect`, a pipeline host/speaker keeps the role status |
+| `Notes (CRM)` | provenance — `Intake: Organizer · Accepted · 2026-08-07` (every merged role and status, in priority order) |
 | `Email` | role tab `Email` — **also the dedupe key** |
 | `What brings you here?` | the survey answer **verbatim**, plus the role's detail (`Talk title` / `Venue name` / `Chapter / city wanted`) |
 
@@ -475,9 +488,12 @@ is why row writes, serialization and the dropdown patch all live inside
 
 ## Sharing: minimal by design
 
-`CRM_WRITTEN` (six columns) and `SYNC_STATUSES` (accepted only) are what keep
-un-vetted applicants and their survey detail out of a folder shared more widely
-than intended. **Re-check the folder's sharing before widening either** — they
+`CRM_WRITTEN` (six columns) plus the status allowlists (`SYNC_STATUSES`,
+`PIPELINE_STATUSES` and the `SELF_SERVE_MIN` gate on pipeline organizers) are
+what keep declined applicants and everyone's survey detail out of a folder
+shared more widely than intended — and since 2026-08 a *vetting-in-progress*
+person can legitimately appear in a self-serve chapter's CRM as a `Prospect`.
+**Re-check the folder's sharing before widening any of them** — they
 are the whole mitigation, and the CRM is written *before* access is narrowed
 (feed → CRM → access), so the write lands under whatever sharing exists at the
 time.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -343,7 +343,11 @@ A pipeline person lands as `Prospect` (organizers) or their role status
 (hosts/speakers), never `Trusted/Regular`. Acceptance upgrades the row in place
 on a later run. **Drive access still keys off acceptance** — `sync_access.py`
 reads the intake with the accepted-only default, so a Prospect in the CRM gets
-no folder grant. One gap to know about: a Prospect whose intake row is later
+no folder grant. One merge refusal (the form is public and email is the merge
+key): a **not-yet-accepted row never merges into a person whose rows are all
+accepted** — it is reported under the not-synced count ("SECURITY" line;
+`--verbose` names it) for a human to review, so a stranger submitting under an
+accepted organizer's address cannot write into that person's CRM row. One gap to know about: a Prospect whose intake row is later
 `Denied` stays in the CRM (the engine never deletes people) and shows up under
 "Already in a CRM and NOT touched" — remove that row by hand.
 
@@ -678,16 +682,21 @@ local-language channels to the convention (a rename keeps members and history,
 so nothing was lost). The exceptions that remain are all deliberate and all
 recorded in code:
 
-- **`KEPT_NON_CONVENTIONAL`** — rooms whose name is kept: `#bay-area` (one room
-  serving two chapters) and the 2026-08-22 **qualified slugs**.
+- **`KEPT_NON_CONVENTIONAL`** — a *decision record* (nothing reads it at
+  runtime) of city rooms whose name is kept: `#bay-area` (one room serving two
+  chapters) plus the 2026-08-22 qualified **city** slugs and `#munchen`. The
+  qualified *organizer* slugs live on the sheet and in `CHANNEL_RENAMES`, not
+  here.
 - **Qualified slugs (2026-08-22, user-decided — "fewest divergences"):** where a
   conventional name is held by an *invisible private squatter* the Pro plan
   cannot reclaim, the room takes a qualified form instead of waiting: city rooms
   get a state code (`#austin-tx`, `#charlotte-nc`, `#dallas-tx`) or keep the
-  native name (`#munchen`, `#deutschland` — the `#españa` precedent); organizer
-  rooms get `<city>-<state|countrycode>-organizers` (`seattle-wa-organizers`,
-  `toronto-ca-organizers`, …). The suffix and column semantics never change —
-  only the city slug gains a code.
+  native name (`#munchen`, the `#españa` precedent); organizer rooms get
+  `<city>-<state|countrycode>-organizers` (`seattle-wa-organizers`,
+  `toronto-ca-organizers`, …). Country rooms follow the same native-name move —
+  `#deutschland` was *created* as Germany's country room because `#germany` is
+  squatted (`COUNTRY_CHANNELS`). The suffix and column semantics never change —
+  only the slug diverges.
 - **`Erstwhile Channels` (sheet column):** every squatted or superseded name is
   recorded there per chapter, and `provision_channels.py` **refuses to create or
   rename into any recorded name** (`forbid_erstwhile`, fed by
@@ -799,10 +808,13 @@ Renames run **before** creates — creating `#bengaluru` first would take the na
 and strand `#bangalore`'s members in the old room.
 
 Two prerequisites, neither in place by default: a token with `channels:write`,
-`groups:write` and `chat:write` (user-token scopes for create/rename and the
-farewell pointer; `channels:join` is worth adding so the sweep can join a
-public room before posting in it — the audit token has read scopes only), and
-`--i-have-approval` alongside `--write`.
+`groups:write` and `chat:write` in `$AAIF_SLACK_WRITE_TOKEN` (user-token scopes
+for create/rename and the farewell pointer; `channels:join` is worth adding so
+the sweep can join a public room before posting in it), and `--i-have-approval`
+alongside `--write`. Since 2026-08-22 the **read-only report also prefers
+`$AAIF_SLACK_WRITE_TOKEN`** — the Slack CLI credential expired for good and
+cannot be re-scoped, so without the env var the run falls back to a dead
+credential and says so on stderr.
 
 ## Adding organizers to their channel (`invite_organizers.py`)
 

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -671,15 +671,31 @@ Naming, and the one rule that is not obvious:
   deliberate multi-chapter room `#bay-area` (SF + Silicon Valley), which the
   `<city>` convention cannot express at all.
 
-## Why one channel name is still not `<city>`, and why that is correct
+## Why some channel names are still not `<city>`, and why that is correct
 
 The 2026-08-17 naming sweep renamed the legacy meetup-era, wider-scope and
 local-language channels to the convention (a rename keeps members and history,
-so nothing was lost — even `#munchen` and `#medellín` fell to typability; a few
-renames are still pending behind invisible squatters, see
-`provision_channels.CHANNEL_RENAMES`). One survivor remains, recorded in
-`KEPT_NON_CONVENTIONAL`: `#bay-area`, one room deliberately serving two
-chapters.
+so nothing was lost). The exceptions that remain are all deliberate and all
+recorded in code:
+
+- **`KEPT_NON_CONVENTIONAL`** — rooms whose name is kept: `#bay-area` (one room
+  serving two chapters) and the 2026-08-22 **qualified slugs**.
+- **Qualified slugs (2026-08-22, user-decided — "fewest divergences"):** where a
+  conventional name is held by an *invisible private squatter* the Pro plan
+  cannot reclaim, the room takes a qualified form instead of waiting: city rooms
+  get a state code (`#austin-tx`, `#charlotte-nc`, `#dallas-tx`) or keep the
+  native name (`#munchen`, `#deutschland` — the `#españa` precedent); organizer
+  rooms get `<city>-<state|countrycode>-organizers` (`seattle-wa-organizers`,
+  `toronto-ca-organizers`, …). The suffix and column semantics never change —
+  only the city slug gains a code.
+- **`Erstwhile Channels` (sheet column):** every squatted or superseded name is
+  recorded there per chapter, and `provision_channels.py` **refuses to create or
+  rename into any recorded name** (`forbid_erstwhile`, fed by
+  `sync_resources.read_erstwhile`). If a refusal is wrong, fix the sheet — both
+  the resource cell and the history column — not the plan.
+- **Renames are individually confirmed.** Never batch-rename on a scheme
+  approval: present each `old → new` to the user and wait, then delete the
+  "renamed the channel" system message the rename leaves behind.
 
 ### A country room is not a chapter room
 

--- a/skills/aaif-sync-chapters/scripts/invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/invite_organizers.py
@@ -76,10 +76,16 @@ def collect(city_filter=None):
     rows = [{city, channel, channel_id, missing: [(name, id)], present: [...],
              unaccounted: [ids]}].
     """
-    # Same read-token fallback as provision_channels.main(): the CLI credential
-    # expired for good in 2026-08, and the env write token carries the read
-    # scopes the audits already run on.
-    api = slackmod.Slack(token=os.environ.get(WRITE_TOKEN_ENV, "").strip() or None)
+    # Same read-token fallback as provision_channels.main(): this estate's CLI
+    # credential expired for good in 2026-08, and the env write token carries
+    # the read scopes the audits already run on. Name the real fix when the
+    # env var is absent, or the eventual auth error blames the wrong credential.
+    token = os.environ.get(WRITE_TOKEN_ENV, "").strip()
+    if not token:
+        print("note: %s is not set — falling back to the Slack CLI credential, "
+              "which on this estate is expired. If auth fails, export %s."
+              % (WRITE_TOKEN_ENV, WRITE_TOKEN_ENV), file=sys.stderr)
+    api = slackmod.Slack(token=token or None)
     api.require_scopes("channels:read", "groups:read",
                        "users:read", "users:read.email")
 

--- a/skills/aaif-sync-chapters/scripts/invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/invite_organizers.py
@@ -52,7 +52,8 @@ sys.path.insert(0, os.path.join(_HERE, "..", "..", "..", "lib"))
 
 from sync_chapters import NO_RESOURCE, fold_city  # noqa: E402
 from sync_resources import read_grid  # noqa: E402
-from provision_channels import call_write, write_token, WRITE_METHODS  # noqa: E402
+from provision_channels import (call_write, write_token, WRITE_METHODS,  # noqa: E402
+                                WRITE_TOKEN_ENV)
 
 import audit_organizers as ao  # noqa: E402
 from aaif_events import slack as slackmod  # noqa: E402
@@ -75,7 +76,10 @@ def collect(city_filter=None):
     rows = [{city, channel, channel_id, missing: [(name, id)], present: [...],
              unaccounted: [ids]}].
     """
-    api = slackmod.Slack()
+    # Same read-token fallback as provision_channels.main(): the CLI credential
+    # expired for good in 2026-08, and the env write token carries the read
+    # scopes the audits already run on.
+    api = slackmod.Slack(token=os.environ.get(WRITE_TOKEN_ENV, "").strip() or None)
     api.require_scopes("channels:read", "groups:read",
                        "users:read", "users:read.email")
 

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -133,8 +133,9 @@ CHANNEL_RENAMES = {
     "london-meetup-organizers": "london-organizers",
     "bay-area-sf-organizers": "bay-area-organizers",
     # 2026-08-21: the once-queued #austin-area-organizers -> #austin-organizers
-    # rename was DROPPED along with the #austin plan below — the chapter keeps
-    # the austin-area name, so its organizer room already matches.
+    # rename was DROPPED with the #austin plan; on 2026-08-22 the qualified
+    # convention then renamed the pair by hand: #austin-area -> #austin-tx and
+    # #austin-area-organizers -> #austin-tx-organizers (see the block below).
     # 2026-08-17 naming-convention sweep (user-decided): city channels take the
     # plain city name, organizer rooms take <city>-organizers. #bay-area is a
     # deliberate keep.
@@ -148,29 +149,32 @@ CHANNEL_RENAMES = {
     # frankfurt_main→frankfurt(+-organizers), nyc→new-york,
     # nyc-chapter-leads→new-york-organizers, portland-oregon→portland,
     # washington-dc-the-capital-organizers→washington-dc-organizers.
-    # STILL PENDING below — each target name is held by an INVISIBLE private
-    # room, so they fail with name_taken (non-fatal) until those are
-    # deprecated via the admin UI. (NOT meetup-barcelona-organizers ->
-    # barcelona-organizers: its "squatter" turned out to be the REAL organizer
-    # room — 2024, 16 members — so the freshly provisioned 3-member room merges
-    # into it instead; see CHANNEL_MERGES.)
-    # 2026-08-22 (user-decided): squat-affected organizer rooms take the
-    # QUALIFIED convention `<city>-<state|countrycode>-organizers` instead of
-    # waiting on their invisible squatters — the suffix stays, only the city
-    # slug gains a code, mirroring the austin-tx / charlotte-nc / dallas-tx
-    # city rooms. Applied same day for Seattle, Portland and Austin, and for
-    # the seven rooms that had briefly carried the reversed organizers-<city>
-    # names (Toronto/Melbourne/Milan/Oslo/Seoul/Sydney/Vancouver).
+    # (NOT meetup-barcelona-organizers -> barcelona-organizers: its "squatter"
+    # turned out to be the REAL organizer room — 2024, 16 members — so the
+    # freshly provisioned 3-member room merges into it instead; see
+    # CHANNEL_MERGES.)
+    # 2026-08-22 (user-decided, "fewest divergences"): squat-affected organizer
+    # rooms take the QUALIFIED convention `<city>-<state|countrycode>-organizers`
+    # instead of waiting on their invisible squatters — the suffix stays, only
+    # the city slug gains a code, mirroring the austin-tx / charlotte-nc /
+    # dallas-tx city rooms. The qualified targets have NO squatter, and every
+    # rename below was APPLIED BY HAND the same day (kept here as the record;
+    # plan() classifies them applied because the old names are no longer live).
+    # Also applied by hand, no entries needed: the seven rooms that briefly
+    # carried reversed organizers-<city> names (Toronto/Melbourne/Milan/Oslo/
+    # Seoul/Sydney/Vancouver) were renamed to their qualified forms, and
+    # #austin-area / #austin-area-organizers became #austin-tx /
+    # #austin-tx-organizers.
     "meetup-seattle-organizers": "seattle-wa-organizers",
     "washington-dc-the-capital": "washington-dc",
-    # Austin RESOLVED 2026-08-21 (user-decided): #austin stays squatted by an
-    # invisible private room with no path to free it on the Pro plan, so the
-    # chapter keeps its historical name instead — the real room (76 members,
-    # 2023; parked as #austin-area-deprecated on 2026-08-17) was renamed BACK
-    # to #austin-area, the sheet's Slack Channel cell now says `austin-area`,
-    # and the 2026-08-18 junk room was renamed to #austin-area-junk and
-    # re-archived to free the name. A deliberate keep like #bay-area — do NOT
-    # re-plan #austin even if the squatter is someday cleared.
+    # Austin, full history: #austin is squatted with no path to free it on the
+    # Pro plan. 2026-08-21 parked the chapter on its historical #austin-area
+    # (junk room archived as #austin-area-junk); 2026-08-22's qualified
+    # convention superseded that with #austin-tx (the sheet's Slack Channel
+    # cell now says `austin-tx`, KEPT_NON_CONVENTIONAL carries it, and the
+    # squatted `austin`/`austin-organizers` names live in the sheet's
+    # Erstwhile Channels column). Do NOT re-plan #austin even if the squatter
+    # is someday cleared.
     "portland-oregon-organizers": "portland-or-organizers",
     # 2026-08-19 (user-decided, revised same day): country-named chapters
     # become capital-city chapters — but #switzerland (80) and #scotland (71)
@@ -192,8 +196,9 @@ CHANNEL_RENAMES = {
     # the real chapter room (all the recent activity) — its own message history
     # settled it: a TEMPORARY event-coordination room with external sponsor
     # folk in it, to be left alone under its own name. #sydney (2022, 57
-    # members) stays the city room; #sydney-organizers is planned from the
-    # sheet and currently blocked by an invisible private squatter.
+    # members) stays the city room; the organizer room is
+    # #sydney-au-organizers (created 2026-08-22 under the qualified
+    # convention — the squatted #sydney-organizers is recorded as erstwhile).
     # munchen -> munich DROPPED 2026-08-22 (user-decided): #munich is squatted
     # by an invisible private room, so #munchen (107 members) keeps its native
     # name — the #españa / #deutschland precedent. The sheet's Slack Channel
@@ -327,10 +332,14 @@ def order_renames(renames, live):
 
 
 #: Write scopes cannot be added to the Slack CLI's own token, so the write path
-#: takes a SEPARATE token from `AAIF_SLACK_WRITE_TOKEN`. The audit keeps using
-#: `~/.slack/credentials.json` untouched — which is the point: the read path
-#: cannot acquire write power by accident, and revoking the write app does not
-#: disturb the audits.
+#: takes a SEPARATE token from `AAIF_SLACK_WRITE_TOKEN`. Since 2026-08-22 the
+#: READ path here (and in invite_organizers) prefers the same env token: the
+#: CLI credential expired for good that month and cannot be re-scoped, so the
+#: old "reads never touch the write token" separation is retired for these two
+#: scripts — the remaining guarantees are call-level, not token-level:
+#: call_write() is the only door to WRITE_METHODS, and every write still sits
+#: behind `--write --i-have-approval`. (On a machine with live CLI creds and
+#: no env token, reads still work read-only off the CLI credential.)
 WRITE_TOKEN_ENV = "AAIF_SLACK_WRITE_TOKEN"
 
 
@@ -398,8 +407,14 @@ def _retry_secs(value, default=10):
         return default
 
 
-def plan(tables, live, all_names=None):
-    """Return (creates, renames, blocked, merges, already, applied).
+def plan(tables, live, all_names=None, forbidden=frozenset()):
+    """Return (creates, renames, blocked, merges, already, applied, refused).
+
+    `forbidden` is the erstwhile-name set (sync_resources.read_erstwhile):
+    creates and rename TARGETS matching it are moved to `refused` — inside
+    plan(), not at the call site, so no future caller can obtain an unfiltered
+    plan. The filter runs BEFORE rename ordering, so a refused rename can
+    never leave order_renames() counting on a name it would have freed.
 
     `all_names` is every channel name INCLUDING archived ones (defaults to
     `live`). Applied-rename detection must use it: once the deprecated-room
@@ -454,9 +469,12 @@ def plan(tables, live, all_names=None):
     # step that was meant to free a name simply never appearing anywhere.
     applied = sorted((o, n) for o, n in CHANNEL_RENAMES.items()
                      if o in live and o not in wanted)
+    creates, wanted_pairs, refused = forbid_erstwhile(
+        creates, sorted(wanted.items()), forbidden)
+    wanted = dict(wanted_pairs)
     renames, blocked = order_renames(wanted, live)
     merges = [(o, m) for o, m in sorted(CHANNEL_MERGES.items()) if o in live]
-    return creates, renames, blocked, merges, already, applied
+    return creates, renames, blocked, merges, already, applied, refused
 
 
 def forbid_erstwhile(creates, renames, forbidden):
@@ -486,11 +504,18 @@ def main():
                     help="required alongside --write; see the module docstring")
     a = ap.parse_args()
 
-    # The CLI credential expired for good in 2026-08 and cannot be re-scoped,
-    # so reads fall back to the same env token the writes use — it carries the
-    # read scopes (the audits run on it), and a run that has no env token still
-    # works read-only off live CLI creds where those exist.
-    token = os.environ.get(WRITE_TOKEN_ENV, "").strip() or slackmod.load_token()
+    # This estate's CLI credential expired for good in 2026-08 and cannot be
+    # re-scoped, so reads prefer the same env token the writes use — it
+    # carries the read scopes (the audits run on it). The load_token fallback
+    # exists for a DIFFERENT machine with its own live CLI credential; here it
+    # only produces a later auth failure, so name the actual fix up front
+    # instead of letting load_token's "run `slack auth login`" advice mislead.
+    token = os.environ.get(WRITE_TOKEN_ENV, "").strip()
+    if not token:
+        print("note: %s is not set — falling back to the Slack CLI credential, "
+              "which on this estate is expired. If auth fails, export %s."
+              % (WRITE_TOKEN_ENV, WRITE_TOKEN_ENV), file=sys.stderr)
+        token = slackmod.load_token()
     api = slackmod.Slack(token=token)
     who = api.ok("auth.test")
     print("workspace: %s (%s)\n" % (who.get("team"), who.get("team_id")))
@@ -499,18 +524,33 @@ def main():
     live = {c["name"] for c in chans if not c["is_archived"]}
     by_name = {c["name"]: c for c in chans}
     _, tables = ao.read_chapters()
-    creates, renames, blocked, merges, already, applied = plan(
-        tables, live, set(by_name))
     # Imported here, not at module top: sync_resources pulls in the whole CRM
     # engine, and the plan()/forbid_erstwhile() unit tests import this module
     # without a sheet to read.
-    from sync_resources import read_erstwhile
-    creates, renames, refused = forbid_erstwhile(creates, renames, read_erstwhile())
+    from sync_resources import ERSTWHILE_COLUMN, read_erstwhile
+    forbidden, unparsed, col_present = read_erstwhile()
+    creates, renames, blocked, merges, already, applied, refused = plan(
+        tables, live, set(by_name), forbidden=forbidden)
     # Only rooms ALREADY deprecated at plan time: one this run retires still
     # has its people, so it waits for the next run — by which point they have
     # had the pointer, or (private) have been invited across.
     archives = plan_archives(api, by_name, live, who.get("user_id"))
 
+    # The guard's state prints on EVERY run, active or not: a run with the
+    # column missing/renamed must not be indistinguishable from a run where
+    # the guard loaded and had nothing to refuse — this sheet has silently
+    # broken a reader through restructuring once already.
+    if not col_present:
+        print("WARNING: erstwhile guard INACTIVE — column %r is not on the "
+              "sheet. On the live tab it has existed since 2026-08-22, so its "
+              "absence means a rename/restructure disarmed the guard."
+              % ERSTWHILE_COLUMN)
+    else:
+        print("erstwhile guard: %d name(s) protected%s"
+              % (len(forbidden),
+                 "; %d unparsable token(s) NOT protected: %s"
+                 % (len(unparsed), ", ".join(sorted(set(unparsed))))
+                 if unparsed else ""))
     print("Already exist: %d" % len(already))
     if refused:
         print("\nREFUSED — erstwhile name(s) the estate walked away from "

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -132,10 +132,9 @@ CHANNEL_RENAMES = {
     "london-organizers": "london-organizers-deprecated",
     "london-meetup-organizers": "london-organizers",
     "bay-area-sf-organizers": "bay-area-organizers",
-    # The organizer room was freshly created 2026-08-16 with no history to
-    # lose, so it takes the plain city name the user asked for. (Blocked until
-    # the invisible #austin-organizers squatter is deprecated.)
-    "austin-area-organizers": "austin-organizers",
+    # 2026-08-21: the once-queued #austin-area-organizers -> #austin-organizers
+    # rename was DROPPED along with the #austin plan below — the chapter keeps
+    # the austin-area name, so its organizer room already matches.
     # 2026-08-17 naming-convention sweep (user-decided): city channels take the
     # plain city name, organizer rooms take <city>-organizers. #bay-area is a
     # deliberate keep.
@@ -157,14 +156,14 @@ CHANNEL_RENAMES = {
     # into it instead; see CHANNEL_MERGES.)
     "meetup-seattle-organizers": "seattle-organizers",
     "washington-dc-the-capital": "washington-dc",
-    # Austin's REAL room (76 members, 2023) was hand-renamed to -deprecated in
-    # the admin UI on 2026-08-17 while #austin was still squatted, and the
-    # sheet's stale `austin-area` cell then made a --write run create a junk
-    # room under the freed name (archived 2026-08-18). This entry is the
-    # recovery: the moment the #austin squatter is cleared, the real room takes
-    # the city name — and its presence stops plan() from CREATING #austin
-    # first, which would re-run the same accident under the new name.
-    "austin-area-deprecated": "austin",
+    # Austin RESOLVED 2026-08-21 (user-decided): #austin stays squatted by an
+    # invisible private room with no path to free it on the Pro plan, so the
+    # chapter keeps its historical name instead — the real room (76 members,
+    # 2023; parked as #austin-area-deprecated on 2026-08-17) was renamed BACK
+    # to #austin-area, the sheet's Slack Channel cell now says `austin-area`,
+    # and the 2026-08-18 junk room was renamed to #austin-area-junk and
+    # re-archived to free the name. A deliberate keep like #bay-area — do NOT
+    # re-plan #austin even if the squatter is someday cleared.
     "portland-oregon-organizers": "portland-organizers",
     # 2026-08-19 (user-decided, revised same day): country-named chapters
     # become capital-city chapters — but #switzerland (80) and #scotland (71)
@@ -460,7 +459,11 @@ def main():
                     help="required alongside --write; see the module docstring")
     a = ap.parse_args()
 
-    token = slackmod.load_token()
+    # The CLI credential expired for good in 2026-08 and cannot be re-scoped,
+    # so reads fall back to the same env token the writes use — it carries the
+    # read scopes (the audits run on it), and a run that has no env token still
+    # works read-only off live CLI creds where those exist.
+    token = os.environ.get(WRITE_TOKEN_ENV, "").strip() or slackmod.load_token()
     api = slackmod.Slack(token=token)
     who = api.ok("auth.test")
     print("workspace: %s (%s)\n" % (who.get("team"), who.get("team_id")))

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -459,6 +459,26 @@ def plan(tables, live, all_names=None):
     return creates, renames, blocked, merges, already, applied
 
 
+def forbid_erstwhile(creates, renames, forbidden):
+    """Drop any create or rename whose TARGET is a recorded erstwhile name.
+
+    Returns (creates, renames, refused) where refused = [(kind, name, detail)].
+    An erstwhile name is one the sheet's Erstwhile Channels column records as
+    squatted or superseded (see sync_resources.ERSTWHILE_COLUMN): the estate
+    deliberately walked away from it, so recreating it — because a cell was
+    hand-reverted, or a squatter was archived and the name came free — would
+    resurrect a divergence the 2026-08-22 convention closed. Refused entries
+    are REPORTED, never silently dropped; fixing one means editing the sheet
+    (both the resource cell and the history column), not this code.
+    """
+    refused = ([("create", n, why) for n, _, why in creates if n in forbidden]
+               + [("rename", new, "#%s -> #%s" % (old, new))
+                  for old, new in renames if new in forbidden])
+    return ([c for c in creates if c[0] not in forbidden],
+            [r for r in renames if r[1] not in forbidden],
+            refused)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--write", action="store_true")
@@ -481,12 +501,22 @@ def main():
     _, tables = ao.read_chapters()
     creates, renames, blocked, merges, already, applied = plan(
         tables, live, set(by_name))
+    # Imported here, not at module top: sync_resources pulls in the whole CRM
+    # engine, and the plan()/forbid_erstwhile() unit tests import this module
+    # without a sheet to read.
+    from sync_resources import read_erstwhile
+    creates, renames, refused = forbid_erstwhile(creates, renames, read_erstwhile())
     # Only rooms ALREADY deprecated at plan time: one this run retires still
     # has its people, so it waits for the next run — by which point they have
     # had the pointer, or (private) have been invited across.
     archives = plan_archives(api, by_name, live, who.get("user_id"))
 
     print("Already exist: %d" % len(already))
+    if refused:
+        print("\nREFUSED — erstwhile name(s) the estate walked away from "
+              "(fix the sheet, not the plan):")
+        for kind, name, detail in refused:
+            print("  #%-28s %-8s %s" % (name, kind, detail))
     print("\nTo CREATE (%d):" % len(creates))
     for name, private, why in creates:
         print("  #%-28s %-8s %s" % (name, "private" if private else "public", why))

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -154,7 +154,14 @@ CHANNEL_RENAMES = {
     # barcelona-organizers: its "squatter" turned out to be the REAL organizer
     # room — 2024, 16 members — so the freshly provisioned 3-member room merges
     # into it instead; see CHANNEL_MERGES.)
-    "meetup-seattle-organizers": "seattle-organizers",
+    # 2026-08-22 (user-decided): squat-affected organizer rooms take the
+    # QUALIFIED convention `<city>-<state|countrycode>-organizers` instead of
+    # waiting on their invisible squatters — the suffix stays, only the city
+    # slug gains a code, mirroring the austin-tx / charlotte-nc / dallas-tx
+    # city rooms. Applied same day for Seattle, Portland and Austin, and for
+    # the seven rooms that had briefly carried the reversed organizers-<city>
+    # names (Toronto/Melbourne/Milan/Oslo/Seoul/Sydney/Vancouver).
+    "meetup-seattle-organizers": "seattle-wa-organizers",
     "washington-dc-the-capital": "washington-dc",
     # Austin RESOLVED 2026-08-21 (user-decided): #austin stays squatted by an
     # invisible private room with no path to free it on the Pro plan, so the
@@ -164,7 +171,7 @@ CHANNEL_RENAMES = {
     # and the 2026-08-18 junk room was renamed to #austin-area-junk and
     # re-archived to free the name. A deliberate keep like #bay-area — do NOT
     # re-plan #austin even if the squatter is someday cleared.
-    "portland-oregon-organizers": "portland-organizers",
+    "portland-oregon-organizers": "portland-or-organizers",
     # 2026-08-19 (user-decided, revised same day): country-named chapters
     # become capital-city chapters — but #switzerland (80) and #scotland (71)
     # STAY as country rooms; fresh #bern and #edinburgh city rooms are created
@@ -187,12 +194,12 @@ CHANNEL_RENAMES = {
     # folk in it, to be left alone under its own name. #sydney (2022, 57
     # members) stays the city room; #sydney-organizers is planned from the
     # sheet and currently blocked by an invisible private squatter.
-    # 2026-08-17 (user-decided): the last local-language keep falls too —
-    # English/ASCII wins for the same typability reason as medellin. The
-    # organizer room was deprecated by hand in the admin UI
-    # (#munchen-organizers-deprecated, 4 members to invite into the fresh
-    # #munich-organizers the sheet now plans).
-    "munchen": "munich",
+    # munchen -> munich DROPPED 2026-08-22 (user-decided): #munich is squatted
+    # by an invisible private room, so #munchen (107 members) keeps its native
+    # name — the #españa / #deutschland precedent. The sheet's Slack Channel
+    # cell says `munchen` and KEPT_NON_CONVENTIONAL carries it; do NOT re-plan
+    # #munich even if the squatter is someday cleared. (The organizer room is
+    # unaffected: #munich-organizers was adopted 2026-08-17 and is live.)
 }
 
 #: Merges: the room is retired and its chapter moves to another room. Distinct

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -11,8 +11,9 @@ Who syncs (the 2026-08 organizer-selection policy):
 
   * Accepted / Existing (from MLOps) people always sync, across all three role
     tabs (see SYNC_STATUSES).
-  * Hosts and Speakers in the pipeline (PIPELINE_STATUSES — everything except
-    Denied / Inactive / Duplicate) sync too, so a chapter sees its candidate
+  * Hosts and Speakers in the pipeline (PIPELINE_STATUSES — the recognised
+    in-flight statuses; Denied / Inactive / Duplicate and any value the list
+    does not name are excluded) sync too, so a chapter sees its candidate
     venues and talks without waiting on central triage.
   * Organizers in the pipeline sync ONLY into a self-serve chapter — one with
     SELF_SERVE_MIN (4) or more accepted organizers, not counting AAIF ops
@@ -83,7 +84,10 @@ CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)"
 SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
 
 # The "still in flight" statuses ("" is a blank cell, which triage treats as
-# New). Pipeline hosts/speakers sync unconditionally; pipeline organizers sync
+# New — and the "" entry must STAY: read_role_tab checks membership on the RAW
+# cell value, before the `status or "New"` normalization, so removing the
+# "redundant" empty string would reject every untriaged row).
+# Pipeline hosts/speakers sync unconditionally; pipeline organizers sync
 # only into a self-serve chapter (see gate_pipeline_organizers). Both lists are
 # ALLOWLISTS on purpose: a status added to the intake dropdown tomorrow —
 # including a new rejected-ish one — syncs nobody until it is placed here, which
@@ -98,9 +102,12 @@ SELF_SERVE_MIN = 4
 
 # AAIF / MLOps-community ops people. They appear on the intake like anyone else
 # but are not a chapter's own team, so they never count toward SELF_SERVE_MIN.
-# Matched on the folded FULL name exactly — never a fragment, which would also
-# catch an unrelated organizer sharing a first name. Names, not emails, so this
-# public repo carries no addresses.
+# Matched on the folded FULL name exactly — never a substring, which would also
+# catch an unrelated organizer sharing a first name. The bare "Demetrios" entry
+# is a deliberate alias for a real intake row that carries only the first name;
+# it can exact-match an unrelated mononymous "Demetrios", and that failure
+# direction is accepted (the chapter is merely held longer). Names, not emails,
+# so this public repo carries no addresses.
 AAIF_OPS_NAMES = ("Rahul Parundekar", "Demetrios Brinkmann", "Demetrios",
                   "Ijeoma Onwuka")
 AAIF_OPS_FOLDED = frozenset(fold(n) for n in AAIF_OPS_NAMES)
@@ -702,20 +709,26 @@ def read_role_tab(tab, interests, include_pipeline=False):
 
 
 def is_aaif_ops(name):
-    """Exact folded-name match against AAIF_OPS_NAMES — never a fragment."""
+    """Exact folded-name match against AAIF_OPS_FOLDED — never a substring."""
     return fold(name) in AAIF_OPS_FOLDED
 
 
 def is_accepted(p):
-    """Whether a person/row dict carries a decided-yes intake status."""
+    """Whether a PRE-MERGE person/row dict carries a decided-yes intake status.
+
+    Only valid before merge_people: a merged person has `status` popped, so
+    calling this on one raises KeyError — deliberately, per the stale-read rule.
+    """
     return p["status"] in SYNC_STATUSES
 
 
 def gate_pipeline_organizers(people):
     """Split (kept, held): pipeline organizers whose chapter is below
     SELF_SERVE_MIN accepted organizers are held back for central approval.
-    Held entries carry a `why`, authored here beside the rule itself, in the
-    same shape read_role_tab's rejections use.
+    Held entries carry a `why`, authored here beside the rule itself; they are
+    a SUPERSET of the rejection shape (the full person dict plus `why`, not the
+    4-key {row, tab, name, why}) — run()'s Held summary reads `city` off them,
+    which a plain rejection does not have.
 
     The threshold counts DISTINCT accepted-organizer emails per folded city,
     excluding AAIF ops people — a chapter is self-serve on the strength of its
@@ -732,28 +745,54 @@ def gate_pipeline_organizers(people):
     for p in people:
         if (p["tab"] == "Organizers" and not is_accepted(p)
                 and len(accepted.get(fold_city(p["city"]), ())) < SELF_SERVE_MIN):
-            held.append(dict(p, why="status %r — %r has fewer than %d accepted "
-                                    "organizers, so organizer approval stays "
-                                    "with AAIF ops"
-                                    % (p["status"], p["city"], SELF_SERVE_MIN)))
+            # The folded key is named in the why: the count groups by it, so a
+            # chapter whose accepted organizers split across spellings that
+            # fold differently shows the split instead of stating a false
+            # count as fact.
+            held.append(dict(p, why="status %r — %r (city key %r) has fewer "
+                                    "than %d accepted organizers, so organizer "
+                                    "approval stays with AAIF ops"
+                                    % (p["status"], p["city"],
+                                       fold_city(p["city"]), SELF_SERVE_MIN)))
         else:
             kept.append(p)
     return kept, held
 
 
-def merge_people(people):
+def merge_people(people, blocked=None):
     """One CRM row per person per chapter, even when they applied twice.
 
     Keyed on (folded city, folded email). Role precedence follows ROLE_TABS, so
     someone who is both an organizer and a speaker lands as Organizer with both
     interests recorded — the alternative, two rows, breaks the workbook's own
     "keep one row per person, merge by email" rule.
+
+    One refusal (2026-08-22, security review): a NOT-yet-accepted row never
+    merges into a person whose rows so far are ALL accepted. The form is
+    public and email is the merge key, so a stranger submitting under an
+    accepted organizer's address would otherwise fill that person's blank CRM
+    cells and restamp their Notes — attacker content attributed to a trusted
+    identity. Refused rows are appended to `blocked` (rejection-shaped, for
+    the report) when the caller passes a list; the legitimate mixed case — one
+    person pipeline in one role and accepted in another — still merges when
+    the pipeline row seeds first (ROLE_TABS order), which is how a real
+    person's rows arrive, and is covered by the tests either way.
     """
     merged = {}
     for tab in ROLE_TABS:                       # priority order
         for p in (x for x in people if x["tab"] == tab):
             key = (fold_city(p["city"]), fold_email(p["email"]))
             cur = merged.get(key)
+            if (cur is not None and not is_accepted(p)
+                    and all(s in SYNC_STATUSES for s in cur["statuses"])):
+                if blocked is not None:
+                    blocked.append({
+                        "row": p["row"], "tab": tab, "name": p["name"],
+                        "why": "status %r — same email as an accepted person's "
+                               "CRM row; refusing to merge an unvetted "
+                               "submission into it. Review the intake row."
+                               % p["status"]})
+                continue
             if cur is None:
                 m = dict(p, tabs=[tab], rows=[p["row"]], statuses=[p["status"]])
                 # Drop the singular forms: on a merged person `tab`/`row`/
@@ -792,8 +831,12 @@ def crm_fields(p, today):
     without a human having to touch it.
     """
     # Derived, not stored: tabs/statuses are index-aligned by merge_people, so
-    # the accepted roles need no third parallel list to keep in sync.
-    acc = [t for t, s in zip(p["tabs"], p["statuses"]) if s in SYNC_STATUSES]
+    # the accepted roles need no third parallel list to keep in sync. strict=
+    # True is the alignment tripwire: a future edit that appends to one list
+    # but not the other must raise here, not silently truncate the zip and
+    # demote an accepted person to Prospect.
+    acc = [t for t, s in zip(p["tabs"], p["statuses"], strict=True)
+           if s in SYNC_STATUSES]
     if acc:
         status = CRM_STATUS[acc[0]]
         # An accepted organizer is on the chapter's team, not a guest to triage.
@@ -1077,7 +1120,9 @@ def run(args):
     # as every other excluded row, so --verbose names them individually.
     rejected += held
     counts = Counter(p["tab"] for p in people)
-    merged = merge_people(people)
+    merge_blocked = []
+    merged = merge_people(people, blocked=merge_blocked)
+    rejected += merge_blocked
 
     # People are matched against EVERY chapter folder, then --city narrows only
     # which workbooks get opened. Filtering first made --city report every other
@@ -1104,10 +1149,18 @@ def run(args):
              " + ".join("%d %s" % (counts[t], t.lower()) for t in ROLE_TABS),
              len(rejected)))
     if held:
+        # Distinct people, not rows — the same candidate with two intake rows
+        # must not inflate a number that gets quoted in status reports.
         print("Held    : %d pipeline organizer(s) across %d chapter(s) still under "
               "central approval (fewer than %d accepted organizers) — counted in "
               "the not-synced total above."
-              % (len(held), len({fold_city(p["city"]) for p in held}), SELF_SERVE_MIN))
+              % (len({fold_email(p["email"]) for p in held}),
+                 len({fold_city(p["city"]) for p in held}), SELF_SERVE_MIN))
+    if merge_blocked:
+        print("SECURITY: %d not-yet-accepted intake row(s) share an email with "
+              "an accepted person and were NOT merged into their CRM row — "
+              "--verbose lists them; review those intake rows."
+              % len(merge_blocked))
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
     touched, skipped, no_dropdown, keepers = [], [], [], []

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -7,18 +7,31 @@ onto the public chapters feed, this one pushes accepted *people and their stated
 interest* into the private per-chapter CRM. Same house rules — the intake sheet
 is only ever READ, the report is the default, and --write re-verifies itself.
 
-Only Accepted / Existing (from MLOps) people sync, across all three role tabs
-(see SYNC_STATUSES). The CRM is the onboarding list that decides who gets access
-to a chapter folder, so a person reaches it after a decision, not on submitting
-the form.
+Who syncs (the 2026-08 organizer-selection policy):
+
+  * Accepted / Existing (from MLOps) people always sync, across all three role
+    tabs (see SYNC_STATUSES).
+  * Hosts and Speakers in the pipeline (PIPELINE_STATUSES — everything except
+    Denied / Inactive / Duplicate) sync too, so a chapter sees its candidate
+    venues and talks without waiting on central triage.
+  * Organizers in the pipeline sync ONLY into a self-serve chapter — one with
+    SELF_SERVE_MIN (4) or more accepted organizers, not counting AAIF ops
+    people (AAIF_OPS_NAMES). Those chapters run their own interviews and grow
+    their own team; below the threshold, organizer approval stays with AAIF
+    ops and pipeline organizers are held back and reported.
+
+A pipeline person lands as `Prospect` (organizers) or their role status
+(hosts/speakers), never as a trusted team member — Drive access still keys off
+acceptance in sync_access.py, so reaching the CRM grants nothing by itself.
 
 Each chapter folder under the Chapters Drive holds one "<City> CRM.xlsx" whose
 "Attendees" tab has eleven columns. Only six are ever written (CRM_WRITTEN) —
 identity, decision and interest, and nothing else:
 
     Full name           <- role tab name
-    Trusted/Regular     <- "Yes" for an organizer (they're on the team)
-    Status              <- Organizer / Speaker / Host
+    Trusted/Regular     <- "Yes" for an ACCEPTED organizer (they're on the team)
+    Status              <- Organizer / Speaker / Host — or Prospect, for a
+                           pipeline organizer in a self-serve chapter
     Notes (CRM)         <- provenance: role, intake status, date
     Email               <- role tab email        (also the dedupe key)
     What brings you here? <- the survey answer verbatim, + talk/venue/city detail
@@ -38,7 +51,7 @@ Usage:
   python3 sync_crm.py --write            # apply, then re-read and verify
 """
 import argparse, datetime, io, json, os, re, sys, tempfile, zipfile
-from collections import namedtuple
+from collections import Counter, namedtuple
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -63,19 +76,34 @@ CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)"
                "Email", "LinkedIn URL", "Company", "Role / title",
                "Technical expertise", "What brings you here?")
 
-# ONLY these two statuses sync. The CRM is the onboarding list that decides who
-# gets access to a chapter folder, so a person reaches it after a decision, not
-# on submitting the form. This is an allowlist: every other value on the intake
-# dropdown is held back by construction, so do not enumerate the complement here
-# — the dropdown is maintained in a Google Sheet and any list written down would
-# rot silently. See aaif-triage-intake/SKILL.md for the current status set.
+# The "decided yes" statuses. A person with one of these always syncs, and they
+# are what an organizer must hold to count toward a chapter's self-serve
+# threshold and to earn Trusted/Regular + Drive access downstream.
 # Exact dropdown strings — "Existing" alone would miss every MLOps row.
-# Consequence, and it is intended: as of 2026-08 the Hosts and Speakers tabs
-# had no accepted row, so in practice this synced organizers only. Both start
-# flowing the moment someone accepts them and nothing here needs to change —
-# do NOT read the organizers-only shape as permanent. The report's per-tab
-# counts are the live source of truth.
 SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
+
+# The "still in flight" statuses ("" is a blank cell, which triage treats as
+# New). Pipeline hosts/speakers sync unconditionally; pipeline organizers sync
+# only into a self-serve chapter (see gate_pipeline_organizers). Both lists are
+# ALLOWLISTS on purpose: a status added to the intake dropdown tomorrow —
+# including a new rejected-ish one — syncs nobody until it is placed here, which
+# is the fail-closed direction. Denied / Inactive / Duplicate are excluded by
+# not appearing. See aaif-triage-intake/SKILL.md for the current dropdown.
+PIPELINE_STATUSES = ("", "New", "In progress", "Tentative", "Interviewing")
+
+# A chapter with this many accepted organizers (SYNC_STATUSES, minus AAIF ops
+# people) runs its own organizer interviews: its pipeline organizers sync into
+# its CRM as Prospects. Below it, organizer approval stays with AAIF ops.
+SELF_SERVE_MIN = 4
+
+# AAIF / MLOps-community ops people. They appear on the intake like anyone else
+# but are not a chapter's own team, so they never count toward SELF_SERVE_MIN.
+# Matched on the folded FULL name exactly — never a fragment, which would also
+# catch an unrelated organizer sharing a first name. Names, not emails, so this
+# public repo carries no addresses.
+AAIF_OPS_NAMES = ("Rahul Parundekar", "Demetrios Brinkmann", "Demetrios",
+                  "Ijeoma Onwuka")
+AAIF_OPS_FOLDED = frozenset(fold(n) for n in AAIF_OPS_NAMES)
 
 ROLE_TABS = ("Organizers", "Speakers", "Hosts")   # also the merge priority order
 CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
@@ -553,11 +581,17 @@ def read_survey_interests():
     return out
 
 
-def read_role_tab(tab, interests):
-    """Return (people, rejected) for one role tab.
+def read_role_tab(tab, interests, include_pipeline=False):
+    """Return (people, rejected, fallbacks) for one role tab.
 
     people   = [{row, tab, name, email, city, status, ...}]
-    rejected = [{row, tab, name, why}]   not accepted / no email / no city
+    rejected = [{row, tab, name, why}]   not syncable / no email / no city
+
+    `include_pipeline=False` (the default) keeps the original contract — only
+    SYNC_STATUSES people — and every other caller depends on it staying that
+    way: sync_access turns this roster into Drive grants, and a pipeline person
+    must never reach one. Only sync_crm's own run() opts in, and it still gates
+    pipeline ORGANIZERS per chapter afterwards (gate_pipeline_organizers).
     """
     rows = get_values(INTAKE_ID, "%s!A:BB" % tab)
     if not rows:
@@ -607,10 +641,19 @@ def read_role_tab(tab, interests):
         if not (email or name):
             continue                          # trailing empty grid row
         status = cell(row, i_status)
-        if status not in SYNC_STATUSES:
-            rejected.append({"row": rownum, "tab": tab, "name": name,
-                             "why": "status %r — not accepted yet" % (status or "New")})
-            continue
+        accepted = status in SYNC_STATUSES
+        if not accepted:
+            if not include_pipeline:
+                rejected.append({"row": rownum, "tab": tab, "name": name,
+                                 "why": "status %r — not accepted yet" % (status or "New")})
+                continue
+            if status not in PIPELINE_STATUSES:
+                # Denied / Inactive / Duplicate, or a dropdown value this script
+                # has never seen — either way, fail closed and say so.
+                rejected.append({"row": rownum, "tab": tab, "name": name,
+                                 "why": "status %r — declined, parked, or not a "
+                                        "recognised pipeline status" % status})
+                continue
         if not valid_email(email):
             rejected.append({"row": rownum, "tab": tab, "name": name,
                              "why": "no usable email (%r) — the CRM dedupes on it" % email})
@@ -635,7 +678,7 @@ def read_role_tab(tab, interests):
             fallbacks.append(rownum)
         interest = joined or DEFAULT_INTEREST[tab]
         people.append({
-            "row": rownum, "tab": tab, "status": status,
+            "row": rownum, "tab": tab, "status": status or "New",
             "name": clean_text(name) or clean_text(email),
             "email": clean_text(email), "city": clean_text(city),
             "linkedin": clean_text(first_of(row, headers, ("LinkedIn",))),
@@ -658,6 +701,46 @@ def read_role_tab(tab, interests):
     return people, rejected, fallbacks
 
 
+def is_aaif_ops(name):
+    """Exact folded-name match against AAIF_OPS_NAMES — never a fragment."""
+    return fold(name) in AAIF_OPS_FOLDED
+
+
+def is_accepted(p):
+    """Whether a person/row dict carries a decided-yes intake status."""
+    return p["status"] in SYNC_STATUSES
+
+
+def gate_pipeline_organizers(people):
+    """Split (kept, held): pipeline organizers whose chapter is below
+    SELF_SERVE_MIN accepted organizers are held back for central approval.
+    Held entries carry a `why`, authored here beside the rule itself, in the
+    same shape read_role_tab's rejections use.
+
+    The threshold counts DISTINCT accepted-organizer emails per folded city,
+    excluding AAIF ops people — a chapter is self-serve on the strength of its
+    own team, not because central staff appear on its roster. Accepted people
+    and pipeline hosts/speakers pass through untouched; the count comes from
+    the same intake read, so a chapter crossing the threshold starts pulling
+    its Prospects on the very next run.
+    """
+    accepted = {}
+    for p in people:
+        if p["tab"] == "Organizers" and is_accepted(p) and not is_aaif_ops(p["name"]):
+            accepted.setdefault(fold_city(p["city"]), set()).add(fold_email(p["email"]))
+    kept, held = [], []
+    for p in people:
+        if (p["tab"] == "Organizers" and not is_accepted(p)
+                and len(accepted.get(fold_city(p["city"]), ())) < SELF_SERVE_MIN):
+            held.append(dict(p, why="status %r — %r has fewer than %d accepted "
+                                    "organizers, so organizer approval stays "
+                                    "with AAIF ops"
+                                    % (p["status"], p["city"], SELF_SERVE_MIN)))
+        else:
+            kept.append(p)
+    return kept, held
+
+
 def merge_people(people):
     """One CRM row per person per chapter, even when they applied twice.
 
@@ -672,17 +755,19 @@ def merge_people(people):
             key = (fold_city(p["city"]), fold_email(p["email"]))
             cur = merged.get(key)
             if cur is None:
-                m = dict(p, tabs=[tab], rows=[p["row"]])
-                # Drop the singular forms: on a merged person `tab`/`row` are
-                # an arbitrary member of `tabs`/`rows`, equal to the winning
-                # one only by the accident that the highest-priority tab seeds
-                # the entry. Removing them makes a stale read a KeyError
-                # instead of a plausible wrong answer.
-                m.pop("tab", None), m.pop("row", None)
+                m = dict(p, tabs=[tab], rows=[p["row"]], statuses=[p["status"]])
+                # Drop the singular forms: on a merged person `tab`/`row`/
+                # `status` are an arbitrary member of the plural lists, equal
+                # to the winning one only by the accident that the
+                # highest-priority tab seeds the entry. Removing them makes a
+                # stale read a KeyError instead of a plausible wrong answer.
+                for k in ("tab", "row", "status"):
+                    m.pop(k, None)
                 merged[key] = m
                 continue
             cur["tabs"].append(tab)
             cur["rows"].append(p["row"])
+            cur["statuses"].append(p["status"])
             for field in ("linkedin", "company", "title"):
                 cur[field] = cur[field] or p[field]
             cur["expertise"] = join_distinct([cur["expertise"], p["expertise"]])
@@ -697,17 +782,32 @@ def crm_fields(p, today):
     deliberately absent, so the automation never touches them. A blank value
     means "leave that cell alone", never "blank it out".
 
-    Every person reaching here is Accepted or Existing (from MLOps): read_role_tab
-    drops everything else, so the CRM Status is always the role itself.
+    Status and Trusted/Regular follow the ACCEPTED roles only:
+      * any accepted role -> that role's status (highest-priority accepted tab
+        wins), and Trusted/Regular = "Yes" for an accepted organizer;
+      * no accepted role, but an organizer application in flight -> "Prospect"
+        — a candidate for the chapter's own interviews, not on the team;
+      * a pipeline host/speaker -> their role status, never trusted.
+    "Prospect" is in AUTO_STATUS, so acceptance upgrades the row on a later run
+    without a human having to touch it.
     """
-    role_tab = p["tabs"][0]
+    # Derived, not stored: tabs/statuses are index-aligned by merge_people, so
+    # the accepted roles need no third parallel list to keep in sync.
+    acc = [t for t, s in zip(p["tabs"], p["statuses"]) if s in SYNC_STATUSES]
+    if acc:
+        status = CRM_STATUS[acc[0]]
+        # An accepted organizer is on the chapter's team, not a guest to triage.
+        trusted = "Yes" if acc[0] == "Organizers" else ""
+    else:
+        status = "Prospect" if "Organizers" in p["tabs"] else CRM_STATUS[p["tabs"][0]]
+        trusted = ""
     return {
         "Full name": p["name"],
-        # An accepted organizer is on the chapter's team, not a guest to triage.
-        "Trusted/Regular": "Yes" if role_tab == "Organizers" else "",
-        "Status": CRM_STATUS[role_tab],
+        "Trusted/Regular": trusted,
+        "Status": status,
         "Notes (CRM)": "Intake: %s · %s · %s" % (
-            "/".join(CRM_STATUS[t] for t in p["tabs"]), p["status"], today),
+            join_distinct([CRM_STATUS[t] for t in p["tabs"]], "/"),
+            join_distinct(p["statuses"], "/"), today),
         "Email": p["email"],
         "What brings you here?": p["interest"],
     }
@@ -967,13 +1067,16 @@ def run(args):
     interests = read_survey_interests()
 
     people, rejected, fallbacks = [], [], []
-    counts = {}
     for tab in ROLE_TABS:
-        pp, rr, fb = read_role_tab(tab, interests)
-        counts[tab] = len(pp)
+        pp, rr, fb = read_role_tab(tab, interests, include_pipeline=True)
         people += pp
         rejected += rr
         fallbacks += fb
+    people, held = gate_pipeline_organizers(people)
+    # Held-back pipeline organizers surface through the same not-synced channel
+    # as every other excluded row, so --verbose names them individually.
+    rejected += held
+    counts = Counter(p["tab"] for p in people)
     merged = merge_people(people)
 
     # People are matched against EVERY chapter folder, then --city narrows only
@@ -1000,6 +1103,11 @@ def run(args):
           % (len(merged), len(by_folder),
              " + ".join("%d %s" % (counts[t], t.lower()) for t in ROLE_TABS),
              len(rejected)))
+    if held:
+        print("Held    : %d pipeline organizer(s) across %d chapter(s) still under "
+              "central approval (fewer than %d accepted organizers) — counted in "
+              "the not-synced total above."
+              % (len(held), len({fold_city(p["city"]) for p in held}), SELF_SERVE_MIN))
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
     touched, skipped, no_dropdown, keepers = [], [], [], []

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -103,6 +103,55 @@ HANDLES_COLUMN = "Organizer Handles"
 KEPT_NON_CONVENTIONAL = ("bay-area", "austin-tx", "charlotte-nc", "dallas-tx",
                          "munchen")
 
+#: The sheet column that records each chapter's squatted and former channel
+#: names ("erstwhile"), added 2026-08-22. Free text per cell, but with a fixed
+#: grammar so it stays machine-readable: bare channel slugs, annotations only
+#: inside parentheses, `·` or `,` between entries, and the word `formerly` as
+#: an allowed connective. parse_erstwhile() below is the one reader; the
+#: provisioner refuses to create or rename into any name it yields. The column
+#: is optional — a sheet without it just yields no forbidden names — because
+#: this engine must keep working against older copies of the tab.
+ERSTWHILE_COLUMN = "Erstwhile Channels"
+_ERSTWHILE_PARENS = re.compile(r"\([^)]*\)")
+_ERSTWHILE_SLUG = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+def parse_erstwhile(text):
+    """The channel names recorded in one Erstwhile Channels cell.
+
+    Strips parenthesized annotations first, then splits on the separators; a
+    token that doesn't look like a channel slug (or is the `formerly`
+    connective) is dropped rather than guessed at — a malformed cell can only
+    under-protect, never invent a forbidden name.
+    """
+    out = set()
+    for part in re.split(r"[·,]", _ERSTWHILE_PARENS.sub(" ", text or "")):
+        for tok in part.split():
+            tok = tok.strip().lower()
+            if tok != "formerly" and _ERSTWHILE_SLUG.match(tok):
+                out.add(tok)
+    return out
+
+
+def read_erstwhile():
+    """Every erstwhile channel name on the sheet, folded to a set.
+
+    Its own small read (not part of read_grid) so the provisioner can call it
+    without adopting read_grid's abort-on-missing-column contract — see the
+    ERSTWHILE_COLUMN note above.
+    """
+    rows = get_values(CHAPTERS_ID, "'%s'!A:AZ" % CHAPTERS_TAB)
+    if not rows:
+        return set()
+    headers = [h.strip() for h in rows[0]]
+    if ERSTWHILE_COLUMN not in headers:
+        return set()
+    i = headers.index(ERSTWHILE_COLUMN)
+    names = set()
+    for row in rows[1:]:
+        names |= parse_erstwhile(cell(row, i))
+    return names
+
 #: Country -> the channel that serves it, where that channel is not named after
 #: the country in ASCII English. Without this the engine plans a brand-new
 #: `#spain` alongside `#españa`, which IS Spain's room and has 112 people in it.

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -89,17 +89,18 @@ HANDLES_COLUMN = "Organizer Handles"
 #: reversed that call: those rooms were RENAMED to the convention via
 #: provision_channels.CHANNEL_RENAMES — a rename keeps members and history, so
 #: "moving people" was never actually the cost. Even the local-language keeps
-#: fell to typability (#munchen -> #munich, #medellín -> #medellin); `#españa`,
-#: a country channel, is now the only accented survivor. Only the entry above
-#: survived on its merits.
-#: `#austin-area` joined 2026-08-21: `#austin` is squatted by an invisible
-#: private room the Pro plan gives no way to reclaim, so Austin's real room
-#: (76 members) keeps its historical name instead of waiting forever.
+#: fell to typability then (#munchen -> #munich, #medellín -> #medellin), but
+#: the 2026-08-22 qualified-slug decision brought `#munchen` BACK — its
+#: `#munich` target turned out to be squatted, and the native name beats
+#: waiting (the #españa / #deutschland precedent).
 #: 2026-08-22 (user-decided): squatted city names resolve to a QUALIFIED slug
 #: instead of waiting on the squatter — `<city>-<state>` for US cities
-#: (austin-tx, charlotte-nc, dallas-tx) — and #munchen keeps its native name
-#: (the #españa / #deutschland precedent). The squatted originals are recorded
-#: in the sheet's `Erstwhile Channels` column; never re-plan them.
+#: (austin-tx, charlotte-nc, dallas-tx; austin-tx superseded the one-day
+#: `#austin-area` keep of 2026-08-21). The squatted originals are recorded in
+#: the sheet's `Erstwhile Channels` column; never re-plan them.
+#: NOTE this tuple is a DECISION RECORD, not config: nothing at runtime reads
+#: it (only a test asserts against it). The live protection is the sheet cell
+#: plus the erstwhile guard.
 KEPT_NON_CONVENTIONAL = ("bay-area", "austin-tx", "charlotte-nc", "dallas-tx",
                          "munchen")
 
@@ -113,44 +114,63 @@ KEPT_NON_CONVENTIONAL = ("bay-area", "austin-tx", "charlotte-nc", "dallas-tx",
 #: this engine must keep working against older copies of the tab.
 ERSTWHILE_COLUMN = "Erstwhile Channels"
 _ERSTWHILE_PARENS = re.compile(r"\([^)]*\)")
+# ASCII slugs only, deliberately: an accented erstwhile name (españa, münchen)
+# would fall out unprotected. This workspace HAS accented channel history, so
+# record such names in their typable ASCII spelling — the test pins the drop.
 _ERSTWHILE_SLUG = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
 
-def parse_erstwhile(text):
+def parse_erstwhile(text, discarded=None):
     """The channel names recorded in one Erstwhile Channels cell.
 
     Strips parenthesized annotations first, then splits on the separators; a
-    token that doesn't look like a channel slug (or is the `formerly`
-    connective) is dropped rather than guessed at — a malformed cell can only
-    under-protect, never invent a forbidden name.
+    leading `#` is shorthand people will type and is stripped before matching.
+    A token that fails the slug shape (or is the `formerly` connective) is
+    dropped — and appended to `discarded` when the caller passes a list, so
+    the provisioner can say how many names it is NOT protecting. Two failure
+    directions, both deliberate: punctuation-bearing junk under-protects
+    (dropped, reported), while bare lowercase prose IS read as names — put
+    annotations in parentheses, because a stray word here over-protects by
+    refusing an unrelated create (loudly, in the REFUSED report).
     """
     out = set()
     for part in re.split(r"[·,]", _ERSTWHILE_PARENS.sub(" ", text or "")):
         for tok in part.split():
-            tok = tok.strip().lower()
-            if tok != "formerly" and _ERSTWHILE_SLUG.match(tok):
+            tok = tok.strip().lower().lstrip("#")
+            if not tok or tok == "formerly":
+                continue
+            if _ERSTWHILE_SLUG.match(tok):
                 out.add(tok)
+            elif discarded is not None:
+                discarded.append(tok)
     return out
 
 
 def read_erstwhile():
-    """Every erstwhile channel name on the sheet, folded to a set.
+    """Return (names, discarded, column_present) for the whole sheet.
+
+    names   — every erstwhile channel name, folded to one set
+    discarded — tokens that failed the slug grammar and are NOT protected
+    column_present — False when the sheet has no ERSTWHILE_COLUMN header
 
     Its own small read (not part of read_grid) so the provisioner can call it
-    without adopting read_grid's abort-on-missing-column contract — see the
-    ERSTWHILE_COLUMN note above.
+    without adopting read_grid's abort-on-missing-column contract. The absent
+    column is TOLERATED (older tab copies) but must be SURFACED by the caller:
+    on the live sheet the column exists as of 2026-08-22, so absence means a
+    rename or restructure silently disarmed the guard — the exact failure the
+    2026-08 A:D-range breakage already demonstrated on this tab.
     """
     rows = get_values(CHAPTERS_ID, "'%s'!A:AZ" % CHAPTERS_TAB)
     if not rows:
-        return set()
+        return set(), [], False
     headers = [h.strip() for h in rows[0]]
     if ERSTWHILE_COLUMN not in headers:
-        return set()
+        return set(), [], False
     i = headers.index(ERSTWHILE_COLUMN)
-    names = set()
+    names, discarded = set(), []
     for row in rows[1:]:
-        names |= parse_erstwhile(cell(row, i))
-    return names
+        names |= parse_erstwhile(cell(row, i), discarded)
+    return names, discarded, True
 
 #: Country -> the channel that serves it, where that channel is not named after
 #: the country in ASCII English. Without this the engine plans a brand-new
@@ -166,9 +186,11 @@ COUNTRY_CHANNELS = {
     # reclaim), so Germany's country room takes the native name instead —
     # created 2026-08-22, same precedent as #españa.
     "Germany": "deutschland",
-    # One Nordic room, not four country rooms (user-decided 2026-08-19):
+    # One Nordic room, not per-country rooms (user-decided 2026-08-19):
     # #nordics (129 members, the 2021 room, renamed from #nordics-public)
-    # serves all five Nordic chapters. The per-country rooms were folded —
+    # serves the Nordic chapters. The four countries with chapters today are
+    # folded below; if a Reykjavik/Iceland chapter lands, add "Iceland" here
+    # in the same change. The per-country rooms were folded —
     # #sweden/#denmark/#finland were days-old and empty, #norway had been
     # silent since 2024 and got a pointer post before archiving.
     "Denmark": "nordics",

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -95,7 +95,13 @@ HANDLES_COLUMN = "Organizer Handles"
 #: `#austin-area` joined 2026-08-21: `#austin` is squatted by an invisible
 #: private room the Pro plan gives no way to reclaim, so Austin's real room
 #: (76 members) keeps its historical name instead of waiting forever.
-KEPT_NON_CONVENTIONAL = ("bay-area", "austin-area")
+#: 2026-08-22 (user-decided): squatted city names resolve to a QUALIFIED slug
+#: instead of waiting on the squatter — `<city>-<state>` for US cities
+#: (austin-tx, charlotte-nc, dallas-tx) — and #munchen keeps its native name
+#: (the #españa / #deutschland precedent). The squatted originals are recorded
+#: in the sheet's `Erstwhile Channels` column; never re-plan them.
+KEPT_NON_CONVENTIONAL = ("bay-area", "austin-tx", "charlotte-nc", "dallas-tx",
+                         "munchen")
 
 #: Country -> the channel that serves it, where that channel is not named after
 #: the country in ASCII English. Without this the engine plans a brand-new

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -107,6 +107,10 @@ KEPT_NON_CONVENTIONAL = ("bay-area", "austin-area")
 #: country that demonstrably already has a room.
 COUNTRY_CHANNELS = {
     "Spain": "españa",
+    # #germany is squatted by an invisible private room (Pro plan, no way to
+    # reclaim), so Germany's country room takes the native name instead —
+    # created 2026-08-22, same precedent as #españa.
+    "Germany": "deutschland",
     # One Nordic room, not four country rooms (user-decided 2026-08-19):
     # #nordics (129 members, the 2021 room, renamed from #nordics-public)
     # serves all five Nordic chapters. The per-country rooms were folded —

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -92,7 +92,10 @@ HANDLES_COLUMN = "Organizer Handles"
 #: fell to typability (#munchen -> #munich, #medellín -> #medellin); `#españa`,
 #: a country channel, is now the only accented survivor. Only the entry above
 #: survived on its merits.
-KEPT_NON_CONVENTIONAL = ("bay-area",)
+#: `#austin-area` joined 2026-08-21: `#austin` is squatted by an invisible
+#: private room the Pro plan gives no way to reclaim, so Austin's real room
+#: (76 members) keeps its historical name instead of waiting forever.
+KEPT_NON_CONVENTIONAL = ("bay-area", "austin-area")
 
 #: Country -> the channel that serves it, where that channel is not named after
 #: the country in ASCII English. Without this the engine plans a brand-new
@@ -102,7 +105,18 @@ KEPT_NON_CONVENTIONAL = ("bay-area",)
 #: name for itself wins over the convention. Add an entry whenever the report's
 #: "countries with chapters but no channel named after them" section names a
 #: country that demonstrably already has a room.
-COUNTRY_CHANNELS = {"Spain": "españa"}
+COUNTRY_CHANNELS = {
+    "Spain": "españa",
+    # One Nordic room, not four country rooms (user-decided 2026-08-19):
+    # #nordics (129 members, the 2021 room, renamed from #nordics-public)
+    # serves all five Nordic chapters. The per-country rooms were folded —
+    # #sweden/#denmark/#finland were days-old and empty, #norway had been
+    # silent since 2024 and got a pointer post before archiving.
+    "Denmark": "nordics",
+    "Finland": "nordics",
+    "Norway": "nordics",
+    "Sweden": "nordics",
+}
 
 #: Values that channel_map.json's unconfirmed `public` table filed in the wrong
 #: COLUMN — not the wrong name, the wrong kind of thing.

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -208,7 +208,7 @@ _TABLES = {"public": {}, "organizers": {}, "regional": {}}
 # The London shape after the chain applied AND the sweep archived the parked
 # room: old name live again (held by the promoted room), target name exists
 # only among ARCHIVED names. Re-planning it would rename the real room away.
-_c, _r, _b, _m, _a, _applied = _with_maps(
+_c, _r, _b, _m, _a, _applied, _ref0 = _with_maps(
     {"old-organizers": "old-organizers-deprecated",
      "meetup-organizers": "old-organizers"}, {},
     lambda: prov.plan(_TABLES, live={"old-organizers"},
@@ -220,7 +220,7 @@ check("the applied classification is reported, not swallowed",
 
 # A genuine squatter: the old name is nobody's rename target, so target-exists
 # means blocked — never silently treated as applied.
-_c, _r, _b, _m, _a, _applied = _with_maps(
+_c, _r, _b, _m, _a, _applied, _ref0 = _with_maps(
     {"utah": "salt-lake-city"}, {},
     lambda: prov.plan(_TABLES, live={"utah", "salt-lake-city"},
                       all_names={"utah", "salt-lake-city"}))
@@ -229,7 +229,7 @@ check("a blocked rename is not reported as applied", _applied, [])
 
 # A name a pending rename frees INTO is satisfied by the rename, not created.
 _tables2 = {"public": {"Bern": "bern"}, "organizers": {}, "regional": {}}
-_c, _r, _b, _m, _a, _applied = _with_maps(
+_c, _r, _b, _m, _a, _applied, _ref0 = _with_maps(
     {"old-bern": "bern"}, {},
     lambda: prov.plan(_tables2, live={"old-bern"}, all_names={"old-bern"}))
 check("a rename-freed name is not also created", _c, [])
@@ -237,7 +237,7 @@ check("it counts as already satisfied", [n for n, _p, _w in _a], ["bern"])
 check("and the rename itself is planned", _r, [("old-bern", "bern")])
 
 # all_names defaults to live — pre-existing behavior unchanged.
-_c, _r, _b, _m, _a, _applied = _with_maps(
+_c, _r, _b, _m, _a, _applied, _ref0 = _with_maps(
     {"a": "b"}, {}, lambda: prov.plan(_TABLES, live={"a"}))
 check("all_names defaults to live", _r, [("a", "b")])
 
@@ -256,6 +256,16 @@ check("refusals are reported, not dropped",
 check("an empty forbidden set changes nothing",
       prov.forbid_erstwhile(_creates, _renames, frozenset()),
       (_creates, _renames, []))
+
+# The guard lives INSIDE plan(): no caller can obtain an unfiltered plan.
+_c, _r, _b, _m, _a, _applied, _ref = _with_maps(
+    {"old-x": "munich"}, {},
+    lambda: prov.plan({"public": {"Austin": "austin"}, "organizers": {},
+                       "regional": {}},
+                      live={"old-x"}, forbidden={"austin", "munich"}))
+check("plan() itself refuses erstwhile creates and rename targets",
+      (_c, _r, sorted(k for k, _n, _d in _ref)), ([], [], ["create", "rename"]))
+check("plan() without forbidden refuses nothing", _ref0, [])
 
 
 # --- plan_archives(): the only gate before a room is closed --------------------

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -242,6 +242,22 @@ _c, _r, _b, _m, _a, _applied = _with_maps(
 check("all_names defaults to live", _r, [("a", "b")])
 
 
+# --- forbid_erstwhile(): recorded-history names are never planned again --------
+_creates = [("boston-organizers", True, "organizer channel for Boston"),
+            ("austin", False, "chapter channel for Austin")]
+_renames = [("x-organizers", "y-organizers"), ("old", "munich")]
+_fc, _fr, _ref = prov.forbid_erstwhile(_creates, _renames,
+                                       {"austin", "munich", "germany"})
+check("an erstwhile create is refused", _fc, [_creates[0]])
+check("an erstwhile rename TARGET is refused", _fr, [("x-organizers", "y-organizers")])
+check("refusals are reported, not dropped",
+      sorted((k, n) for k, n, _d in _ref),
+      [("create", "austin"), ("rename", "munich")])
+check("an empty forbidden set changes nothing",
+      prov.forbid_erstwhile(_creates, _renames, frozenset()),
+      (_creates, _renames, []))
+
+
 # --- plan_archives(): the only gate before a room is closed --------------------
 def _chan(name, private=False, archived=False, members=()):
     return {"name": name, "id": "C-" + name, "is_private": private,

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -138,14 +138,14 @@ check("col_of round-trips", [col_of(cell_ref(i, 3)) for i in (0, 10, 26, 701)],
 # merge_people: one row per person per chapter
 # ---------------------------------------------------------------------------
 both = merge_people([
-    person("Ada L", "ada@x.io", "Boston", "Speakers", "New", interest="I want to be a speaker",
-           title="Staff Eng", expertise="Agents"),
+    person("Ada L", "ada@x.io", "Boston", "Speakers", "Accepted",
+           interest="I want to be a speaker", title="Staff Eng", expertise="Agents"),
     person("Ada Lovelace", "ADA@x.io", "boston", "Organizers", "Accepted",
            interest="I want to be an organizer/volunteer", expertise="Agents"),
 ])
 check("merge collapses one person to one row", len(both), 1)
 check("merge takes the highest-priority role first", both[0]["tabs"], ["Organizers", "Speakers"])
-check("merge keeps every tab's intake status", both[0]["statuses"], ["Accepted", "New"])
+check("merge keeps every tab's intake status", both[0]["statuses"], ["Accepted", "Accepted"])
 check("merge keeps the speaker's title", both[0]["title"], "Staff Eng")
 check("merge unions the interests", both[0]["interest"],
       "I want to be an organizer/volunteer · I want to be a speaker")
@@ -153,11 +153,31 @@ check("merge dedupes identical expertise", both[0]["expertise"], "Agents")
 check("merge keeps different cities apart",
       len(merge_people([person("A", "a@x.io", "Boston"), person("A", "a@x.io", "Berlin")])), 2)
 
+# Security guard: a NOT-yet-accepted row never merges into an all-accepted
+# person — the public form + email-keyed merge would otherwise let a stranger
+# writing under an accepted organizer's address fill their CRM row.
+_blk = []
+guarded = merge_people(
+    [person("Ada", "ada@x.io", "Boston", "Organizers", "Accepted"),
+     person("Mallory", "ada@x.io", "Boston", "Speakers", "New",
+            interest="totally a real talk")], blocked=_blk)
+check("a pipeline row does not merge into an all-accepted person",
+      guarded[0]["tabs"], ["Organizers"])
+check("...its content does not reach the person's record",
+      "totally a real talk" in guarded[0]["interest"], False)
+check("...and the refusal is reported in rejection shape",
+      (len(_blk), sorted(_blk[0]), "refusing to merge" in _blk[0]["why"]),
+      (1, ["name", "row", "tab", "why"], True))
+check("without a blocked list the row is still refused",
+      merge_people([person("Ada", "ada@x.io", "B", "Organizers", "Accepted"),
+                    person("M", "ada@x.io", "B", "Speakers", "New")])[0]["tabs"],
+      ["Organizers"])
+
 f_acc = crm_fields(both[0], TODAY)
 check("accepted organizer -> Organizer", f_acc["Status"], "Organizer")
 check("accepted organizer -> Trusted", f_acc["Trusted/Regular"], "Yes")
-check("note carries every role and status",
-      f_acc["Notes (CRM)"], "Intake: Organizer/Speaker · Accepted/New · 2026-08-06")
+check("note carries every role, statuses deduped",
+      f_acc["Notes (CRM)"], "Intake: Organizer/Speaker · Accepted · 2026-08-06")
 
 f_host = crm_fields(merge_people([person("Bo", "bo@x.io", "B", "Hosts", "Accepted")])[0], TODAY)
 check("accepted host -> Host", f_host["Status"], "Host")
@@ -191,9 +211,17 @@ for col in ("Signal", "LinkedIn URL", "Company", "Role / title", "Technical expe
 # ---------------------------------------------------------------------------
 # The self-serve gate: pipeline organizers need a 4-organizer chapter
 # ---------------------------------------------------------------------------
-check("is_aaif_ops matches an ops person's exact name", is_aaif_ops("Rahul Parundekar"), True)
-check("is_aaif_ops folds case", is_aaif_ops("rahul PARUNDEKAR"), True)
-check("is_aaif_ops never matches on a name fragment", is_aaif_ops("Rahul Krishnan R A"), False)
+# Synthetic roster throughout this section (CLAUDE.md: no real names in
+# tests). is_aaif_ops reads the module global at call time, so patching
+# AAIF_OPS_FOLDED exercises the exact production code path; the shipped
+# roster's shape is asserted without repeating its contents.
+check("the shipped roster folds one entry per name",
+      len(sync_crm.AAIF_OPS_FOLDED), len(sync_crm.AAIF_OPS_NAMES))
+_saved_ops = sync_crm.AAIF_OPS_FOLDED
+sync_crm.AAIF_OPS_FOLDED = frozenset({sync_crm.fold("Ops Person")})
+check("is_aaif_ops matches an ops person's exact name", is_aaif_ops("Ops Person"), True)
+check("is_aaif_ops folds case", is_aaif_ops("ops PERSON"), True)
+check("is_aaif_ops never matches on a name fragment", is_aaif_ops("Ops Person Jr"), False)
 
 def team(city, n):
     return [person("Org %s %d" % (city, i), "org-%s-%d@x.io" % (city.lower(), i),
@@ -213,7 +241,7 @@ check("accepted people always pass the gate",
 # but still a centrally-approved chapter.
 _, held = gate_pipeline_organizers(
     team("Bern", SELF_SERVE_MIN - 1)
-    + [person("Rahul Parundekar", "r@x.io", "Bern", "Organizers", "Accepted"),
+    + [person("Ops Person", "o@x.io", "Bern", "Organizers", "Accepted"),
        dict(small_cand, city="Bern")])
 check("an ops person does not make a chapter self-serve",
       [p["name"] for p in held], ["Kim"])
@@ -231,6 +259,44 @@ check("a duplicated accepted row does not tip the threshold",
 pipe_host = person("Vee", "vee@x.io", "Small", "Hosts", "New")
 kept, held = gate_pipeline_organizers([pipe_host])
 check("a pipeline host is never gated", (kept, held), ([pipe_host], []))
+sync_crm.AAIF_OPS_FOLDED = _saved_ops
+
+
+# ---------------------------------------------------------------------------
+# read_role_tab: the status filter that decides who enters the flow at all
+# ---------------------------------------------------------------------------
+# Mocked grid, no gws. These pin the two contracts nothing else enforces:
+# the accepted-only DEFAULT (sync_access turns this roster into Drive grants)
+# and the fail-closed rejection of Denied/unknown statuses even in pipeline
+# mode.
+_GRID = [
+    ["Status", "Full name", "Email", "Chapter", "City (Existing)", "City (New)"],
+    ["Accepted", "Ada", "ada@x.io", "Boston", "", ""],
+    ["Tentative", "Tess", "tess@x.io", "Boston", "", ""],
+    ["Denied", "Dan", "dan@x.io", "Boston", "", ""],
+    ["Zebra", "Zed", "zed@x.io", "Boston", "", ""],
+    ["", "Bea", "bea@x.io", "Boston", "", ""],
+]
+_saved_gv = sync_crm.get_values
+sync_crm.get_values = lambda *_a, **_k: _GRID
+try:
+    pp, rr, _fb = sync_crm.read_role_tab("Organizers", {})
+    check("the DEFAULT is accepted-only — the Drive-grant contract",
+          [p["name"] for p in pp], ["Ada"])
+    check("everyone else is rejected as not-accepted by default",
+          [r["name"] for r in rr if "not accepted yet" in r["why"]],
+          ["Tess", "Dan", "Zed", "Bea"])
+    pp, rr, _fb = sync_crm.read_role_tab("Organizers", {}, include_pipeline=True)
+    check("pipeline mode admits in-flight statuses",
+          sorted(p["name"] for p in pp), ["Ada", "Bea", "Tess"])
+    check("a blank status is normalized to New on the person",
+          [p["status"] for p in pp if p["name"] == "Bea"], ["New"])
+    check("Denied and unknown statuses fail closed even in pipeline mode",
+          sorted(r["name"] for r in rr
+                 if "declined, parked, or not a recognised" in r["why"]),
+          ["Dan", "Zed"])
+finally:
+    sync_crm.get_values = _saved_gv
 
 
 # ---------------------------------------------------------------------------

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -11,9 +11,11 @@ from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import sync_crm
-from sync_crm import (Attendees, CRM_HEADERS, DV_STATUS_NEW, DV_STATUS_OLD, X,
+from sync_crm import (Attendees, CRM_HEADERS, DV_STATUS_NEW, DV_STATUS_OLD,
+                      SELF_SERVE_MIN, X,
                       apply_ops, cell_ref, clean_text, col_of, crm_fields,
-                      fold_email, join_distinct, load_parts, match_chapters,
+                      fold_email, gate_pipeline_organizers, is_aaif_ops,
+                      join_distinct, load_parts, match_chapters,
                       merge_people, patch_status_dropdown, plan_workbook,
                       save_parts, sheet_part, valid_email)
 
@@ -143,7 +145,7 @@ both = merge_people([
 ])
 check("merge collapses one person to one row", len(both), 1)
 check("merge takes the highest-priority role first", both[0]["tabs"], ["Organizers", "Speakers"])
-check("merge keeps the acceptance", both[0]["status"], "Accepted")
+check("merge keeps every tab's intake status", both[0]["statuses"], ["Accepted", "New"])
 check("merge keeps the speaker's title", both[0]["title"], "Staff Eng")
 check("merge unions the interests", both[0]["interest"],
       "I want to be an organizer/volunteer · I want to be a speaker")
@@ -154,12 +156,29 @@ check("merge keeps different cities apart",
 f_acc = crm_fields(both[0], TODAY)
 check("accepted organizer -> Organizer", f_acc["Status"], "Organizer")
 check("accepted organizer -> Trusted", f_acc["Trusted/Regular"], "Yes")
-check("note carries role, status and date",
-      f_acc["Notes (CRM)"], "Intake: Organizer/Speaker · Accepted · 2026-08-06")
+check("note carries every role and status",
+      f_acc["Notes (CRM)"], "Intake: Organizer/Speaker · Accepted/New · 2026-08-06")
 
 f_host = crm_fields(merge_people([person("Bo", "bo@x.io", "B", "Hosts", "Accepted")])[0], TODAY)
 check("accepted host -> Host", f_host["Status"], "Host")
 check("accepted host is not auto-Trusted", f_host["Trusted/Regular"], "")
+
+# Pipeline (not-yet-accepted) people, per the self-serve policy.
+f_pipe = crm_fields(merge_people([person("Cy", "cy@x.io", "B", "Organizers", "Tentative")])[0], TODAY)
+check("pipeline organizer -> Prospect", f_pipe["Status"], "Prospect")
+check("pipeline organizer is not Trusted", f_pipe["Trusted/Regular"], "")
+check("pipeline note carries the intake status",
+      f_pipe["Notes (CRM)"], "Intake: Organizer · Tentative · 2026-08-06")
+f_pspk = crm_fields(merge_people([person("Dee", "dee@x.io", "B", "Speakers", "New")])[0], TODAY)
+check("pipeline speaker -> Speaker (not Prospect)", f_pspk["Status"], "Speaker")
+check("pipeline speaker is not Trusted", f_pspk["Trusted/Regular"], "")
+# Accepted in one role while still in the pipeline for another: the accepted
+# role wins the Status, and the organizer application alone earns no trust.
+f_mix = crm_fields(merge_people([
+    person("Eve", "eve@x.io", "B", "Organizers", "Interviewing"),
+    person("Eve", "eve@x.io", "B", "Speakers", "Accepted")])[0], TODAY)
+check("accepted speaker beats pipeline organizer", f_mix["Status"], "Speaker")
+check("...and does not become Trusted", f_mix["Trusted/Regular"], "")
 
 # Minimal by construction: the automation must not touch Signal or any of the
 # detail columns, so they are absent from the mapping rather than written blank.
@@ -167,6 +186,51 @@ check("only the minimal columns are produced",
       sorted(f_acc), sorted(sync_crm.CRM_WRITTEN))
 for col in ("Signal", "LinkedIn URL", "Company", "Role / title", "Technical expertise"):
     check("%r is never written" % col, col in f_acc, False)
+
+
+# ---------------------------------------------------------------------------
+# The self-serve gate: pipeline organizers need a 4-organizer chapter
+# ---------------------------------------------------------------------------
+check("is_aaif_ops matches an ops person's exact name", is_aaif_ops("Rahul Parundekar"), True)
+check("is_aaif_ops folds case", is_aaif_ops("rahul PARUNDEKAR"), True)
+check("is_aaif_ops never matches on a name fragment", is_aaif_ops("Rahul Krishnan R A"), False)
+
+def team(city, n):
+    return [person("Org %s %d" % (city, i), "org-%s-%d@x.io" % (city.lower(), i),
+                   city, "Organizers", "Accepted") for i in range(n)]
+
+cand = person("Nia", "nia@x.io", "Big", "Organizers", "Tentative")
+small_cand = person("Kim", "kim@x.io", "Small", "Organizers", "Interviewing")
+kept, held = gate_pipeline_organizers(
+    team("Big", SELF_SERVE_MIN) + [cand] + team("Small", SELF_SERVE_MIN - 1) + [small_cand])
+check("a self-serve chapter keeps its pipeline organizer", cand in kept, True)
+check("a small chapter's pipeline organizer is held",
+      [p["name"] for p in held], ["Kim"])
+check("accepted people always pass the gate",
+      len([p for p in kept if sync_crm.is_accepted(p)]), 2 * SELF_SERVE_MIN - 1)
+
+# AAIF ops people never count toward the threshold: 3 locals + Rahul is 4 rows
+# but still a centrally-approved chapter.
+_, held = gate_pipeline_organizers(
+    team("Bern", SELF_SERVE_MIN - 1)
+    + [person("Rahul Parundekar", "r@x.io", "Bern", "Organizers", "Accepted"),
+       dict(small_cand, city="Bern")])
+check("an ops person does not make a chapter self-serve",
+      [p["name"] for p in held], ["Kim"])
+check("a held person carries the reason beside the rule",
+      "fewer than %d accepted organizers" % SELF_SERVE_MIN in held[0]["why"], True)
+
+# The count is distinct emails, so a duplicated accepted row cannot tip it.
+dup = team("Twin", SELF_SERVE_MIN - 1)
+_, held = gate_pipeline_organizers(
+    dup + [dict(dup[0], row=99)] + [dict(cand, city="Twin")])
+check("a duplicated accepted row does not tip the threshold",
+      [p["name"] for p in held], ["Nia"])
+
+# Pipeline hosts/speakers pass regardless of their chapter's size.
+pipe_host = person("Vee", "vee@x.io", "Small", "Hosts", "New")
+kept, held = gate_pipeline_organizers([pipe_host])
+check("a pipeline host is never gated", (kept, held), ([pipe_host], []))
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +396,20 @@ for before, want in (("", "Organizer"), ("New", "Organizer"), ("Prospect", "Orga
     check("Status %-10r -> op kinds" % before, [o["kind"] for o in ops_s], ["fill"])
     got = ops_s[0]["sets"].get("Status") if ops_s else None
     check("Status %-10r -> %r" % (before, want), got, want)
+
+# The self-serve lifecycle end-to-end: a Prospect synced while in the pipeline
+# is upgraded in place once the chapter accepts them — Status is in AUTO_STATUS
+# and the blank Trusted/Regular cell fills.
+_, _, alc = book(sample_row=SAMPLE)
+pipe = merge_people([person("Ada", "ada@x.io", "Boston", "Organizers", "Tentative",
+                            linkedin="https://li/ada", expertise="Agents, MCP")])
+apply_ops(alc, plan_workbook(alc, pipe, TODAY))
+check("a prospect lands untrusted",
+      [alc.value(3, "Status"), alc.value(3, "Trusted/Regular")], ["Prospect", ""])
+up = plan_workbook(alc, people, TODAY)
+check("acceptance upgrades the prospect in place",
+      (up[0]["kind"], up[0]["sets"].get("Status"), up[0]["sets"].get("Trusted/Regular")),
+      ("fill", "Organizer", "Yes"))
 
 
 # ---------------------------------------------------------------------------

--- a/skills/aaif-sync-chapters/scripts/test_sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_resources.py
@@ -282,9 +282,40 @@ check("parenthesized prose never yields a name",
 check("comma-separated names all survive",
       sr.parse_erstwhile("austin (squatted) · formerly austin-area, austin-area-organizers"),
       {"austin", "austin-area", "austin-area-organizers"})
-check("a malformed cell under-protects instead of inventing names",
-      sr.parse_erstwhile("TBD?? (ask Rahul) · n/a!"), set())
+check("a leading # is shorthand, not a parse failure",
+      sr.parse_erstwhile("#austin (squatted) · #munich"), {"austin", "munich"})
+_disc = []
+check("punctuation-bearing junk under-protects instead of inventing names",
+      sr.parse_erstwhile("TBD?? (ask ops) · n/a!", _disc), set())
+check("...and the dropped tokens are reported to the caller",
+      sorted(_disc), ["n/a!", "tbd??"])
 check("an empty cell yields nothing", sr.parse_erstwhile(""), set())
+# Documented limitations, pinned so a change is a decision rather than drift:
+check("bare lowercase prose IS read as names (annotate in parens instead)",
+      sr.parse_erstwhile("pending decision"), {"pending", "decision"})
+check("accented slugs fall out unprotected — record the ASCII spelling",
+      sr.parse_erstwhile("españa (kept)"), set())
+
+# read_erstwhile(): tolerate an absent column, but SAY so via column_present.
+_saved_gv = sr.get_values
+def _fake_grid(rows):
+    sr.get_values = lambda *_a, **_k: rows
+try:
+    _fake_grid([])
+    check("an empty sheet yields an inactive guard",
+          sr.read_erstwhile(), (set(), [], False))
+    _fake_grid([["City", "Country"], ["Boston", "USA"]])
+    check("a sheet without the column yields an inactive guard",
+          sr.read_erstwhile(), (set(), [], False))
+    _fake_grid([["City", " Erstwhile Channels "],
+                ["Boston", "boston-old (squatted)"],
+                ["Berlin", "#berlin-old · junk!!"]])
+    _n, _d, _p = sr.read_erstwhile()
+    check("names union across rows, header whitespace stripped",
+          (_n, _p), ({"boston-old", "berlin-old"}, True))
+    check("unparsable tokens are surfaced, not swallowed", _d, ["junk!!"])
+finally:
+    sr.get_values = _saved_gv
 
 # The country override stops a brand-new #spain being planned beside #espana.
 check("a country with its own named room is not re-planned",
@@ -296,6 +327,10 @@ check("a country with its own named room is not re-planned",
 check("a country whose channel matches the convention is left alone",
       sr.propose_country_overrides([ch("Tokyo", country="Japan", ctry="japan")]),
       [])
+check("a Nordic country is repointed at the shared #nordics room",
+      [(p["was"], p["value"]) for p in sr.propose_country_overrides(
+          [ch("Oslo", country="Norway", ctry="norway")])],
+      [("norway", "nordics")])
 
 # Both the misfiling fix and the country override reach Madrid's country cell.
 _madrid = [ch("Madrid", country="Spain", slack="españa",

--- a/skills/aaif-sync-chapters/scripts/test_sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_resources.py
@@ -277,8 +277,10 @@ check("a country with its own named room is not re-planned",
       [(p["was"], p["value"]) for p in sr.propose_country_overrides(
           [ch("Barcelona", country="Spain", ctry="spain")])],
       [("spain", "españa")])
+# Japan, not Norway: the Nordics became COUNTRY_CHANNELS exceptions
+# (one #nordics room), so a Norway fixture now correctly gets repointed.
 check("a country whose channel matches the convention is left alone",
-      sr.propose_country_overrides([ch("Oslo", country="Norway", ctry="norway")]),
+      sr.propose_country_overrides([ch("Tokyo", country="Japan", ctry="japan")]),
       [])
 
 # Both the misfiling fix and the country override reach Madrid's country cell.

--- a/skills/aaif-sync-chapters/scripts/test_sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_resources.py
@@ -272,6 +272,20 @@ check("the misfiled value moves column, and the row is repaired",
 check("a row that never claimed it is untouched",
       sr.propose_column_corrections([ch("Berlin", slack="berlin")], _AO), [])
 
+# --- parse_erstwhile(): the history column's fixed grammar ---------------------
+check("parse_erstwhile reads slugs around annotations",
+      sr.parse_erstwhile("seattle-organizers (squatted) · formerly meetup-seattle-organizers"),
+      {"seattle-organizers", "meetup-seattle-organizers"})
+check("parenthesized prose never yields a name",
+      sr.parse_erstwhile("munich (squatted) · germany (squatted country room)"),
+      {"munich", "germany"})
+check("comma-separated names all survive",
+      sr.parse_erstwhile("austin (squatted) · formerly austin-area, austin-area-organizers"),
+      {"austin", "austin-area", "austin-area-organizers"})
+check("a malformed cell under-protects instead of inventing names",
+      sr.parse_erstwhile("TBD?? (ask Rahul) · n/a!"), set())
+check("an empty cell yields nothing", sr.parse_erstwhile(""), set())
+
 # The country override stops a brand-new #spain being planned beside #espana.
 check("a country with its own named room is not re-planned",
       [(p["was"], p["value"]) for p in sr.propose_country_overrides(


### PR DESCRIPTION
## Summary
Chapters with 4+ accepted organizers now vet their own organizer candidates: the CRM sync writes pipeline organizers into those chapters' CRMs as untrusted `Prospect` rows (upgraded in place on acceptance), and pipeline hosts/speakers sync everywhere. Smaller chapters stay under central approval. The channel estate adopts the qualified-slug convention for squatter-blocked names, the sheet's new `Erstwhile Channels` column becomes a machine-read guard against ever re-planning a walked-away-from name, and the Slack read path survives the dead CLI credential. A security review pass added a merge refusal protecting accepted people's CRM rows from impostor form submissions.

## Changesets

### 1. `feat(sync-chapters): self-serve organizer policy for chapter CRMs`
**Files:** `scripts/sync_crm.py`, `scripts/test_sync_crm.py`, `SKILL.md`
`SELF_SERVE_MIN = 4` accepted organizers (excluding `AAIF_OPS_NAMES`, exact folded-name match) makes a chapter self-serve; `gate_pipeline_organizers` holds smaller chapters' candidates and authors the reason. `SYNC_STATUSES`/`PIPELINE_STATUSES` are fail-closed allowlists. `read_role_tab` keeps its accepted-only default so `sync_access` Drive grants are unaffected. Applied live 2026-08-21: 32 workbooks written and verified, 17 Prospects placed, 83 held.

### 2. `fix(sync-chapters): settle Austin/Nordics channel plans; read Slack via env token`
**Files:** `scripts/provision_channels.py`, `scripts/invite_organizers.py`, `scripts/sync_resources.py`, `scripts/test_sync_resources.py`
One `#nordics` room serves the Nordic chapters; reads fall back to `$AAIF_SLACK_WRITE_TOKEN` now the CLI credential is permanently expired.

### 3. `fix(sync-chapters): Germany's country room is #deutschland`
`#germany` is invisibly squatted; the country room takes the native name (the `#españa` precedent). Created live 2026-08-22.

### 4. `fix(sync-chapters): qualified-slug convention for squat-affected channels`
Squatted city rooms take `<city>-<state>` (`#austin-tx`, `#charlotte-nc`, `#dallas-tx`) or the native name (`#munchen`); squat-affected organizer rooms take `<city>-<state|countrycode>-organizers` (10 rooms renamed live). Squatted originals recorded in the sheet's new `Erstwhile Channels` column; the rename queue emptied.

### 5. `feat(sync-chapters): the erstwhile guard`
`sync_resources.parse_erstwhile`/`read_erstwhile` read the history column under a fixed grammar; `plan()` refuses any create or rename targeting a recorded name — refusals reported, never dropped.

### 6. `fix: address self-review findings` (6-agent review + security pass)
**Security:** a not-yet-accepted intake row never merges into an all-accepted person's CRM row (public form + email merge key = impostor risk); refused rows reported for review. **Robustness:** guard state prints on every run (missing column = explicit INACTIVE warning), `#`-prefixed and unparsable erstwhile tokens surfaced, guard moved inside `plan()`, `zip(strict=True)` alignment tripwire, token fallback names its source and fix. **Hygiene:** real names out of test fixtures, stale Austin/Sydney/token comments reconciled, docstring claims corrected. Nine new test cases.

## Test Plan
- [x] `python3 skills/aaif-sync-chapters/scripts/test_*.py` — all 8 pass
- [x] `PYTHONPATH=lib pytest lib/aaif_events/tests` — 126 pass
- [x] `pre-commit run --all-files`, `claude plugin validate .`
- [x] Live CRM `--write` verified convergent across all 83 chapter workbooks
- [x] Live provisioning report: `erstwhile guard: 24 name(s) protected`, 0 renames queued, 0 refusals

_Generated using hero-skills._

🤖 Generated with [Claude Code](https://claude.com/claude-code)