### PR TITLE
Harden all 18 skills: review findings, resume/pins/dry-run, doc truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@ __pycache__/
 # themselves are the durable artifact, not the notes that produced them.
 /docs/
 
-# Local versioned backups from the aaif-backup skill (binary snapshots stay out of git)
-backups/*
+# Local versioned backups from the aaif-backup skill (binary snapshots stay out of
+# git). Unanchored so a backups/ dir anywhere (e.g. under skills/aaif-backup/) is
+# covered; contents-not-directory (`/*`) so the README re-include below can work.
+**/backups/*
 !backups/README.md
 
 # Slack audit output (aaif-audit-slack). THIS REPO IS PUBLIC. The cache holds the
@@ -18,9 +20,7 @@ backups/*
 # and the reports carry organizer names, emails and private-channel rosters. None of
 # it may ever be committed; a single `git add -A` would publish it irreversibly.
 .slack-audit-cache/
-slack-members-audit.*
-slack-organizers-audit.*
-slack-activity-audit.*
+slack-*-audit.*
 
 # Nightly sync runner output (aaif-sync-chapters nightly.py). Same rule as above:
 # the per-engine logs hold the full reports — names, emails, per-person diffs —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,23 @@ pre-commit run --all-files     # run them now against the whole repo
 ```
 
 The hooks cover JSON/YAML/whitespace hygiene, Ruff (bug-focused lint of the
-helper scripts), codespell, gitleaks secret scanning, and a SKILL.md
-frontmatter check.
+helper scripts), codespell, gitleaks secret scanning, a SKILL.md
+frontmatter check, and a tooling-banner drift check. On the last one: the
+tooling-rule banner is deliberately copied into every ops `SKILL.md` (skills
+ship downstream without the repo docs), and `scripts/check_tooling_banner.py`
+fails when the copies drift — **edit all of them together**, never just one.
+
+Then run the tests. Ruff is pyflakes-only and does not resolve imports, so
+pytest is what actually catches a broken import or a stale module name:
+
+```bash
+PYTHONPATH=lib python -m pytest lib/aaif_events/tests -q    # shared library
+python skills/aaif-sync-chapters/scripts/test_sync_crm.py   # per-skill tests:
+                                                            # plain scripts, exit 1 on failure
+```
+
+Skill scripts are not a package, so each skill's `scripts/test_*.py` runs as a
+plain Python script rather than through pytest.
 
 Then validate the manifests. The repo root is both the marketplace and the
 single plugin (marketplace `source: "./"`), so one call validates the

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Pure writing skills. They take the event details you give them and produce copy.
 > Running your own chapter? Swap these URLs in each skill's `SKILL.md`.
 
 ### 🛠️ Ops skills — need Google Workspace access
-These drive Google Drive / Sheets through the `gws` CLI (see below).
+These drive Google Drive / Sheets through the `gws` CLI (see below); a few also
+talk to Slack or Luma.
 
 | Skill | What it does | Touches |
 |---|---|---|
@@ -82,6 +83,11 @@ These drive Google Drive / Sheets through the `gws` CLI (see below).
 | `aaif-triage-intake` | Summarize who's awaiting review in the Community Intake sheet + draft outreach | Google Sheets |
 | `aaif-clean-data` | Normalize/flag data quality in the Intake sheet (LinkedIn, casing, City=Other…) | Google Sheets |
 | `aaif-backup` | Versioned local snapshots of critical data (Intake sheet by default, or any file) before risky edits | Google Drive |
+| `aaif-create-event` | Add an event to a chapter/series Event Tracker (due-dates stamped from the event date), optionally creating the live Luma page on approval | Google Drive, Luma |
+| `aaif-update-event` | Edit an event's details or move its date (recomputing all task due-dates), flag stale assets, optionally sync the change to Luma | Google Drive, Luma |
+| `aaif-event-status` | Report overdue / due-soon event tasks by owner, plus read-only Luma registration stats | Google Drive, Luma |
+| `aaif-sync-chapters` | Push intake decisions to the Chapters List, About docs, chapter CRMs, per-chapter Drive access and the resource map (report/propose by default) | Google Sheets/Drive/Docs, Slack |
+| `aaif-audit-slack` | Audit the community Slack workspace — chapter/organizer channel coverage and member/channel health — as self-contained HTML + PDF reports | Slack, Google Sheets |
 
 > **Heads up — these ship with AAIF's own IDs.** The ops skills reference AAIF's
 > Google resources (the Chapters Drive, the Intake Ops spreadsheet ID, Luma slug
@@ -128,15 +134,17 @@ On your Google Cloud project, enable the **Sheets**, **Docs**, **Slides**,
 **OAuth scopes.** Grant **read-write** scopes for anything you write to —
 read-only access passes the verify step below but then fails on the first write
 (form responses are read-only by nature, hence the `.readonly` scope). The
-bundled scripts use only the Sheets and Drive scopes; the Docs, Slides, and Forms
-scopes are for operating on those assets directly — the chapter/series source docs
-and decks, and the intake form:
+bundled scripts use the Sheets, Drive, and Slides scopes (the shared
+`aaif_events.slides_export` helper renders deck previews through the Slides
+API); the Docs and Forms scopes are for operating on those assets directly —
+the chapter/series source docs and the intake form:
 
 - `https://www.googleapis.com/auth/spreadsheets` — read/write the intake sheet *(scripts)*
 - `https://www.googleapis.com/auth/drive` — copy, create, and update Drive files,
   incl. chapter/series asset clones *(scripts)*
 - `https://www.googleapis.com/auth/documents` — read/edit chapter/series Docs
-- `https://www.googleapis.com/auth/presentations` — read/edit day-of / series Slides
+- `https://www.googleapis.com/auth/presentations` — read/edit day-of / series
+  Slides, and render slide previews *(scripts)*
 - `https://www.googleapis.com/auth/forms.body` — read/edit the intake form
 - `https://www.googleapis.com/auth/forms.responses.readonly` — read form responses
 
@@ -155,7 +163,11 @@ Code *plugin*:
 
 - **Claude Code** — install as the plugin above (native).
 - **claude.ai / Claude Agent SDK** — zip a skill folder (the dir containing
-  `SKILL.md`) and upload it as a Skill.
+  `SKILL.md`) and upload it as a Skill. **Caveat:** skills whose scripts import
+  the shared `lib/aaif_events` package — `aaif-audit-slack`,
+  `aaif-sync-chapters`, `aaif-create-event`, `aaif-update-event`,
+  `aaif-event-status` — do **not** work zipped standalone; they need the full
+  checkout (or plugin install), since the zip won't contain `lib/`.
 - **Cursor** — Cursor uses its own `.cursor/rules/*.mdc` format and does **not**
   consume Claude Code plugins. You can copy a `SKILL.md`'s instructions into a
   Cursor rule, but it won't run the bundled scripts the same way.
@@ -175,10 +187,13 @@ events/
 ├── .claude-plugin/
 │   ├── marketplace.json          # one-plugin marketplace ("aaif")
 │   └── plugin.json               # plugin manifest (aaif-events)
+├── lib/
+│   └── aaif_events/              # shared stdlib-only modules + their tests
+├── scripts/                      # repo tooling (e.g. the banner-drift check)
 ├── skills/
 │   ├── aaif-announcement-post/SKILL.md
 │   ├── aaif-create-chapter/{SKILL.md, scripts/}
-│   └── …  (17 skills total)
+│   └── …  (18 skills total)
 └── README.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The repo root is **both** the marketplace and the single plugin — the marketpl
 entry's `source` is `"./"`, so there's no extra `plugins/<name>/` nesting.
 
 ```
-events/
+meetups/
 ├── .claude-plugin/
 │   ├── marketplace.json          # one-plugin marketplace ("aaif")
 │   └── plugin.json               # plugin manifest (aaif-events)

--- a/lib/aaif_events/jsoncache.py
+++ b/lib/aaif_events/jsoncache.py
@@ -40,7 +40,12 @@ _MISS = object()   # distinguishes "no payload key" from a stored None
 
 
 def write(path, payload, team_id=None):
-    """Write `payload` atomically, stamped with time, format and workspace."""
+    """Write `payload` atomically, stamped with time, format and workspace.
+
+    A caller that passes `team_id` to read() must also pass it here: read()
+    discards an unstamped cache, so skipping the stamp on write means every
+    run discards and re-fetches, forever.
+    """
     envelope = {"format": FORMAT,
                 "written_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
                 "team_id": team_id,

--- a/lib/aaif_events/jsoncache.py
+++ b/lib/aaif_events/jsoncache.py
@@ -52,6 +52,9 @@ def write(path, payload, team_id=None):
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(envelope, fh)
+            fh.flush()
+            os.fsync(fh.fileno())  # data on disk before the rename is; power
+            #                        loss must not leave an empty renamed cache
         os.replace(tmp, path)      # atomic; the 0600 mode travels with the file
     except BaseException:
         if os.path.exists(tmp):
@@ -96,8 +99,14 @@ def read(path, refresh=False, team_id=None, note=None):
         return discard("not a cache envelope")
     if envelope.get("format") != FORMAT:
         return discard("format %r, expected %d" % (envelope.get("format"), FORMAT))
-    if team_id and envelope.get("team_id") and envelope["team_id"] != team_id:
-        return discard("workspace %s, expected %s" % (envelope["team_id"], team_id))
+    stamped = envelope.get("team_id")
+    if team_id and stamped and stamped != team_id:
+        return discard("workspace %s, expected %s" % (stamped, team_id))
+    if team_id and not stamped:
+        # The caller knows which workspace it is auditing; an unstamped cache
+        # cannot prove it matches, and a wrong-tenant join reads as a coherent,
+        # entirely wrong report.
+        return discard("no workspace stamp, expected %s" % team_id)
     payload = envelope.get("payload", _MISS)
     return None if payload is _MISS else payload
 

--- a/lib/aaif_events/luma.py
+++ b/lib/aaif_events/luma.py
@@ -99,7 +99,15 @@ def call(method, path, params=None, body=None, retries=4):
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=30) as r:
-                return json.loads(r.read().decode("utf-8") or "{}")
+                text = r.read().decode("utf-8") or "{}"
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                # A proxy or outage page can answer 200 with HTML; a bare
+                # JSONDecodeError mid-run names neither the request nor the fact
+                # that the body was the problem.
+                raise LumaError("%s %s answered 200 but the body was not JSON "
+                                "(starts %r)" % (method, path, text[:120]))
         except urllib.error.HTTPError as e:
             detail = e.read().decode("utf-8", errors="replace")[:300]
             retryable = e.code == 429 or (method == "GET" and e.code in _TRANSIENT_HTTP)
@@ -128,10 +136,6 @@ def call(method, path, params=None, body=None, retries=4):
 # ---------------------------------------------------------------------------
 # Endpoints (thin)
 # ---------------------------------------------------------------------------
-def get_self():
-    return call("GET", "/v1/users/get-self")
-
-
 def get_calendar():
     return call("GET", "/v1/calendars/get")
 

--- a/lib/aaif_events/report_style.py
+++ b/lib/aaif_events/report_style.py
@@ -316,6 +316,20 @@ def find_chrome():
     return None
 
 
+def write_private(path, text):
+    """Write a PII-carrying report file 0600 from the first byte.
+
+    jsoncache's rule, restated for the report side: a chmod *after* the write
+    leaves the page world-readable for its duration — permanently, if the run
+    is killed in between. The fchmod tightens a pre-existing looser file while
+    it is still truncated-empty.
+    """
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
 def to_pdf(html_path, pdf_path, timeout_s=180):
     """Print a local HTML file to PDF with headless Chrome, and verify it worked.
 
@@ -390,6 +404,11 @@ def _repo_root(path):
 
     Resolved from the path's own directory, not the process cwd — running the
     script from elsewhere must not decide whether the *output* is protected.
+
+    Only git's own "not a git repository" answer means outside-a-repo. Any
+    other failure (dubious ownership, a corrupt .git, …) aborts: mapping it to
+    None would silently disengage the PII guard for a path that may well sit
+    inside this public repo.
     """
     probe_dir = os.path.dirname(os.path.abspath(path)) or os.sep
     while not os.path.isdir(probe_dir) and probe_dir != os.sep:
@@ -403,7 +422,17 @@ def _repo_root(path):
             "%s is ignored. These files hold Slack member names, email addresses "
             "and 2FA/admin flags; install git or point --cache/--out outside any "
             "repository." % path)
-    return proc.stdout.strip() if proc.returncode == 0 else None
+    if proc.returncode == 0:
+        return proc.stdout.strip()
+    stderr = (proc.stderr or "").strip()
+    if "not a git repository" in stderr.lower():
+        return None
+    raise SystemExit(
+        "REFUSING TO RUN: `git rev-parse` failed in %s (exit %d: %s), so this "
+        "cannot verify that %s is ignored. Fix the git error, or point "
+        "--cache/--out outside any repository."
+        % (probe_dir, proc.returncode,
+           stderr.splitlines()[-1] if stderr else "no stderr", path))
 
 
 def assert_git_ignored(*paths):
@@ -426,16 +455,20 @@ def assert_git_ignored(*paths):
         root = _repo_root(path)
         if root is None:
             continue                      # outside any repo — nothing to leak into
+        # Absolute before probing: check-ignore/ls-files run with `-C root`, so
+        # a --out relative to a repo *sub*directory would otherwise be judged
+        # against the wrong file.
+        abs_path = os.path.abspath(path)
         # A directory is probed through a child: `check-ignore` answers
         # differently for a bare directory name, and this works before the
         # directory exists.
-        probe = os.path.join(path, "probe") if path.endswith(os.sep) else path
+        probe = os.path.join(abs_path, "probe") if path.endswith(os.sep) else abs_path
         ignored = subprocess.run(["git", "-C", root, "check-ignore", "-q", probe],
                                  capture_output=True).returncode == 0
         # .gitignore has no effect on an already-tracked file, so a report
         # committed before these rules landed would still ride along on `git
         # add -A` while check-ignore reports it as ignored.
-        tracked = subprocess.run(["git", "-C", root, "ls-files", "--error-unmatch", path],
+        tracked = subprocess.run(["git", "-C", root, "ls-files", "--error-unmatch", abs_path],
                                  capture_output=True).returncode == 0
         if tracked:
             offenders.append("%s (already TRACKED — git rm --cached it)" % path)

--- a/lib/aaif_events/report_style.py
+++ b/lib/aaif_events/report_style.py
@@ -395,6 +395,8 @@ def to_pdf(html_path, pdf_path, timeout_s=180):
             "Chrome exited 0 but produced no usable PDF at %s (%d bytes). Quit "
             "any running Chrome and retry, or pass --no-pdf and print %s by "
             "hand.\n%s" % (pdf_path, os.path.getsize(pdf_path), html_path, stderr))
+    # Chrome creates the PDF with default (world-readable) permissions; it
+    # carries the same PII as the 0600 HTML it was rendered from.
     os.chmod(pdf_path, 0o600)
     return pdf_path
 
@@ -414,8 +416,12 @@ def _repo_root(path):
     while not os.path.isdir(probe_dir) and probe_dir != os.sep:
         probe_dir = os.path.dirname(probe_dir)   # output dir may not exist yet
     try:
+        # LC_ALL=C: the "not a git repository" match below reads git's stderr,
+        # and localized git says e.g. "kein Git-Repository" — which would abort
+        # legitimate outside-repo runs instead of returning None.
         proc = subprocess.run(["git", "-C", probe_dir, "rev-parse", "--show-toplevel"],
-                              capture_output=True, text=True)
+                              capture_output=True, text=True,
+                              env={**os.environ, "LC_ALL": "C", "LANG": "C"})
     except FileNotFoundError:
         raise SystemExit(
             "REFUSING TO RUN: git is not installed, so this cannot verify that "

--- a/lib/aaif_events/slack.py
+++ b/lib/aaif_events/slack.py
@@ -42,6 +42,7 @@ mechanisms they demonstrate are stable.
 import http.client
 import json
 import os
+import re
 import time
 import urllib.error
 import urllib.parse
@@ -139,21 +140,41 @@ def _find_token(obj):
     return found[0] if found else None
 
 
-def _dotenv_token(env_path=".env", key=ENV_TOKEN_VAR):
-    """`key` out of a KEY=VALUE `.env` file, or None.
+def _dotenv_token(env_path=".env"):
+    """`AAIF_SLACK_WRITE_TOKEN` out of a KEY=VALUE `.env` file, or None.
 
     Deliberately not a dotenv loader: only this one key is read, nothing is
     exported into the environment, and the value never appears in any output.
+    It does understand the shapes real .env files take, though: an optional
+    leading `export `, quoted values (kept verbatim, `#` and all), and — for
+    unquoted values only — a trailing ` # comment`, which would otherwise ride
+    into the token and make it invalid.
     """
     if not os.path.exists(env_path):
         return None
     with open(env_path, encoding="utf-8") as fh:
         for line in fh:
-            name, sep, value = line.partition("=")
-            if sep and name.strip() == key:
-                value = value.strip().strip("'\"")
-                if value:
-                    return value
+            name, sep, value = line.strip().partition("=")
+            name = name.strip()
+            if name.startswith("export "):
+                name = name[len("export "):].strip()
+            if not sep or name != ENV_TOKEN_VAR:
+                continue
+            value = value.strip()
+            if value[:1] in ("'", '"'):
+                close = value.find(value[0], 1)
+                # A quoted value keeps its content verbatim — a '#' inside the
+                # quotes is part of the token, not a comment.
+                value = value[1:close] if close > 0 else value[1:]
+            else:
+                # Strip an inline comment: a '#' only starts one when preceded
+                # by whitespace, so a bare `xoxb-a#b` stays intact.
+                if value.startswith("#"):
+                    value = ""
+                else:
+                    value = re.split(r"\s+#", value, maxsplit=1)[0].rstrip()
+            if value:
+                return value
     return None
 
 
@@ -291,7 +312,9 @@ class Slack:
             # and a "missing scopes" message that sends the operator hunting
             # through the app config for a problem that is really the token.
             raise SlackError("auth.test", body.get("error", "unknown"),
-                             "the token is not usable; run `slack auth login`")
+                             "the token is not usable; set %s (environment or "
+                             "./.env), or as a last resort run `slack auth "
+                             "login`" % ENV_TOKEN_VAR)
         raw = headers.get("x-oauth-scopes") or ""
         return {s.strip() for s in raw.split(",") if s.strip()}
 
@@ -307,7 +330,9 @@ class Slack:
             raise SystemExit(
                 "Token is missing the %s scope(s). The audit would report the "
                 "resulting failures as real findings, so it will not run.\n"
-                "Re-authenticate with `slack auth login`." % ", ".join(missing))
+                "Set %s to a token that carries them (environment or ./.env); "
+                "`slack auth login` is the last resort."
+                % (", ".join(missing), ENV_TOKEN_VAR))
         return have
 
 

--- a/lib/aaif_events/slack.py
+++ b/lib/aaif_events/slack.py
@@ -1,8 +1,11 @@
 """Read-only Slack Web API client for the workspace audits.
 
-Auth comes from the Slack CLI's own credentials (`slack auth login`), so no token
-is ever stored in this repo or passed on a command line. The token is never
-printed — callers get data, not credentials.
+Auth resolution, in order: the `AAIF_SLACK_WRITE_TOKEN` app token from the
+environment, then from a `.env` file in the current directory, then the Slack
+CLI's own credentials (`slack auth login`). The app token is the standing way
+the audits run — it is strictly more capable than the CLI credential, which has
+expired. No token is ever stored in this repo or passed on a command line, and
+the token is never printed — callers get data, not credentials.
 
 **This client is read-only.** `call()` refuses any method outside
 `ALLOWED_METHODS`; the audits inspect a community workspace, and a typo must not
@@ -45,6 +48,7 @@ import urllib.parse
 import urllib.request
 
 CRED_PATH = os.path.expanduser("~/.slack/credentials.json")
+ENV_TOKEN_VAR = "AAIF_SLACK_WRITE_TOKEN"
 API = "https://slack.com/api/"
 
 #: The exact set of methods this repo calls. This is deliberately *not* "every
@@ -67,6 +71,7 @@ ALLOWED_METHODS = frozenset({
 MODULE_ERRORS = frozenset({
     "retry_exhausted",     # burnt the retry budget; detail names the last cause
     "transport_failed",    # socket/TLS/DNS failure on the final attempt
+    "not_json",            # a 200 whose body was not JSON (proxy/outage page)
     "malformed_page",      # ok:true but the collection key was absent
     "lookup_failed",       # a lookup failed for API reasons, not absence
 })
@@ -134,11 +139,40 @@ def _find_token(obj):
     return found[0] if found else None
 
 
+def _dotenv_token(env_path=".env", key=ENV_TOKEN_VAR):
+    """`key` out of a KEY=VALUE `.env` file, or None.
+
+    Deliberately not a dotenv loader: only this one key is read, nothing is
+    exported into the environment, and the value never appears in any output.
+    """
+    if not os.path.exists(env_path):
+        return None
+    with open(env_path, encoding="utf-8") as fh:
+        for line in fh:
+            name, sep, value = line.partition("=")
+            if sep and name.strip() == key:
+                value = value.strip().strip("'\"")
+                if value:
+                    return value
+    return None
+
+
 def load_token(path=CRED_PATH):
-    """Read the Slack CLI credentials and return its token."""
+    """Return a Slack token, preferring the app token over the CLI credential.
+
+    Resolution order: `AAIF_SLACK_WRITE_TOKEN` in the environment, the same key
+    in a `./.env` file, then the Slack CLI credentials at `path`. The app token
+    is checked first because it is strictly more capable than the CLI one and
+    is how the audits run since the CLI credential expired.
+    """
+    token = os.environ.get(ENV_TOKEN_VAR, "").strip() or _dotenv_token()
+    if token:
+        return token
     if not os.path.exists(path):
         raise SystemExit(
-            "No Slack credentials at %s — run `slack auth login` first." % path)
+            "No Slack token: %s is not set (environment or ./.env) and there "
+            "are no Slack CLI credentials at %s — set the app token or run "
+            "`slack auth login`." % (ENV_TOKEN_VAR, path))
     with open(path, encoding="utf-8") as fh:
         token = _find_token(json.load(fh))
     if not token:
@@ -166,19 +200,27 @@ class Slack:
                 "%s is not a read-only audit method; refusing to call it." % method)
         body = urllib.parse.urlencode(
             {k: v for k, v in params.items() if v is not None}).encode()
+        return self._fetch(method, body)[0]
+
+    def _fetch(self, method, body):
+        """The retry loop under call() and scopes(): (payload, headers).
+
+        One exception vocabulary out of here — a caller writing `except
+        SlackError` must not miss a final 429, a 5xx, a transport failure, or a
+        200 whose body is an HTML outage page instead of JSON.
+        """
         last = "unknown"
         for attempt in range(MAX_ATTEMPTS):
             try:
                 with urllib.request.urlopen(self._request(method, body),
                                             timeout=TIMEOUT_S) as response:
-                    payload = json.loads(response.read())
+                    headers = response.headers
+                    raw = response.read()
             except urllib.error.HTTPError as exc:
                 if exc.code == 429 and attempt < MAX_ATTEMPTS - 1:
                     last = "http_429"
                     self._sleep(_retry_secs(exc.headers.get("Retry-After")))
                     continue
-                # One vocabulary out of call(): a caller writing `except
-                # SlackError` must not miss the final 429 or a 5xx.
                 raise SlackError(method, "http_%d" % exc.code, exc.reason or "")
             except (http.client.HTTPException, urllib.error.URLError,
                     ConnectionError, TimeoutError) as exc:
@@ -192,13 +234,19 @@ class Slack:
                 last = type(exc).__name__
                 self._sleep(2 * (attempt + 1))
                 continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                raise SlackError(method, "not_json",
+                                 "HTTP 200 but the body was not JSON "
+                                 "(starts %r)" % raw[:80])
             if not payload.get("ok") and payload.get("error") == "ratelimited":
                 last = "ratelimited"
                 if attempt == MAX_ATTEMPTS - 1:
                     break          # no point sleeping before giving up
                 self._sleep(_retry_secs(payload.get("retry_after")))
                 continue
-            return payload
+            return payload, headers
         raise SlackError(method, "retry_exhausted",
                          "%d attempts, last failure: %s" % (MAX_ATTEMPTS, last))
 
@@ -233,19 +281,18 @@ class Slack:
         """OAuth scopes on this client's token, read from a live response header.
 
         The one request that bypasses `call()` — it needs the response headers,
-        which `call()` discards. Hardcoded to `auth.test`; see the module
-        docstring.
+        which `call()` discards — but it shares `_fetch`, so a 429 or a network
+        blip retries and fails as a SlackError here exactly as it would there.
+        Hardcoded to `auth.test`; see the module docstring.
         """
-        with urllib.request.urlopen(self._request("auth.test"),
-                                    timeout=TIMEOUT_S) as response:
-            raw = response.headers.get("x-oauth-scopes") or ""
-            body = json.loads(response.read())
+        body, headers = self._fetch("auth.test", b"")
         if not body.get("ok"):
             # Without this, a dead token yields no scope header, an empty set,
             # and a "missing scopes" message that sends the operator hunting
             # through the app config for a problem that is really the token.
             raise SlackError("auth.test", body.get("error", "unknown"),
                              "the token is not usable; run `slack auth login`")
+        raw = headers.get("x-oauth-scopes") or ""
         return {s.strip() for s in raw.split(",") if s.strip()}
 
     def require_scopes(self, *needed):
@@ -471,13 +518,3 @@ def lookup_emails(api, emails, progress=None):
             "Refusing to report these people as having no Slack account."
             % (len(failures), len(resolved), ", ".join(sorted(set(failures)))))
     return resolved
-
-
-def scopes(token=None):
-    """OAuth scopes for a token, loading one from disk if not given.
-
-    Prefer `Slack.scopes()` when you already hold a client — this function reads
-    the credentials a second time and could therefore answer for a different
-    token than the one your client is using.
-    """
-    return Slack(token=token).scopes()

--- a/lib/aaif_events/slides_export.py
+++ b/lib/aaif_events/slides_export.py
@@ -53,6 +53,22 @@ def _gws_json(*args, params=None, body=None):
         raise RuntimeError("gws returned non-JSON output for %s: %s" % (" ".join(args), s[:200]))
 
 
+def _download(url, out_path, timeout=30):
+    """Fetch `url` to `out_path` with a bounded timeout. Any failure — network,
+    timeout, or the too-small sanity check — deletes the partial file, so a
+    truncated PNG can never be mistaken for a finished render."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r, \
+                open(out_path, "wb") as fh:
+            fh.write(r.read())
+        if os.path.getsize(out_path) < 1000:
+            raise RuntimeError("rendered thumbnail suspiciously small (%s)" % out_path)
+    except BaseException:
+        if os.path.exists(out_path):
+            os.remove(out_path)
+        raise
+
+
 def render_slide_png(file_id, out_path, slide_index=0, thumbnail_size="WIDTH2000_PX"):
     """Export slide `slide_index` (0-based) of the Drive pptx `file_id` to a PNG
     at `out_path`. Makes a throwaway Google Slides copy to render from (Slides
@@ -73,9 +89,7 @@ def render_slide_png(file_id, out_path, slide_index=0, thumbnail_size="WIDTH2000
                            params={"presentationId": presentation_id, "pageObjectId": page_object_id,
                                    "thumbnailProperties.thumbnailSize": thumbnail_size})
         os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-        urllib.request.urlretrieve(thumb["contentUrl"], out_path)
-        if os.path.getsize(out_path) < 1000:
-            raise RuntimeError("rendered thumbnail suspiciously small (%s)" % out_path)
+        _download(thumb["contentUrl"], out_path)
         return out_path
     finally:
         # The throwaway copy has no `parents` set, so it lands in the SAME

--- a/lib/aaif_events/slides_export.py
+++ b/lib/aaif_events/slides_export.py
@@ -54,19 +54,22 @@ def _gws_json(*args, params=None, body=None):
 
 
 def _download(url, out_path, timeout=30):
-    """Fetch `url` to `out_path` with a bounded timeout. Any failure — network,
-    timeout, or the too-small sanity check — deletes the partial file, so a
-    truncated PNG can never be mistaken for a finished render."""
+    """Fetch `url` to `out_path` with a bounded timeout. The bytes land in a
+    temp file that is renamed over `out_path` only after the too-small sanity
+    check passes, so a failure — network, timeout, or a truncated render — can
+    neither be mistaken for a finished PNG nor destroy a pre-existing good one:
+    only what THIS call wrote is ever cleaned up."""
+    tmp = out_path + ".partial"
     try:
         with urllib.request.urlopen(url, timeout=timeout) as r, \
-                open(out_path, "wb") as fh:
+                open(tmp, "wb") as fh:
             fh.write(r.read())
-        if os.path.getsize(out_path) < 1000:
+        if os.path.getsize(tmp) < 1000:
             raise RuntimeError("rendered thumbnail suspiciously small (%s)" % out_path)
-    except BaseException:
-        if os.path.exists(out_path):
-            os.remove(out_path)
-        raise
+        os.replace(tmp, out_path)
+    finally:
+        if os.path.exists(tmp):   # gone on success (os.replace consumed it)
+            os.remove(tmp)
 
 
 def render_slide_png(file_id, out_path, slide_index=0, thumbnail_size="WIDTH2000_PX"):

--- a/lib/aaif_events/tests/test_jsoncache.py
+++ b/lib/aaif_events/tests/test_jsoncache.py
@@ -105,6 +105,18 @@ def test_a_cache_from_another_workspace_is_refused(tmp_path):
     assert jsoncache.read(p, team_id="T_OTHER") is None
 
 
+def test_an_unstamped_cache_is_refused_when_a_workspace_is_expected(tmp_path):
+    """An unstamped file cannot prove it matches the caller's workspace — and
+    the discard must be announced, not silent."""
+    p = str(tmp_path / "c.json")
+    jsoncache.write(p, {"chans": 1})           # no team_id stamp
+    said = []
+    assert jsoncache.read(p, team_id="T_AAIF", note=said.append) is None
+    assert said and "no workspace stamp" in said[0]
+    # ...while a caller with no expectation still gets the payload.
+    assert jsoncache.read(p) == {"chans": 1}
+
+
 def test_discarding_a_cache_is_announced(tmp_path):
     """Throwing away a 20-minute pull in silence is what this repo refuses to do."""
     p = tmp_path / "c.json"

--- a/lib/aaif_events/tests/test_luma.py
+++ b/lib/aaif_events/tests/test_luma.py
@@ -99,6 +99,15 @@ class TestCall(unittest.TestCase):
             self.assertEqual(uo.call_count, 1)
             self.assertEqual(cm.exception.status, 404)
 
+    def test_a_200_html_body_is_a_lumaerror_not_a_bare_jsondecodeerror(self):
+        r = mock.MagicMock()
+        r.__enter__.return_value = r
+        r.read.return_value = b"<html>maintenance</html>"
+        with mock.patch("urllib.request.urlopen", return_value=r):
+            with self.assertRaises(luma.LumaError) as cm:
+                luma.call("GET", "/v1/x")
+            self.assertIn("not JSON", str(cm.exception))
+
     def test_get_network_error_retries_then_raises_without_status(self):
         with mock.patch("urllib.request.urlopen",
                         side_effect=urllib.error.URLError("down")) as uo:

--- a/lib/aaif_events/tests/test_report_style.py
+++ b/lib/aaif_events/tests/test_report_style.py
@@ -126,6 +126,38 @@ def test_a_git_failure_that_is_not_outside_a_repo_aborts(monkeypatch, tmp_path):
     assert "dubious ownership" in str(exc.value)
 
 
+def test_repo_root_pins_git_to_the_c_locale(monkeypatch, tmp_path):
+    """The "not a git repository" stderr match is defeated by localized git
+    (de_DE says "kein Git-Repository"), so the subprocess must run LC_ALL=C."""
+    seen = {}
+
+    def fake_run(*a, **kw):
+        seen.update(kw)
+        return subprocess.CompletedProcess(["git"], 0, stdout="/repo\n", stderr="")
+
+    monkeypatch.setattr(rs.subprocess, "run", fake_run)
+    assert rs._repo_root(str(tmp_path / "r.html")) == "/repo"
+    assert seen["env"]["LC_ALL"] == "C"
+    assert seen["env"]["LANG"] == "C"
+
+
+def test_to_pdf_makes_the_pdf_0600(monkeypatch, tmp_path):
+    """Chrome writes the PDF twin of the 0600 HTML with default (world-readable)
+    permissions; to_pdf must tighten it after a successful render."""
+    html = tmp_path / "r.html"
+    html.write_text("<p>x</p>", encoding="utf-8")
+    pdf = tmp_path / "r.pdf"
+
+    def fake_run(cmd, **kw):
+        pdf.write_bytes(b"%PDF-" + b"x" * 2000)   # written 0644-ish by umask
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(rs, "find_chrome", lambda: "/fake/chrome")
+    monkeypatch.setattr(rs.subprocess, "run", fake_run)
+    assert rs.to_pdf(str(html), str(pdf)) == str(pdf)
+    assert oct(os.stat(pdf).st_mode & 0o777) == "0o600"
+
+
 def test_not_a_git_repository_still_means_outside_a_repo(monkeypatch, tmp_path):
     fake = subprocess.CompletedProcess(
         ["git"], 128, stdout="",

--- a/lib/aaif_events/tests/test_report_style.py
+++ b/lib/aaif_events/tests/test_report_style.py
@@ -113,6 +113,40 @@ def test_a_path_outside_any_repo_is_allowed(tmp_path, monkeypatch):
     rs.assert_git_ignored(str(outside) + os.sep, str(outside / "r.html"))
 
 
+def test_a_git_failure_that_is_not_outside_a_repo_aborts(monkeypatch, tmp_path):
+    """Exit 128 for e.g. dubious ownership must not read as "outside any repo"
+    and silently disengage the guard."""
+    fake = subprocess.CompletedProcess(
+        ["git"], 128, stdout="",
+        stderr="fatal: detected dubious ownership in repository at '/x'")
+    monkeypatch.setattr(rs.subprocess, "run", lambda *a, **kw: fake)
+    with pytest.raises(SystemExit) as exc:
+        rs._repo_root(str(tmp_path / "r.html"))
+    assert "REFUSING TO RUN" in str(exc.value)
+    assert "dubious ownership" in str(exc.value)
+
+
+def test_not_a_git_repository_still_means_outside_a_repo(monkeypatch, tmp_path):
+    fake = subprocess.CompletedProcess(
+        ["git"], 128, stdout="",
+        stderr="fatal: not a git repository (or any of the parent directories): .git")
+    monkeypatch.setattr(rs.subprocess, "run", lambda *a, **kw: fake)
+    assert rs._repo_root(str(tmp_path / "r.html")) is None
+
+
+def test_a_relative_path_is_judged_from_the_cwd_not_the_repo_root(tmp_path, monkeypatch):
+    """From a repo subdirectory, a relative --out must be checked as the file
+    it actually names, not as root/<name>."""
+    root = _repo(tmp_path)
+    (root / ".gitignore").write_text("sub/report.html\n", encoding="utf-8")
+    sub = root / "sub"
+    sub.mkdir()
+    monkeypatch.chdir(sub)
+    rs.assert_git_ignored("report.html")       # sub/report.html is ignored
+    with pytest.raises(SystemExit):
+        rs.assert_git_ignored("leaky.html")    # sub/leaky.html is not
+
+
 def test_the_check_follows_the_path_not_the_cwd(tmp_path, monkeypatch):
     """Running from a non-repo directory must not disable the control for an
     absolute path pointing into a repo."""
@@ -122,3 +156,17 @@ def test_the_check_follows_the_path_not_the_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(elsewhere)
     with pytest.raises(SystemExit):
         rs.assert_git_ignored(str(root / "leaky.html"))
+
+
+def test_write_private_is_0600_and_tightens_existing(tmp_path):
+    import os
+    from aaif_events import report_style as rs
+    p = tmp_path / "report.html"
+    rs.write_private(str(p), "névé — ok")
+    assert oct(os.stat(p).st_mode & 0o777) == "0o600"
+    assert p.read_text(encoding="utf-8") == "névé — ok"
+    # A pre-existing looser file is tightened, not left world-readable.
+    os.chmod(p, 0o644)
+    rs.write_private(str(p), "second")
+    assert oct(os.stat(p).st_mode & 0o777) == "0o600"
+    assert p.read_text(encoding="utf-8") == "second"

--- a/lib/aaif_events/tests/test_slack.py
+++ b/lib/aaif_events/tests/test_slack.py
@@ -121,6 +121,8 @@ def test_scopes_reports_a_dead_token_as_a_token_problem(monkeypatch):
     with pytest.raises(slack.SlackError) as exc:
         api.scopes()
     assert exc.value.error == "invalid_auth"
+    # The standing remedy is the app token; CLI login is the last resort.
+    assert slack.ENV_TOKEN_VAR in str(exc.value)
     assert "slack auth login" in str(exc.value)
 
 
@@ -179,6 +181,8 @@ def test_require_scopes_aborts_on_a_missing_scope(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         api.require_scopes("channels:read", "users:read.email")
     assert "users:read.email" in str(exc.value)
+    # The remedy names the app token first, not `slack auth login` alone.
+    assert slack.ENV_TOKEN_VAR in str(exc.value)
 
 
 def test_user_record_defaults_flags_to_booleans(monkeypatch):
@@ -306,6 +310,39 @@ def test_dotenv_parse_ignores_other_keys_and_tolerates_quotes(tmp_path):
                    "AAIF_SLACK_WRITE_TOKEN='xoxp-quoted'\n", encoding="utf-8")
     assert slack._dotenv_token(env_path=str(env)) == "xoxp-quoted"
     assert slack._dotenv_token(env_path=str(tmp_path / "nope")) is None
+
+
+def test_dotenv_strips_an_inline_comment_from_an_unquoted_value(tmp_path):
+    """`KEY=xoxb-abc  # prod` must yield the token, not token-plus-comment."""
+    env = tmp_path / ".env"
+    env.write_text("AAIF_SLACK_WRITE_TOKEN=xoxb-abc  # prod\n", encoding="utf-8")
+    assert slack._dotenv_token(env_path=str(env)) == "xoxb-abc"
+
+
+def test_dotenv_keeps_a_hash_glued_to_the_value(tmp_path):
+    """Only a whitespace-preceded '#' starts a comment."""
+    env = tmp_path / ".env"
+    env.write_text("AAIF_SLACK_WRITE_TOKEN=xoxb-a#b\n", encoding="utf-8")
+    assert slack._dotenv_token(env_path=str(env)) == "xoxb-a#b"
+
+
+def test_dotenv_quoted_values_keep_their_content(tmp_path):
+    """Inside quotes a '#' is part of the token, comment or not after."""
+    env = tmp_path / ".env"
+    env.write_text('AAIF_SLACK_WRITE_TOKEN="xoxb-a #b"  # prod\n', encoding="utf-8")
+    assert slack._dotenv_token(env_path=str(env)) == "xoxb-a #b"
+
+
+def test_dotenv_accepts_an_export_prefix(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("export AAIF_SLACK_WRITE_TOKEN=xoxb-exported\n", encoding="utf-8")
+    assert slack._dotenv_token(env_path=str(env)) == "xoxb-exported"
+
+
+def test_dotenv_a_value_that_is_only_a_comment_is_a_miss(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("AAIF_SLACK_WRITE_TOKEN= # set me\n", encoding="utf-8")
+    assert slack._dotenv_token(env_path=str(env)) is None
 
 
 @pytest.mark.parametrize("blob,expected", [

--- a/lib/aaif_events/tests/test_slack.py
+++ b/lib/aaif_events/tests/test_slack.py
@@ -218,6 +218,96 @@ def test_lookup_emails_dedupes_and_skips_blanks(monkeypatch):
     assert len(calls) == 1
 
 
+def test_a_200_html_body_is_a_slackerror_not_a_bare_traceback(monkeypatch):
+    """A proxy/outage page can answer 200 with HTML mid-pull."""
+    class HtmlResponse:
+        headers = {}
+
+        def read(self):
+            return b"<html>maintenance</html>"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(slack.urllib.request, "urlopen", lambda *a, **kw: HtmlResponse())
+    api = slack.Slack(token="xoxp-test", sleep=lambda s: None)
+    with pytest.raises(slack.SlackError) as exc:
+        api.call("auth.test")
+    assert exc.value.error == "not_json"
+    assert "not JSON" in str(exc.value)
+
+
+def test_scopes_retries_a_429_like_call_does(monkeypatch):
+    """scopes() bypasses call() for the headers, but keeps its retry and its
+    one-vocabulary contract."""
+    err = urllib.error.HTTPError("u", 429, "slow down", {"Retry-After": "2"}, None)
+    sleeps = []
+    api, calls = client(monkeypatch, [err, {"ok": True}], sleeps)
+    assert api.scopes() == set()
+    assert len(calls) == 2 and sleeps == [2]
+
+
+def test_scopes_translates_a_transport_failure(monkeypatch):
+    api, _ = client(monkeypatch,
+                    [urllib.error.URLError("dns")] * slack.MAX_ATTEMPTS, [])
+    with pytest.raises(slack.SlackError) as exc:
+        api.scopes()
+    assert exc.value.error == "transport_failed"
+
+
+def test_scopes_reads_the_header_off_the_live_response(monkeypatch):
+    def fake_urlopen(request, *a, **kw):
+        return FakeResponse({"ok": True},
+                            headers={"x-oauth-scopes": "users:read, channels:read"})
+
+    monkeypatch.setattr(slack.urllib.request, "urlopen", fake_urlopen)
+    api = slack.Slack(token="xoxp-test")
+    assert api.scopes() == {"users:read", "channels:read"}
+
+
+# ------------------------------------------------------- token resolution ---
+
+def test_load_token_prefers_the_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv(slack.ENV_TOKEN_VAR, "xoxp-env")
+    assert slack.load_token(path=str(tmp_path / "absent.json")) == "xoxp-env"
+
+
+def test_load_token_falls_back_to_a_dotenv_file(monkeypatch, tmp_path):
+    monkeypatch.delenv(slack.ENV_TOKEN_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        'OTHER=1\n%s="xoxp-dotenv"\n' % slack.ENV_TOKEN_VAR, encoding="utf-8")
+    assert slack.load_token(path=str(tmp_path / "absent.json")) == "xoxp-dotenv"
+
+
+def test_load_token_falls_back_to_the_cli_credentials(monkeypatch, tmp_path):
+    monkeypatch.delenv(slack.ENV_TOKEN_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)                # no .env here
+    cred = tmp_path / "credentials.json"
+    cred.write_text(json.dumps({"team": {"token": "xoxp-cli"}}), encoding="utf-8")
+    assert slack.load_token(path=str(cred)) == "xoxp-cli"
+
+
+def test_load_token_with_nothing_anywhere_names_both_remedies(monkeypatch, tmp_path):
+    monkeypatch.delenv(slack.ENV_TOKEN_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        slack.load_token(path=str(tmp_path / "absent.json"))
+    assert slack.ENV_TOKEN_VAR in str(exc.value)
+    assert "slack auth login" in str(exc.value)
+
+
+def test_dotenv_parse_ignores_other_keys_and_tolerates_quotes(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("# comment\nAAIF_SLACK_WRITE_TOKEN_OLD=x\n"
+                   "AAIF_SLACK_WRITE_TOKEN='xoxp-quoted'\n", encoding="utf-8")
+    assert slack._dotenv_token(env_path=str(env)) == "xoxp-quoted"
+    assert slack._dotenv_token(env_path=str(tmp_path / "nope")) is None
+
+
 @pytest.mark.parametrize("blob,expected", [
     ({"a": {"token": "xoxp-1"}}, "xoxp-1"),
     ({"list": [{"t": "xoxb-2"}]}, "xoxb-2"),

--- a/lib/aaif_events/tests/test_slides_export.py
+++ b/lib/aaif_events/tests/test_slides_export.py
@@ -178,6 +178,32 @@ class TestDownload(unittest.TestCase):
                     se._download("https://example.invalid/x.png", out)
             self.assertFalse(os.path.exists(out))
 
+    def test_an_early_network_failure_leaves_a_preexisting_file_alone(self):
+        """A re-render whose fetch dies before any byte lands must not delete
+        the good PNG a previous call produced."""
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "x.png")
+            with open(out, "wb") as f:
+                f.write(b"g" * 2000)
+            with mock.patch("urllib.request.urlopen",
+                            side_effect=OSError("connection refused")):
+                with self.assertRaises(OSError):
+                    se._download("https://example.invalid/x.png", out)
+            with open(out, "rb") as f:
+                self.assertEqual(f.read(), b"g" * 2000)
+
+    def test_a_too_small_rerender_leaves_the_previous_good_file_alone(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "x.png")
+            with open(out, "wb") as f:
+                f.write(b"g" * 2000)
+            with mock.patch("urllib.request.urlopen", return_value=self._resp(b"tiny")):
+                with self.assertRaises(RuntimeError):
+                    se._download("https://example.invalid/x.png", out)
+            with open(out, "rb") as f:
+                self.assertEqual(f.read(), b"g" * 2000)
+            self.assertEqual(os.listdir(d), ["x.png"])   # no .partial left
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lib/aaif_events/tests/test_slides_export.py
+++ b/lib/aaif_events/tests/test_slides_export.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -96,8 +98,8 @@ class TestRenderSlidePng(unittest.TestCase):
             return self._fake_gws_json(responses)(*args, **kwargs)
 
         with mock.patch.object(se, "_gws_json", side_effect=fake), \
-                mock.patch("urllib.request.urlretrieve"), \
-                mock.patch("os.path.getsize", return_value=10):  # < 1000 -> triggers the raise
+                mock.patch.object(se, "_download",
+                                  side_effect=RuntimeError("rendered thumbnail suspiciously small")):
             with self.assertRaises(RuntimeError) as cm:
                 se.render_slide_png("file1", "/tmp/out.png")
             self.assertIn("suspiciously small", str(cm.exception))
@@ -134,10 +136,47 @@ class TestRenderSlidePng(unittest.TestCase):
             ("drive", "files", "update"): {"id": "pres1"},
         }
         with mock.patch.object(se, "_gws_json", side_effect=self._fake_gws_json(responses)), \
-                mock.patch("urllib.request.urlretrieve"), \
-                mock.patch("os.path.getsize", return_value=5000):
+                mock.patch.object(se, "_download"):
             out = se.render_slide_png("file1", "/tmp/out.png", slide_index=1)
             self.assertEqual(out, "/tmp/out.png")
+
+
+class TestDownload(unittest.TestCase):
+    """_download must never leave a partial PNG behind, whatever failed."""
+
+    def _resp(self, data):
+        r = mock.MagicMock()
+        r.__enter__.return_value = r
+        r.read.return_value = data
+        return r
+
+    def test_success_writes_the_file_with_a_timeout(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "x.png")
+            with mock.patch("urllib.request.urlopen",
+                            return_value=self._resp(b"p" * 2000)) as uo:
+                self.assertIsNone(se._download("https://example.invalid/x.png", out))
+            self.assertEqual(os.path.getsize(out), 2000)
+            self.assertEqual(uo.call_args.kwargs.get("timeout"), 30)
+
+    def test_a_too_small_render_is_deleted_not_left_behind(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "x.png")
+            with mock.patch("urllib.request.urlopen", return_value=self._resp(b"tiny")):
+                with self.assertRaises(RuntimeError) as cm:
+                    se._download("https://example.invalid/x.png", out)
+            self.assertIn("suspiciously small", str(cm.exception))
+            self.assertFalse(os.path.exists(out))
+
+    def test_a_read_failure_deletes_the_partial_file(self):
+        r = self._resp(b"")
+        r.read.side_effect = TimeoutError("timed out")
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "x.png")
+            with mock.patch("urllib.request.urlopen", return_value=r):
+                with self.assertRaises(TimeoutError):
+                    se._download("https://example.invalid/x.png", out)
+            self.assertFalse(os.path.exists(out))
 
 
 if __name__ == "__main__":

--- a/lib/aaif_events/tests/test_tracker.py
+++ b/lib/aaif_events/tests/test_tracker.py
@@ -52,6 +52,15 @@ class TestEventModel(unittest.TestCase):
         ev = tracker.read_event(self.root, "next")
         self.assertIn("Agentic AI Night", ev["title"])
 
+    def test_select_refuses_duplicate_identical_titles(self):
+        # Two events carrying the very same title: an exact match is still
+        # ambiguous, and a write must never silently land on the wrong one.
+        events = [{"title": "Agentic AI Night", "date": dt.date(2026, 6, 24)},
+                  {"title": "Agentic AI Night", "date": dt.date(2026, 9, 15)}]
+        with self.assertRaises(LookupError) as cm:
+            tracker._select(events, "Agentic AI Night")
+        self.assertIn("identical titles", str(cm.exception))
+
 
 class TestWrites(unittest.TestCase):
     def setUp(self):

--- a/lib/aaif_events/tracker.py
+++ b/lib/aaif_events/tracker.py
@@ -112,8 +112,9 @@ def list_events(root):
 def _select(events, event):
     """Resolve an event ref. 'next'/'latest' pick by date; otherwise prefer an
     exact (case-insensitive) title match, then a unique substring match. Raises
-    LookupError if a substring is ambiguous (matches 2+ titles) so a write never
-    silently lands on the wrong event."""
+    LookupError when the match is ambiguous — a substring matching 2+ titles,
+    or 2+ events carrying the identical title — so a write never silently lands
+    on the wrong event."""
     key = (event or "").strip().lower()
     dated = [e for e in events if e["date"]]
     if key == "next":
@@ -125,6 +126,10 @@ def _select(events, event):
     if key == "latest":
         return max(dated, key=lambda e: e["date"]) if dated else None
     exact = [e for e in events if e["title"].strip().lower() == key]
+    if len(exact) > 1:
+        raise LookupError("event %r matches %d events with identical titles; "
+                          "rename one, or select by 'next'/'latest'"
+                          % (event, len(exact)))
     if exact:
         return exact[0]
     partial = [e for e in events if key in e["title"].lower()]

--- a/skills/aaif-announcement-post/SKILL.md
+++ b/skills/aaif-announcement-post/SKILL.md
@@ -11,13 +11,14 @@ The launch post for when RSVPs open. Structure: **one-line hook**, the
 ~120 words, scannable, **at most one emoji, max 3 hashtags**.
 
 **House voice:** share the practice, never sell the product. Specific over grand,
-builder-to-builder. Signal, not numbers. The RSVP line MUST be a Luma link. Edit
-the draft before it ships.
+builder-to-builder. Signal, not numbers. The RSVP line MUST link the event's RSVP
+page — Luma for chapter events; some online events use Gradual.AI. Edit the draft
+before it ships.
 
 **Standard footer (always include).** Below the RSVP/hashtag block, add one quiet
 line with the two standing AAIF attendee links (defaults on every announcement):
-Code of Conduct (events.linuxfoundation.org/about/code-of-conduct) and Privacy
-Policy (linuxfoundation.org/legal/privacy-policy).
+Code of Conduct (https://events.linuxfoundation.org/about/code-of-conduct) and
+Privacy Policy (https://www.linuxfoundation.org/legal/privacy-policy).
 
 ## Input (from the event tracker)
 - Chapter : `[CHAPTER]`
@@ -33,7 +34,7 @@ Agentic AI Night:
 
 > Agents in production: what's working at scale, and what the demos never showed.
 >
-> AAIF San Francisco is back with Agentic AI Night — our Launch Series — on Tue,
+> AAIF San Francisco is back with Agentic AI Night — our Launch Series — on Wed,
 > June 24, 17:30 in SoMa.
 >
 > Maya Chen (payments) opens with tool calling at 10M requests a day: the retries,
@@ -46,5 +47,5 @@ Agentic AI Night:
 > RSVP → lu.ma/aaif-sanfrancisco
 > #AgenticAI #MCP
 >
-> Code of Conduct: events.linuxfoundation.org/about/code-of-conduct · Privacy:
-> linuxfoundation.org/legal/privacy-policy
+> Code of Conduct: https://events.linuxfoundation.org/about/code-of-conduct ·
+> Privacy: https://www.linuxfoundation.org/legal/privacy-policy

--- a/skills/aaif-attendee-reminder/SKILL.md
+++ b/skills/aaif-attendee-reminder/SKILL.md
@@ -12,7 +12,7 @@ by asking them to update their RSVP if plans change** so the seat can be release
 
 **House voice:** warm, concrete, builder-to-builder. Signal, not numbers.
 
-**Standard footer (always include).** After the RSVP line, append one quiet line
+**Standard footer (always include).** After the closing update-your-RSVP sentence, append one quiet line
 with the two standing AAIF attendee links (defaults on every reminder), e.g.
 *"Reminder: our Code of Conduct
 (events.linuxfoundation.org/about/code-of-conduct) and Privacy Policy
@@ -26,7 +26,7 @@ body count.
 ## Example (tested — match this format and voice)
 Agentic AI Night:
 
-> You're set for Agentic AI Night this Tuesday, June 24 — doors 17:30 in SoMa, San
+> You're set for Agentic AI Night this Wednesday, June 24 — doors 17:30 in SoMa, San
 > Francisco (exact address and door code land in your inbox the morning of). Maya
 > Chen opens with tool calling at 10M requests a day, then three quick community
 > demos. If your plans change, please update your RSVP so we can pass your seat to

--- a/skills/aaif-attendee-reminder/SKILL.md
+++ b/skills/aaif-attendee-reminder/SKILL.md
@@ -15,8 +15,8 @@ by asking them to update their RSVP if plans change** so the seat can be release
 **Standard footer (always include).** After the closing update-your-RSVP sentence, append one quiet line
 with the two standing AAIF attendee links (defaults on every reminder), e.g.
 *"Reminder: our Code of Conduct
-(events.linuxfoundation.org/about/code-of-conduct) and Privacy Policy
-(linuxfoundation.org/legal/privacy-policy) apply."* This sits outside the ~70-word
+(https://events.linuxfoundation.org/about/code-of-conduct) and Privacy Policy
+(https://www.linuxfoundation.org/legal/privacy-policy) apply."* This sits outside the ~70-word
 body count.
 
 ## Input (from the event tracker)
@@ -32,5 +32,5 @@ Agentic AI Night:
 > demos. If your plans change, please update your RSVP so we can pass your seat to
 > the waitlist. See you there.
 >
-> Reminder: our Code of Conduct (events.linuxfoundation.org/about/code-of-conduct)
-> and Privacy Policy (linuxfoundation.org/legal/privacy-policy) apply.
+> Reminder: our Code of Conduct (https://events.linuxfoundation.org/about/code-of-conduct)
+> and Privacy Policy (https://www.linuxfoundation.org/legal/privacy-policy) apply.

--- a/skills/aaif-audit-slack/SKILL.md
+++ b/skills/aaif-audit-slack/SKILL.md
@@ -42,21 +42,26 @@ HTML, not Office files, and render to PDF through **headless Chrome**;
 `lib/aaif_events/report_style.to_pdf` does that correctly, so call it rather than
 shelling out to a converter yourself.
 
-Prereqs: the Slack CLI authenticated (`slack auth login`); for the organizer
-engine, `gws` installed and authenticated (see the user's `gws-cli-access`
-memory). The Slack token is read from `~/.slack/credentials.json` and never
-printed.
+Prereqs: for the organizer engine, `gws` installed and authenticated (see the
+user's `gws-cli-access` memory); for Slack, the **AAIF app token**. The client
+looks for `AAIF_SLACK_WRITE_TOKEN` in the environment first, then in a `.env`
+in the working directory, and only then falls back to
+`~/.slack/credentials.json` — where the Slack CLI credential now sits expired.
+In practice the app token is the standing token for all three engines; the
+credentials file is the last resort, not the source. Wherever it came from,
+the token is never printed.
 
 ---
 
 # The ceiling — state this in any summary you write
 
-**Which ceiling applies depends on the token.** The Slack CLI token carries no
-`channels:history` and no `search:read`, and `conversations.history` returns
-`missing_scope` even for public channels — on that token, *last message posted*
-and *is this channel alive* are **unreadable**, and the organizer/member reports
-print exactly that. The **AAIF app token** (`AAIF_SLACK_WRITE_TOKEN` in the
-user's `.env`, added 2026-08-16) DOES carry `channels:history`/`groups:history`
+**Which ceiling applies depends on the token.** The Slack CLI token — the
+expired credentials-file fallback — carries no `channels:history` and no
+`search:read`, and `conversations.history` returns `missing_scope` even for
+public channels: on a token like that, *last message posted* and *is this
+channel alive* are **unreadable**, and the organizer/member reports print
+exactly that. The **AAIF app token** — the standing token, see the prereqs —
+DOES carry `channels:history`/`groups:history`
 — `conversations.history` is in the client's allowlist for it, and
 `audit_activity.py` is the engine built on it. Even then the numbers are
 **floors**: thread replies are invisible to `conversations.history`, and the
@@ -115,6 +120,10 @@ names the channel each chapter *will* have before `provision_channels.py` has
 created it, and without the flag every such name aborts the run as a
 rename/archive bug. With it, they are downgraded to "planned" in the
 data-quality notes and the chapter truthfully reports as having no channel.
+The flag also covers the sibling pre-convert state: a `Slack Channel` cell
+naming a room that exists but is still **private** (a squat awaiting an
+admin-UI convert) is downgraded to "held private" instead of aborting, and the
+chapter reports as having no public channel yet.
 Drop the flag once provisioning has run, so the abort protects the map again.
 
 | Source | Read | Used for |
@@ -203,7 +212,9 @@ The engine enforces this rather than trusting it:
   left alone it downgrades the chapter to "no channel at all" and generates
   advice to create a room it already has.
 - **A `public` alias pointing at a private channel aborts.** The automatic path
-  refuses private channels, and an alias must not be a way around that.
+  refuses private channels, and an alias must not be a way around that. Under
+  `--planned-ok` it is downgraded to "held private" and the chapter truthfully
+  reports as having no public channel yet — never as covered.
 - **The report says how each chapter matched.** Aliased chapters and deliberate
   `null`s are listed in *Data quality*, so coverage that rests on the map is
   visible rather than indistinguishable from a name match.

--- a/skills/aaif-audit-slack/scripts/audit_activity.py
+++ b/skills/aaif-audit-slack/scripts/audit_activity.py
@@ -54,15 +54,17 @@ def cached_channels(api, cache_dir, refresh, team_id):
     return data
 
 
-def chapter_channel_names(cache_dir):
+def chapter_channel_names(cache_dir, team_id):
     """{channel name: city} for channels the organizer audit tied to a chapter.
 
     Read from the organizer audit's own output, so the two reports can never
     disagree about which channel is whose. Empty when that audit hasn't run —
     the chapter section is then omitted rather than re-derived badly here.
+    Stamped like every other read: an audit.json from a different workspace
+    would otherwise join its chapter map into this one's activity table.
     """
     path = os.path.join(cache_dir, "audit.json")
-    data = jsoncache.read(path)
+    data = jsoncache.read(path, team_id=team_id)
     if data is None:
         return {}
     out = {}
@@ -81,8 +83,7 @@ def collect(api, live, cache_dir, days, refresh, team_id, now_ts):
     enough that an interrupted 15-minute sweep resumes instead of restarting.
     """
     path = os.path.join(cache_dir, "activity.json")
-    stats = (jsoncache.read(path, refresh, team_id, note=print)
-             if not refresh else None) or {}
+    stats = jsoncache.read(path, refresh, team_id, note=print) or {}
     today = dt.datetime.fromtimestamp(now_ts, dt.timezone.utc).date().isoformat()
     # Same day AND same window: a 90-day count rendered under a --days 30
     # headline is a wrong number that looks fully measured.
@@ -109,7 +110,10 @@ def collect(api, live, cache_dir, days, refresh, team_id, now_ts):
 
 def build_report(live, stats, chapter_of, days, today):
     def age_days(ts):
-        return int((today.timestamp() - ts) // 86400)
+        # `today` is stamped before the sweep, so a message posted while the
+        # sweep runs is newer than it; a negative age would fall outside every
+        # AGE_BUCKET and trip the histogram check. It is simply "this week".
+        return max(0, int((today.timestamp() - ts) // 86400))
 
     rows = []
     for c in live:
@@ -253,12 +257,10 @@ def main():
     stats = collect(api, live, args.cache, args.days, args.refresh,
                     team_id, now.timestamp())
 
-    html_doc = build_report(live, stats, chapter_channel_names(args.cache),
+    html_doc = build_report(live, stats, chapter_channel_names(args.cache, team_id),
                             args.days, now)
     html_path = args.out + ".html"
-    with open(html_path, "w", encoding="utf-8") as fh:
-        fh.write(html_doc)
-    os.chmod(html_path, 0o600)
+    rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
     if not args.no_pdf:
         print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),

--- a/skills/aaif-audit-slack/scripts/audit_activity.py
+++ b/skills/aaif-audit-slack/scripts/audit_activity.py
@@ -64,7 +64,10 @@ def chapter_channel_names(cache_dir, team_id):
     would otherwise join its chapter map into this one's activity table.
     """
     path = os.path.join(cache_dir, "audit.json")
-    data = jsoncache.read(path, team_id=team_id)
+    # note=print: a pre-stamp or foreign-workspace audit.json is discarded, and
+    # without the note the chapter section just vanishes from the report with
+    # no hint that re-running audit_organizers.py would bring it back.
+    data = jsoncache.read(path, team_id=team_id, note=print)
     if data is None:
         return {}
     out = {}

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -373,7 +373,7 @@ def main():
     # pass a pull that had lost half the workspace.
     general = next((c for c in chans if c.get("is_general")), None)
     active_humans = sum(1 for u in directory
-                        if not u["is_bot"] and not u["is_app_user"]
+                        if not u["is_bot"] and not u.get("is_app_user")
                         and not u["deleted"] and u["id"] != "USLACKBOT")
     if general is None or general["num_members"] is None:
         print("  note: no default channel size available — the directory "
@@ -408,11 +408,7 @@ def main():
     html_doc = build_report(chans, directory, dt.datetime.now(dt.timezone.utc),
                             activity)
     html_path = args.out + ".html"
-    # Explicit UTF-8: channel and person names carry accents and the page uses
-    # em dashes; the locale default would mangle or refuse them.
-    with open(html_path, "w", encoding="utf-8") as fh:
-        fh.write(html_doc)
-    os.chmod(html_path, 0o600)   # names + emails: same handling as the cache
+    rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
     if not args.no_pdf:
         print("wrote %s" % rs.to_pdf(os.path.abspath(html_path), os.path.abspath(args.out + ".pdf")))

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -74,11 +74,17 @@ def build_report(chans, directory, today, activity=None):
     pub = [c for c in live if not c["is_private"]]
     priv = [c for c in live if c["is_private"]]
 
+    # Bracket access on is_app_user, deliberately, here and at the directory
+    # floor in main(): slack.users() defaults every USER_FLAGS boolean, so a
+    # record without the key is schema drift or a foreign cache — and a soft
+    # .get() would silently promote every app user to "human", inflating the
+    # very counts (and the 0.9 short-pull floor) this report exists to state.
+    # Drift must abort as a KeyError, not skew the numbers.
     humans = [u for u in directory
-              if not u["is_bot"] and not u.get("is_app_user") and u["id"] != "USLACKBOT"]
+              if not u["is_bot"] and not u["is_app_user"] and u["id"] != "USLACKBOT"]
     active = [u for u in humans if not u["deleted"]]
     deact = [u for u in humans if u["deleted"]]
-    bots = [u for u in directory if u["is_bot"] or u.get("is_app_user")]
+    bots = [u for u in directory if u["is_bot"] or u["is_app_user"]]
 
     # Slack omits num_members on some conversations. "Not reported" is not
     # "empty": bucketing an unknown as 0 publishes it as an abandoned channel and
@@ -372,8 +378,12 @@ def main():
     # members, so measuring it against all humans (deactivated included) would
     # pass a pull that had lost half the workspace.
     general = next((c for c in chans if c.get("is_general")), None)
+    # is_app_user by bracket access, like build_report's partition: the key is
+    # guaranteed by slack.users(), so its absence is schema drift and must
+    # KeyError here — a .get() quietly counted app users as active humans,
+    # inflating exactly the number the 0.9 tripwire below compares.
     active_humans = sum(1 for u in directory
-                        if not u["is_bot"] and not u.get("is_app_user")
+                        if not u["is_bot"] and not u["is_app_user"]
                         and not u["deleted"] and u["id"] != "USLACKBOT")
     if general is None or general["num_members"] is None:
         print("  note: no default channel size available — the directory "

--- a/skills/aaif-audit-slack/scripts/audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/audit_organizers.py
@@ -513,6 +513,69 @@ def mark_planned_aliases(rows):
     return planned, held
 
 
+def check_membership_floor(membership, chans, chans_cached, refetch, note=print):
+    """The free floor on a paged membership pull: no channel's pulled ids may
+    number fewer than conversations.list said it has members. A short pull
+    would render real members as "accepted but absent" pills, so it aborts.
+
+    `membership` is {name: [ids]}; `chans` is the channel list those names came
+    from; `refetch` re-pulls the list (and re-stamps its cache) and is called
+    at most once, only when `chans_cached` — a CACHED size may simply predate
+    someone leaving, and aborting on that with "re-run" advice loops forever
+    because a plain re-run reuses the same cache.
+
+    Two silences this function exists to keep loud:
+
+    * only the channels short against the CACHED size are re-checked against
+      the fresh list. A channel that passed the cached floor and gained a
+      member between the membership pull and the re-fetch is the normal join
+      race, not a dropped page — re-checking everything turned that race into
+      a spurious abort about a pull that was complete.
+    * a re-checked channel MISSING from the fresh list was renamed (or
+      archived/deleted) mid-run. Its floor is unverifiable and everything
+      matched against the old name is stale, so it aborts naming the rename —
+      the alternative, re-pulling that one membership, would quietly verify a
+      roster the rest of the report still files under a name that no longer
+      exists.
+
+    Returns the channel list the final check ran against.
+    """
+    def undersized(chans, only=None):
+        sizes = {c["name"]: c["num_members"] for c in chans}
+        return [(n, len(ids), sizes[n])
+                for n, ids in sorted(membership.items())
+                if (only is None or n in only)
+                and sizes.get(n) is not None and len(ids) < sizes[n]]
+
+    short = undersized(chans)
+    if short and chans_cached:
+        note("  %d channel(s) smaller than their cached size — re-fetching the "
+             "channel list to tell a stale cache from a short pull ..."
+             % len(short))
+        chans = refetch()
+        names = {c["name"] for c in chans}
+        short_names = {n for n, _got, _want in short}
+        gone = sorted(short_names - names)
+        if gone:
+            raise SystemExit(
+                "ABORT: %d channel(s) whose membership pull came back short "
+                "no longer appear in a fresh channel list under that name: %s."
+                "\nThey were renamed, archived or deleted mid-run, so their "
+                "membership floor cannot be verified — and every chapter match "
+                "in this run still uses the old name. Re-run with --refresh."
+                % (len(gone), ", ".join("#" + n for n in gone)))
+        short = undersized(chans, only=short_names)
+    if short:
+        raise SystemExit(
+            "ABORT: membership came back short for %d channel(s) against a "
+            "fresh channel list: %s.\nPeople would be reported as absent from "
+            "rooms they are in. Re-run with --refresh; if it persists, the "
+            "members() pagination is dropping pages."
+            % (len(short),
+               ", ".join("#%s (%d of %d)" % s for s in short)))
+    return chans
+
+
 def build_audit(rows, people, slack_ids, membership, directory, staff_domain):
     """Join the sheet data to the Slack data, per chapter.
 
@@ -578,6 +641,23 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain):
 # --------------------------------------------------------------------------
 # Report
 # --------------------------------------------------------------------------
+
+def rooms_to_create(audit):
+    """The chapters the report may honestly tell an admin to build a room for.
+
+    Uncovered plus two accepted organizers is not enough on its own: a
+    public_how of "planned:<name>" or "held-private:<name>" means the room is
+    already provisioned-or-pending (often behind a squatting name, where a
+    create is guaranteed to fail), and "known-none" is a human's standing
+    answer that there is no channel on purpose. All three are surfaced in the
+    Data-quality notes; repeating them here as create advice would send an
+    admin to fight Slack over a name that is already spoken for.
+    """
+    return [c for c in audit
+            if not c["public"] and len(c["accepted"]) >= 2
+            and c["public_how"] != "known-none"
+            and not c["public_how"].startswith(("planned:", "held-private:"))]
+
 
 def render(audit, orphans, dupes, today):
     allp = [p for c in audit for p in c["accepted"]]
@@ -706,7 +786,7 @@ def render(audit, orphans, dupes, today):
                       % (e(c["city"]), chips or '<span class="nil">no channels</span>',
                          "".join(items)))
 
-    create = [c for c in audit if not c["public"] and len(c["accepted"]) >= 2]
+    create = rooms_to_create(audit)
     unreachable = [c for c in audit if c["accepted"]
                    and not any(p["slack_account"] for p in c["accepted"])]
     empty_room = [c for c in audit if c["public"] and c["accepted"]
@@ -1034,36 +1114,17 @@ def main():
                 targets[name] = cid
     print("  pulling membership for %d channels ..." % len(targets))
     membership = {name: members(api, cid) for name, cid in sorted(targets.items())}
-    # conversations.list already told us how big each channel is; comparing that
-    # against what conversations.members returned is a free floor on a short
-    # paged pull, which would otherwise render as "accepted but absent" pills.
-    # But the size may be a CACHED size: one person leaving a channel since it
-    # was written makes a complete pull look short, and aborting on that with
-    # "re-run" advice loops forever — a plain re-run reuses the same cache. So
-    # when the sizes came from cache, re-fetch the channel list (and re-stamp
-    # the cache) before accusing the pull; against fresh sizes, short really
-    # does mean a dropped page. `rows` keeps the earlier snapshot — the
+    # conversations.list already told us how big each channel is; comparing
+    # that against what conversations.members returned is a free floor on a
+    # short paged pull, which would otherwise render as "accepted but absent"
+    # pills. The stale-cache / join-race / renamed-channel reasoning lives on
+    # check_membership_floor. `rows` keeps the earlier snapshot — the
     # membership ids above were pulled for exactly those channels.
-    def undersized(chans):
-        sizes = {c["name"]: c["num_members"] for c in chans}
-        return ["#%s (%d of %d)" % (n, len(ids), sizes[n])
-                for n, ids in sorted(membership.items())
-                if sizes.get(n) is not None and len(ids) < sizes[n]]
-    short = undersized(chans)
-    if short and chans_cached:
-        print("  %d channel(s) smaller than their cached size — re-fetching the "
-              "channel list to tell a stale cache from a short pull ..."
-              % len(short))
-        chans = channels(api)
-        write_cache(chan_path, chans, team_id)
-        short = undersized(chans)
-    if short:
-        raise SystemExit(
-            "ABORT: membership came back short for %d channel(s) against a "
-            "fresh channel list: %s.\nPeople would be reported as absent from "
-            "rooms they are in. Re-run with --refresh; if it persists, the "
-            "members() pagination is dropping pages."
-            % (len(short), ", ".join(short)))
+    def refetch():
+        fresh = channels(api)
+        write_cache(chan_path, fresh, team_id)
+        return fresh
+    chans = check_membership_floor(membership, chans, chans_cached, refetch)
 
     # Only the organizer-channel members need naming, so resolve those ids
     # individually rather than pulling a 30k-row directory.

--- a/skills/aaif-audit-slack/scripts/audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/audit_organizers.py
@@ -337,7 +337,9 @@ def _resolve_alias(city, table, by_name):
     `how` is one of: "" (the map was silent), "known-none", "alias", or
     "alias-missing:<name>". Callers must run assert_aliases_resolve() to rule
     out the last, which is always a configuration bug — or, pre-provisioning,
-    mark_planned_aliases() to downgrade it to "planned:<name>".
+    mark_planned_aliases() to downgrade it to "planned:<name>". match_channels()
+    adds "alias-private:<name>" for a public alias held by a private room,
+    policed by the same pair of callers.
     """
     if city not in table:
         return None, ""
@@ -374,10 +376,10 @@ def match_channels(chapters, chans, cfg):
         if pub and pub["is_private"]:
             # The auto path refuses private channels; an alias must not be a way
             # around that, or a private room is reported as the city's home.
-            raise SystemExit(
-                "ABORT: the Chapters List gives %r the Slack Channel #%s, which is "
-                "PRIVATE. A city's own channel must be public — move it to that "
-                "row's Organizer Channel instead." % (city, pub["name"]))
+            # Recorded rather than raised so --planned-ok can downgrade the
+            # pre-convert state (the sheet-named room exists but is still held
+            # private); the default run aborts in assert_aliases_resolve().
+            pub, how = None, "alias-private:%s" % pub["name"]
         candidates = []
         if not pub and not how:
             # Prefixes are tried in the order the config lists them, so an exact
@@ -466,6 +468,16 @@ def assert_aliases_resolve(rows, source=CHAPTERS_TAB):
             "reported as having no channel at all."
             % (len(broken), source,
                "\n  ".join("%s -> #%s" % (c, n) for c, n in broken), NO_RESOURCE))
+    held = [(r["city"], r["public_how"].split(":", 1)[1])
+            for r in rows if r["public_how"].startswith("alias-private:")]
+    if held:
+        raise SystemExit(
+            "ABORT: %d Slack Channel cell(s) on %s point at a PRIVATE channel:\n"
+            "  %s\nA city's own channel must be public. Convert the room to "
+            "public, or run with --planned-ok to report these chapters truthfully "
+            "as having no public channel yet."
+            % (len(held), source,
+               "\n  ".join("%s -> #%s" % (c, n) for c, n in held)))
 
 
 def mark_planned_aliases(rows):
@@ -481,15 +493,24 @@ def mark_planned_aliases(rows):
     The chapter is still reported as having no channel — that is the truthful
     current state — but the report's data-quality notes list these as planned
     rather than letting them blend into "nobody ever made a room".
+
+    A `public` alias held by a PRIVATE room is the sibling pre-convert state
+    (the name exists, the admin-UI convert has not happened) and is downgraded
+    to "held-private:<name>" the same way, kept distinct so the report does not
+    claim the channel is yet to be created.
     """
-    planned = []
+    planned, held = [], []
     for r in rows:
         for k in ("public_how", "organizers_how", "regional_how"):
             if r[k].startswith("alias-missing:"):
                 name = r[k].split(":", 1)[1]
                 r[k] = "planned:" + name
                 planned.append((r["city"], name))
-    return planned
+        if r["public_how"].startswith("alias-private:"):
+            name = r["public_how"].split(":", 1)[1]
+            r["public_how"] = "held-private:" + name
+            held.append((r["city"], name))
+    return planned, held
 
 
 def build_audit(rows, people, slack_ids, membership, directory, staff_domain):
@@ -785,6 +806,13 @@ def render(audit, orphans, dupes, today):
                      "provision_channels.py has created them.</li>"
                      % (len(planned), len(planned_cities),
                         ", ".join(e(c) for c in planned_cities)))
+    held = sorted((c["city"], c["public_how"].split(":", 1)[1])
+                  for c in audit if c["public_how"].startswith("held-private:"))
+    if held:
+        notes.append("<li><strong>%d chapters' named channels exist but are still private</strong> "
+                     "— awaiting an admin-UI convert to public, so they are reported above as "
+                     "having no public channel, which is the current truth: %s.</li>"
+                     % (len(held), ", ".join("%s (#%s)" % (e(c), e(n)) for c, n in held)))
     cand = [c for c in audit if not c["public"] and c["public_candidates"]]
     if cand:
         notes.append("<li><strong>%d chapters have near-miss channels</strong> that were NOT "
@@ -948,6 +976,7 @@ def main():
 
     chan_path = os.path.join(args.cache, "channels.json")
     chans = read_cache(chan_path, args.refresh, team_id, note=print)
+    chans_cached = chans is not None      # the short-check below needs to know
     if chans is None:
         print("  fetching channels ...")
         chans = channels(api)
@@ -958,10 +987,13 @@ def main():
 
     rows = match_channels(chapters, chans, cfg)
     if args.planned_ok:
-        planned = mark_planned_aliases(rows)
+        planned, held = mark_planned_aliases(rows)
         if planned:
             print("  %d sheet-named channel(s) do not exist yet — treated as "
                   "planned, not as renames" % len(planned))
+        if held:
+            print("  %d sheet-named channel(s) exist but are still PRIVATE — "
+                  "reported as no public channel yet" % len(held))
     else:
         assert_aliases_resolve(rows)
     print("  matched: %d own channel, %d organizers channel"
@@ -1005,14 +1037,32 @@ def main():
     # conversations.list already told us how big each channel is; comparing that
     # against what conversations.members returned is a free floor on a short
     # paged pull, which would otherwise render as "accepted but absent" pills.
-    sizes = {c["name"]: c["num_members"] for c in chans}
-    short = ["#%s (%d of %d)" % (n, len(ids), sizes[n])
-             for n, ids in sorted(membership.items())
-             if sizes.get(n) is not None and len(ids) < sizes[n]]
+    # But the size may be a CACHED size: one person leaving a channel since it
+    # was written makes a complete pull look short, and aborting on that with
+    # "re-run" advice loops forever — a plain re-run reuses the same cache. So
+    # when the sizes came from cache, re-fetch the channel list (and re-stamp
+    # the cache) before accusing the pull; against fresh sizes, short really
+    # does mean a dropped page. `rows` keeps the earlier snapshot — the
+    # membership ids above were pulled for exactly those channels.
+    def undersized(chans):
+        sizes = {c["name"]: c["num_members"] for c in chans}
+        return ["#%s (%d of %d)" % (n, len(ids), sizes[n])
+                for n, ids in sorted(membership.items())
+                if sizes.get(n) is not None and len(ids) < sizes[n]]
+    short = undersized(chans)
+    if short and chans_cached:
+        print("  %d channel(s) smaller than their cached size — re-fetching the "
+              "channel list to tell a stale cache from a short pull ..."
+              % len(short))
+        chans = channels(api)
+        write_cache(chan_path, chans, team_id)
+        short = undersized(chans)
     if short:
         raise SystemExit(
-            "ABORT: membership came back short for %d channel(s): %s.\n"
-            "People would be reported as absent from rooms they are in. Re-run."
+            "ABORT: membership came back short for %d channel(s) against a "
+            "fresh channel list: %s.\nPeople would be reported as absent from "
+            "rooms they are in. Re-run with --refresh; if it persists, the "
+            "members() pagination is dropping pages."
             % (len(short), ", ".join(short)))
 
     # Only the organizer-channel members need naming, so resolve those ids
@@ -1057,11 +1107,7 @@ def main():
 
     html_doc = render(audit, orphans, dupes, dt.datetime.now(dt.timezone.utc))
     html_path = args.out + ".html"
-    # Explicit UTF-8: the page carries españa, Montréal and em dashes, and the
-    # locale default would mangle or refuse them.
-    with open(html_path, "w", encoding="utf-8") as fh:
-        fh.write(html_doc)
-    os.chmod(html_path, 0o600)   # names + emails + rosters: as sensitive as the cache
+    rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
     if not args.no_pdf:
         print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),

--- a/skills/aaif-audit-slack/scripts/test_audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/test_audit_organizers.py
@@ -408,7 +408,7 @@ def test_folding_matches_accent_and_punctuation_variants():
 
 #: A floor, not a target. Without it, renaming the `test_` prefix or losing the
 #: functions in a bad merge prints "all checks passed" having run nothing.
-MIN_TESTS = 36
+MIN_TESTS = 42
 
 
 def test_regional_alias_that_no_longer_resolves_aborts():
@@ -480,6 +480,75 @@ def test_unidentified_members_are_excluded_from_the_accusing_counts():
           "1 distinct people hold 1 of these seats" in html, True)
     check("the unidentified are surfaced in Data quality",
           "could not be identified" in html, True)
+
+
+# ------------------------------------------------- membership short-pull floor ---
+
+def _floor(membership, cached_chans, chans_cached, fresh_chans=None):
+    """Run check_membership_floor over fixture channel lists; returns the
+    number of refetches made (or the SystemExit, via check_raises at callers)."""
+    calls = []
+
+    def refetch():
+        calls.append(1)
+        return fresh_chans if fresh_chans is not None else cached_chans
+
+    ao.check_membership_floor(membership, cached_chans, chans_cached, refetch,
+                              note=lambda *_: None)
+    return len(calls)
+
+
+def test_short_against_cached_size_passes_when_fresh_matches():
+    """The person-left-since-the-cache case: one refetch, then a clean pass."""
+    n = _floor({"a": ["U1"]}, [chan("a", members=2)], True,
+               fresh_chans=[chan("a", members=1)])
+    check("stale cache resolves with exactly one refetch", n, 1)
+
+
+def test_short_against_a_fresh_list_aborts_without_refetching():
+    check_raises("fresh+short aborts",
+                 lambda: _floor({"a": ["U1"]}, [chan("a", members=2)], False),
+                 "membership came back short")
+
+
+def test_still_short_after_the_refetch_aborts():
+    check_raises("still-short-after-refetch aborts",
+                 lambda: _floor({"a": ["U1"]}, [chan("a", members=2)], True,
+                                fresh_chans=[chan("a", members=2)]),
+                 "#a (1 of 2)")
+
+
+def test_a_channel_renamed_between_snapshots_is_not_silently_passed():
+    """The old code's sizes.get(n)-is-None skip let a renamed channel escape
+    the floor entirely; it must abort naming the vanished channel instead."""
+    check_raises("renamed channel aborts, not passes",
+                 lambda: _floor({"a": ["U1"]}, [chan("a", members=2)], True,
+                                fresh_chans=[chan("a-renamed", members=2)]),
+                 "#a")
+
+
+def test_a_join_after_the_pull_is_not_a_short_pull():
+    """Channel `b` triggers the refetch; `a` passed the cached floor and only
+    looks short against the FRESH size because someone joined in between —
+    re-checking it would turn the join race into a spurious abort."""
+    n = _floor({"a": ["U1"], "b": ["U1"]},
+               [chan("a", members=1), chan("b", members=2)], True,
+               fresh_chans=[chan("a", members=2), chan("b", members=1)])
+    check("a join race on an already-verified channel passes", n, 1)
+
+
+def test_settled_and_inflight_states_get_no_create_advice():
+    """`held-private:` / `planned:` / `known-none` chapters already have their
+    answer surfaced in Data quality; a create recommendation against the
+    squatting (or deliberately absent) room is guaranteed-bad advice."""
+    def c(city, how, n=2):
+        return dict(_row(city), public_how=how,
+                    accepted=[{"slack_account": True}] * n, unaccounted=[])
+    audit = [c("Boston", ""), c("Bern", "planned:bern"),
+             c("Graz", "held-private:graz"), c("Wellington", "known-none"),
+             c("Pune", "", n=1)]
+    check("only the genuinely uncovered 2+ chapter gets create advice",
+          [x["city"] for x in ao.rooms_to_create(audit)], ["Boston"])
 
 
 def main():

--- a/skills/aaif-audit-slack/scripts/test_audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/test_audit_organizers.py
@@ -22,6 +22,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import audit_organizers as ao  # noqa: E402
 
+# ao's own import shims lib/ onto sys.path, so this resolves after it.
+from aaif_events.slack import SlackError  # noqa: E402
+
 FAILS = []
 
 
@@ -38,7 +41,7 @@ def check_raises(label, fn, needle=""):
             FAILS.append("%s: aborted, but message lacked %r:\n     %s"
                          % (label, needle, exc))
         return
-    except ao.SlackError as exc:  # pragma: no cover - defensive
+    except SlackError as exc:  # pragma: no cover - defensive
         if needle and needle not in str(exc):
             FAILS.append("%s: raised, but message lacked %r" % (label, needle))
         return
@@ -441,11 +444,26 @@ def test_organizer_suffix_precedence_is_config_order():
 
 def test_a_public_alias_pointing_at_a_private_channel_aborts():
     """The auto path refuses private channels; an alias must not bypass it."""
-    check_raises(
-        "private public-alias aborts",
-        lambda: ao.match_channels([{"city": "Boston"}], [chan("secret", private=True)],
-                                  cfg(public={"Boston": "secret"})),
-        "PRIVATE")
+    rows = ao.match_channels([{"city": "Boston"}], [chan("secret", private=True)],
+                             cfg(public={"Boston": "secret"}))
+    check("private public-alias is recorded, not matched",
+          (rows[0]["public"], rows[0]["public_how"]),
+          (None, "alias-private:secret"))
+    check_raises("private public-alias aborts by default",
+                 lambda: ao.assert_aliases_resolve(rows, "map.json"), "PRIVATE")
+
+
+def test_a_private_public_alias_downgrades_under_planned_ok():
+    """--planned-ok reports the pre-convert state truthfully instead of dying."""
+    rows = ao.match_channels([{"city": "Boston"}], [chan("secret", private=True)],
+                             cfg(public={"Boston": "secret"}))
+    planned, held = ao.mark_planned_aliases(rows)
+    check("held-private downgrade is distinct from planned",
+          (planned, held), ([], [("Boston", "secret")]))
+    check("downgraded row still reports no public channel",
+          (rows[0]["public"], rows[0]["public_how"]),
+          (None, "held-private:secret"))
+    ao.assert_aliases_resolve(rows, "map.json")  # must no longer raise
 
 
 def test_unidentified_members_are_excluded_from_the_accusing_counts():

--- a/skills/aaif-backup/SKILL.md
+++ b/skills/aaif-backup/SKILL.md
@@ -53,8 +53,11 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/backup.py --dest /some/dir
 ```
 
 - `<dest>` defaults to **`./backups`** (relative to where you run it — inside the
-  `events/` repo when run from there). `backups/` is **git-ignored**, so the binary
-  snapshots never enter the repo.
+  `meetups` repo when run from there). `backups/` is **git-ignored**, so the binary
+  snapshots never enter the repo — and the script verifies that at run time: it
+  **refuses to start** if the destination is committable (not git-ignored, or
+  already holding tracked files) inside any repo. A `--dest` outside every repo
+  is always fine.
 - Filenames are UTC timestamps, so a folder listing is the version history in order.
 - The target's type decides the format: a Google Sheet is exported to `.xlsx`, a Doc to
   `.docx`, Slides to `.pptx`; already-binary Drive files and local files are copied as-is.

--- a/skills/aaif-backup/scripts/backup.py
+++ b/skills/aaif-backup/scripts/backup.py
@@ -82,8 +82,12 @@ def _repo_root(path):
     while not os.path.isdir(probe_dir) and probe_dir != os.sep:
         probe_dir = os.path.dirname(probe_dir) or os.sep
     try:
+        # LC_ALL=C: the "not a git repository" match below reads git's stderr,
+        # and localized git says e.g. "kein Git-Repository" — which would abort
+        # legitimate outside-repo runs instead of returning None.
         proc = subprocess.run(["git", "-C", probe_dir, "rev-parse", "--show-toplevel"],
-                              capture_output=True, text=True)
+                              capture_output=True, text=True,
+                              env={**os.environ, "LC_ALL": "C", "LANG": "C"})
     except FileNotFoundError:
         sys.exit("REFUSING TO RUN: git is not installed, so this cannot verify "
                  f"that {path} is ignored. Snapshots hold every applicant's name "

--- a/skills/aaif-backup/scripts/backup.py
+++ b/skills/aaif-backup/scripts/backup.py
@@ -72,6 +72,75 @@ def gws_download(args, out_path):
 DRIVE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{20,}$")
 
 
+def _repo_root(path):
+    """Git repo root containing `path`, or None when it lives outside any repo.
+
+    Resolved from the destination itself, not the process cwd — where the script
+    is run from must not decide whether the *snapshots* are protected. Walks up
+    to the nearest existing dir first, since the destination may not exist yet."""
+    probe_dir = os.path.abspath(path)
+    while not os.path.isdir(probe_dir) and probe_dir != os.sep:
+        probe_dir = os.path.dirname(probe_dir) or os.sep
+    try:
+        proc = subprocess.run(["git", "-C", probe_dir, "rev-parse", "--show-toplevel"],
+                              capture_output=True, text=True)
+    except FileNotFoundError:
+        sys.exit("REFUSING TO RUN: git is not installed, so this cannot verify "
+                 f"that {path} is ignored. Snapshots hold every applicant's name "
+                 "and email; install git or pass --dest outside any repository.")
+    if proc.returncode == 0:
+        return proc.stdout.strip()
+    # Mirrors report_style._repo_root (the reference implementation): only
+    # git's own "not a git repository" answer means outside-a-repo. Any other
+    # failure (dubious ownership, corrupt .git, ...) aborts — mapping it to
+    # None would silently disengage the PII guard.
+    stderr = (proc.stderr or "").strip()
+    if "not a git repository" in stderr.lower():
+        return None
+    sys.exit(f"REFUSING TO RUN: `git rev-parse` failed in {probe_dir} (exit "
+             f"{proc.returncode}: {stderr[:200]}), so this cannot verify that "
+             f"{path} is ignored. Fix the git error, or pass --dest outside "
+             "any repository.")
+
+
+def assert_dest_git_safe(dest_root):
+    """Refuse to write snapshots git would happily commit.
+
+    The default target is the full Intake Ops export — every applicant's name,
+    email and free-text answers — and the repo this usually runs in is PUBLIC,
+    so `.gitignore` coverage is a safety control, not tidiness. Verified at run
+    time (git check-ignore) rather than trusted to a `.gitignore` rule that a
+    rename or an unanchored pattern can silently stop matching. Mirrors the
+    audit skills' assert_git_ignored; inlined because this script is
+    deliberately self-contained (see AGENTS.md on the lib coupling).
+
+    A destination outside every repository is fine — there is nothing to commit
+    it to. `check-ignore` exits 128 (not 1) there, which is why the repo root is
+    resolved first instead of treating that exit as "unignored"."""
+    root = _repo_root(dest_root)
+    if root is None:
+        return                       # outside any repo — nothing to leak into
+    # Probe through a child: `check-ignore` answers differently for a bare
+    # directory name, and this works before the directory exists.
+    probe = os.path.join(dest_root, "probe")
+    ignored = subprocess.run(["git", "-C", root, "check-ignore", "-q", probe],
+                             capture_output=True).returncode == 0
+    # .gitignore has no effect on already-tracked files, so a snapshot committed
+    # before the rules landed would still ride along on `git add -A` while
+    # check-ignore reports the folder as ignored.
+    tracked = subprocess.run(["git", "-C", root, "ls-files", "--error-unmatch",
+                              dest_root], capture_output=True).returncode == 0
+    if tracked:
+        sys.exit(f"REFUSING TO RUN: {dest_root} already holds files TRACKED by "
+                 f"the repo at {root} — git rm --cached them first. Snapshots "
+                 "hold every applicant's name and email.")
+    if not ignored:
+        sys.exit(f"REFUSING TO RUN: {dest_root} is committable — not ignored in "
+                 f"{root}. Snapshots hold every applicant's name and email. Add "
+                 "the path to .gitignore, or pass --dest to a location outside "
+                 "any git repository.")
+
+
 def slugify(name):
     s = re.sub(r"[^\w.-]+", "-", name.strip()).strip("-.")
     return (s or "backup").lower()
@@ -143,6 +212,7 @@ def main():
                     help="Root folder for snapshots (default: ./backups)")
     a = ap.parse_args()
     dest_root = os.path.abspath(a.dest)
+    assert_dest_git_safe(dest_root)   # before ANY fetch: fail in a second, not after a pull
     # Dispatch explicitly so a mistyped local path can't silently fall through to
     # Drive (and die with a cryptic 404): existing path -> local; a clean Drive-id
     # shape -> Drive; anything else is a mistake, so say so.

--- a/skills/aaif-backup/scripts/test_backup.py
+++ b/skills/aaif-backup/scripts/test_backup.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -57,6 +58,51 @@ class TestBackupLocal(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             with self.assertRaises(SystemExit):
                 backup.backup_local(os.path.join(d, "nope.xlsx"), d)
+
+
+class TestAssertDestGitSafe(unittest.TestCase):
+    """The committable-path guard: snapshots are the full applicant export, and
+    the repo is public, so an unignored --dest must refuse before any fetch."""
+
+    def _repo(self, d):
+        subprocess.run(["git", "init", "-q", d], check=True, capture_output=True)
+        return d
+
+    def test_refuses_an_unignored_dest_inside_a_repo(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            with self.assertRaises(SystemExit) as e:
+                backup.assert_dest_git_safe(os.path.join(d, "backups"))
+            self.assertIn("committable", str(e.exception))
+
+    def test_allows_an_ignored_dest_even_before_it_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            with open(os.path.join(d, ".gitignore"), "w") as f:
+                f.write("backups/\n")
+            backup.assert_dest_git_safe(os.path.join(d, "backups"))  # must not raise
+
+    def test_allows_a_dest_outside_any_repo(self):
+        with tempfile.TemporaryDirectory() as d:
+            # check-ignore exits 128 out here; that must read as "safe", since
+            # moving --dest outside the repo is the guard's own recommendation.
+            backup.assert_dest_git_safe(os.path.join(d, "backups"))
+
+    def test_refuses_a_dest_holding_tracked_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            bk = os.path.join(d, "backups")
+            os.makedirs(bk)
+            with open(os.path.join(bk, "old.xlsx"), "w") as f:
+                f.write("x")
+            subprocess.run(["git", "-C", d, "add", "backups/old.xlsx"],
+                           check=True, capture_output=True)
+            # ignored NOW, but the earlier commit-era file still rides `git add -A`
+            with open(os.path.join(d, ".gitignore"), "w") as f:
+                f.write("backups/\n")
+            with self.assertRaises(SystemExit) as e:
+                backup.assert_dest_git_safe(bk)
+            self.assertIn("TRACKED", str(e.exception))
 
 
 class TestDriveIdDispatch(unittest.TestCase):

--- a/skills/aaif-backup/scripts/test_backup.py
+++ b/skills/aaif-backup/scripts/test_backup.py
@@ -88,6 +88,18 @@ class TestAssertDestGitSafe(unittest.TestCase):
             # moving --dest outside the repo is the guard's own recommendation.
             backup.assert_dest_git_safe(os.path.join(d, "backups"))
 
+    def test_a_git_failure_that_is_not_outside_a_repo_aborts(self):
+        """Pins the deliberate copy of report_style._repo_root's guard: a git
+        failure other than "not a git repository" (here a corrupt .git; dubious
+        ownership behaves the same) must abort, not read as "outside any repo"
+        and silently disengage the PII guard."""
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, ".git"), "w") as f:
+                f.write("not a gitfile\n")     # exit 128: invalid gitfile format
+            with self.assertRaises(SystemExit) as e:
+                backup.assert_dest_git_safe(os.path.join(d, "backups"))
+            self.assertIn("REFUSING TO RUN", str(e.exception))
+
     def test_refuses_a_dest_holding_tracked_files(self):
         with tempfile.TemporaryDirectory() as d:
             self._repo(d)

--- a/skills/aaif-carousel-copy/SKILL.md
+++ b/skills/aaif-carousel-copy/SKILL.md
@@ -29,7 +29,11 @@ line. **Slide 1 hooks, slide 6 is the CTA.**
 builder-to-builder. Signal, not numbers.
 
 **Workflow:** update the LinkedIn Carousel deck (`Event Template/LinkedIn Carousel.pptx`
-in the chapter's Drive folder) with this copy, export it as a PDF, then post the PDF.
+in the chapter's Drive folder) with this copy, then export the PDF:
+`gws drive files copy` the `.pptx`, converting it to a Google Slides file →
+`gws drive files export` that copy to PDF → trash the copy. (The conversion can
+substitute fonts; when fidelity matters, render each slide to PNG via
+`aaif_events.slides_export` instead.) Post the PDF.
 
 ## Input (from the event tracker)
 - Event : `[EVENT TITLE] ([SERIES]) — [THEME]`
@@ -45,5 +49,5 @@ Agentic AI Night:
 | 2 | Tool calling at 10M/day. | Maya Chen on what broke, and the fixes. |
 | 3 | Three live demos. | AGENTS.md at monorepo scale. Sandboxing goose. |
 | 4 | Builder-first, always. | Vendor-neutral. No pitches. People who ship. |
-| 5 | Tue June 24 — 17:30. | SoMa, San Francisco. Doors at 5:30. |
+| 5 | Wed June 24 — 17:30. | SoMa, San Francisco. Doors at 5:30. |
 | 6 | Grab a seat. | Curated + limited. RSVP at lu.ma/aaif-sanfrancisco |

--- a/skills/aaif-clean-data/SKILL.md
+++ b/skills/aaif-clean-data/SKILL.md
@@ -197,15 +197,21 @@ by **header name**, never column letter.
 1. **Scan** and show the user the proposed mechanical fixes and the flags, grouped
    and skimmable. Lead with anything that blocks usability (missing/invalid email).
 2. **Resolve judgment flags yourself before asking the user to.** For each
-   `City="Other"` row, read that person's free-text in `Form Responses` (their
-   "Why organize / ties", "Have you helped run events before?", LinkedIn, etc.) and
-   infer the real city — e.g. Bangalore, Frankfurt, Luxembourg. Write the inferred
-   value into the **`Resolved City`** source column (found by header name — shown in
-   the role tabs as **`City (New)`**), **never overwrite the submitted `City` dropdown**
-   (shown as **`City (Existing)`**) — that's the non-destructive rule. `City (New)`
-   holds **only net-new cities** (rows where `City = "Other"`); existing form cities
-   stay in `City (Existing)` and must **not** be copied across. A row stops being
-   flagged once `Resolved City` is filled. Don't guess with no signal.
+   `City="Other"` row, run `cities` first — extraction resolves most of them from
+   the free text. For the rows it leaves unresolved, read that person's free-text
+   in `Form Responses` (their "Why organize / ties", "Have you helped run events
+   before?", LinkedIn, etc.) and infer the real city — e.g. Bangalore, Frankfurt,
+   Luxembourg. Write the inferred value into **`Extracted City`** via `apply`
+   (`{"row": ..., "header": "Extracted City", "value": ...}`) — the derived
+   `Resolved City` (shown in the role tabs as **`City (New)`**) picks it up on
+   its own. **Never write `Resolved City` itself**: it is an `ARRAYFORMULA` (see
+   the Cities section above) and `apply` refuses it — a literal would `#REF!`
+   the whole column. And **never overwrite the submitted `City` dropdown**
+   (shown as **`City (Existing)`**) — that's the non-destructive rule. `City
+   (New)` holds **only net-new cities** (rows where `City = "Other"`); existing
+   form cities stay in `City (Existing)` and must **not** be copied across. A
+   row stops being flagged once `Extracted City` fills its `Resolved City`.
+   Don't guess with no signal.
 3. **Confirm with the user** which fixes to apply. Mechanical fixes are safe to
    batch; city resolutions should be eyeballed since they're inferred.
 4. **Build `changes.json`** (rows + header names + new values) and run `apply`.

--- a/skills/aaif-clean-data/scripts/clean.py
+++ b/skills/aaif-clean-data/scripts/clean.py
@@ -691,7 +691,7 @@ def plan_cities():
     """Propose an `Extracted City` for every row where the dropdown didn't answer.
 
     Migration policy — **an existing hand-filled `Resolved City` always wins.**
-    123 of those were typed by a human, 23 of them for rows whose free text is
+    122 of those were typed by a human, 23 of them for rows whose free text is
     empty (the question didn't exist yet), so deriving them fresh would blank
     real organizers. Seeding Extracted from Resolved makes the switch to a
     derived Resolved lossless by construction; extraction only fills blanks.
@@ -874,9 +874,28 @@ def apply(path):
 
 
 # ---------- install live Issues flag + bright-red rule ----------
+# Headers the Issues ARRAYFORMULA is built from. The formula goes out
+# USER_ENTERED, so there is no downstream safety net: a missing "Timestamp"
+# yields a literal `$None2:$None` range installed live, and a renamed Email or
+# LinkedIn silently shrinks the coverage the bright-red rule still claims.
+FLAG_HEADERS = ("Timestamp", "Email", "LinkedIn")
+
+
 def install_flags():
-    for tab, sid in ROLE_TABS.items():
+    # Pre-flight: validate EVERY tab before writing to any of them (the same
+    # contract install_colors has). Aborting mid-loop used to leave the first
+    # tab rewritten and the rest untouched.
+    headers = {}
+    for tab in ROLE_TABS:
         hdr, _ = read_tab(tab)
+        missing = [h for h in FLAG_HEADERS if h not in hdr]
+        if missing:
+            sys.exit("ABORT: %s has no %s column(s) — the Issues formula would be "
+                     "built on a hole. No tab modified. Headers: %s"
+                     % (tab, ", ".join(repr(m) for m in missing), hdr))
+        headers[tab] = hdr
+    for tab, sid in ROLE_TABS.items():
+        hdr = headers[tab]
         def L(name):
             return colletter(hdr.index(name) + 1) if name in hdr else None
         ts = L("Timestamp")

--- a/skills/aaif-clean-data/scripts/test_clean.py
+++ b/skills/aaif-clean-data/scripts/test_clean.py
@@ -547,6 +547,59 @@ class TestInstallFlagsRedRule(unittest.TestCase):
         self.assertEqual(adds, [])
 
 
+class TestInstallFlagsPreflight(unittest.TestCase):
+    """The Issues formula ships USER_ENTERED, so a missing 'Timestamp' used to
+    install a literal `$None2:$None` formula live, and a renamed Email/LinkedIn
+    silently shrank the coverage the bright-red rule still claims. Every tab is
+    validated before ANY write, mirroring install_colors."""
+
+    GOOD = ["Status", "Timestamp", "Email", "LinkedIn", "City", "Resolved City"]
+
+    def _run(self, headers_by_tab, calls=None):
+        # `calls` may be passed in so an aborting run's writes stay observable —
+        # a list created here is unreachable once SystemExit propagates.
+        calls = [] if calls is None else calls
+        for name in ("gws", "read_tab", "_all_conditional_formats",
+                     "ROLE_TABS", "install_colors"):
+            self.addCleanup(setattr, clean, name, getattr(clean, name))
+        clean.gws = lambda args: calls.append(args) or {}
+        clean.read_tab = lambda tab: (headers_by_tab[tab], [])
+        clean._all_conditional_formats = lambda: {i: [] for i in range(1, 4)}
+        clean.ROLE_TABS = {t: i for i, t in enumerate(headers_by_tab, start=1)}
+        clean.install_colors = lambda: None
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()):
+            clean.install_flags()
+        return calls
+
+    def test_aborts_naming_the_missing_headers_before_any_write(self):
+        calls = []
+        with self.assertRaises(SystemExit) as e:
+            self._run({"Organizers": ["Status", "Email", "LinkedIn"]}, calls)
+        self.assertIn("'Timestamp'", str(e.exception))
+        self.assertIn("No tab modified", str(e.exception))
+        self.assertEqual(calls, [], "nothing may be written on a preflight abort")
+
+    def test_a_renamed_email_or_linkedin_is_an_abort_not_shrunk_coverage(self):
+        for gone in ("Email", "LinkedIn"):
+            hdr = [h for h in self.GOOD if h != gone]
+            with self.assertRaises(SystemExit) as e:
+                self._run({"Organizers": hdr})
+            self.assertIn(repr(gone), str(e.exception))
+
+    def test_no_tab_is_written_when_a_later_tab_fails_preflight(self):
+        calls = []
+        with self.assertRaises(SystemExit) as e:
+            self._run({"Organizers": self.GOOD,
+                       "Hosts": ["Status", "Email", "LinkedIn"]}, calls)
+        self.assertIn("Hosts", str(e.exception))
+        self.assertEqual(calls, [], "Organizers must not be written when Hosts fails")
+
+    def test_a_clean_tab_still_installs(self):
+        calls = self._run({"Organizers": self.GOOD})
+        self.assertTrue(calls, "the happy path must still write")
+
+
 class TestAutofixNoteSeparators(unittest.TestCase):
     """The regression the value-carrying phrase introduced: a value containing a
     separator could not be split back out of `prior`, so it never matched `seen`

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -128,12 +128,24 @@ Two consequences of dropping the override table:
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/create_chapter.py --city "New York" --resume
    ```
-   It enters the existing folder, skips every child whose (rebranded) name is
-   already present (logged `exists, skipped`), and clones/rebrands only what's
-   missing — so resuming a fully-cloned chapter is a no-op. The same flag is the
-   backfill path when a chapter is missing part of the template (e.g. Luxembourg,
-   whose 6 design assets were never cloned). Note it matches by **name only**: a
-   present-but-corrupt file is skipped, not repaired.
+   It enters the existing folder and clones/rebrands only what's missing — so
+   resuming a fully-cloned chapter is a no-op. The same flag is the backfill
+   path when a chapter is missing part of the template (e.g. Luxembourg, whose
+   6 design assets were never cloned). Two safeguards make the skip decision
+   trustworthy:
+   - Existing children are matched by their **rebranded or original** template
+     name. A survivor still under its original name (a folder part-cloned before
+     the rename step existed, or a hand copy) is renamed in place (logged `~ old
+     -> new`) and treated as present — never re-cloned as a duplicate.
+   - Every skipped Office file is **residual-checked**, because the likeliest
+     crash state is copied-but-never-rebranded. A clean file logs `exists,
+     skipped — residual-checked clean`; a dirty one is repaired in place
+     (downloaded, rebranded, re-uploaded, dot moved) and logged as repaired.
+     Only a residual that survives the repair is flagged `!! residual (skipped)`
+     and fails the run, same as on a fresh clone.
+
+   A present file whose *content* is corrupt but token-clean is still skipped,
+   not repaired.
 
 4. **Verify.** Confirm the run printed no `!! residual` flags and report the new
    folder URL to the user. If the Luma page wasn't live, remind them to create it.

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-create-chapter
 description: Create a new AAIF city chapter in the "Chapters" Google Drive by cloning TemplateCity and rebranding all assets. Use when asked to add/launch/set up a new AAIF city, chapter, or location.
-argument-hint: '<City Name> [--slug <lumaslug>] [--lat <deg> --lon <deg>]'
+argument-hint: '<City Name> [--slug <lumaslug>] [--lat <deg> --lon <deg>] [--resume]'
 ---
 
 # Create AAIF Chapter
@@ -44,6 +44,7 @@ not touch it.
 | `San Francisco` / `SAN FRANCISCO` | new city, case-matched | contiguous in the clean template |
 | `SF` abbreviation (`AAIF · SF`, `SF CHAPTER`, `About the AAIF SF Chapter`, `AAIF SF — Attendee CRM`, doc metadata) | full city name | **UPPER** in all-caps contexts, **Title case** in prose |
 | `aaif-sanfrancisco` / `AAIF-SANFRANCISCO` (Luma slug, incl. hyperlink targets) | `aaif-<slug>` / `AAIF-<SLUG>` | see slug rules below |
+| File/folder **names** carrying any of the above (e.g. `San Francisco CRM.xlsx`) | renamed with the same transform | not just file contents; unit-tested |
 
 Beyond text, the script also **repositions the green "you-are-here" dot and its
 `<CITY> · TONIGHT` label** on slide 5 ("THE NETWORK") of `Event Template/Slides.pptx`
@@ -120,6 +121,20 @@ Two consequences of dropping the override table:
    downloads, rebrands, and re-uploads each `.pptx/.docx/.xlsx` in place. It
    prints a tree and flags any file with `!! residual` tokens.
 
+   **Recovering a failed or partial run — `--resume`.** If a run dies midway
+   (a `gws` 403, template drift raising in the rebrand engine, network loss),
+   the half-created chapter folder is already in Drive and a plain re-run aborts
+   on the name collision. Don't trash the folder — re-run with `--resume`:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/create_chapter.py --city "New York" --resume
+   ```
+   It enters the existing folder, skips every child whose (rebranded) name is
+   already present (logged `exists, skipped`), and clones/rebrands only what's
+   missing — so resuming a fully-cloned chapter is a no-op. The same flag is the
+   backfill path when a chapter is missing part of the template (e.g. Luxembourg,
+   whose 6 design assets were never cloned). Note it matches by **name only**: a
+   present-but-corrupt file is skipped, not repaired.
+
 4. **Verify.** Confirm the run printed no `!! residual` flags and report the new
    folder URL to the user. If the Luma page wasn't live, remind them to create it.
    Open slide 5 ("THE NETWORK") of `Event Template/Slides.pptx` and confirm the
@@ -158,6 +173,8 @@ bounds, and the 2-shapes-or-raise guard.
 To validate the engine after any edit, rebrand a throwaway copy of the template
 and diff it against an existing chapter (the canonical end-state):
 ```bash
+# --rebrand-local requires --lat/--lon: local mode is fully offline and refuses
+# to geocode, so the coordinates must be passed explicitly.
 python3 ${CLAUDE_SKILL_DIR}/scripts/create_chapter.py \
     --city "Los Angeles" --lat 34.05 --lon -118.24 --rebrand-local /path/to/template-copy
 # then compare paragraph text against the real Los Angeles chapter, and open

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -162,15 +162,21 @@ def rebrand_file(path, name, upper, newslug):
     return _rewrite_zip(path, lambda n, d: rebrand_part(n, d, name, upper, newslug))
 
 def residual_tokens(path):
-    """List any stale San Francisco / SF / aaif-sf tokens still present."""
-    z = zipfile.ZipFile(path); hits = []
-    for n in z.namelist():
-        if not n.endswith((".xml", ".rels")):
-            continue
-        d = z.read(n)
-        for pat in (rb"San Francisco", rb"SAN FRANCISCO", rb"aaif-sf(?![a-z])", rb"\bSF\b"):
-            if re.search(pat, d, re.I):
-                hits.append((n.split("/")[-1], pat.decode("latin1")))
+    """List any stale San Francisco / SF / aaif-sf tokens still present. The city
+    name and slug are matched case-insensitively; the bare "SF" abbreviation is
+    matched case-SENSITIVELY (uppercase only) — theme/font XML legitimately holds
+    lowercase "sf" tokens that are not stale brand text."""
+    hits = []
+    with zipfile.ZipFile(path) as z:
+        for n in z.namelist():
+            if not n.endswith((".xml", ".rels")):
+                continue
+            d = z.read(n)
+            for pat, flags in ((rb"San Francisco", re.I),
+                               (rb"aaif-sf(?![a-z])", re.I),
+                               (rb"\bSF\b", 0)):
+                if re.search(pat, d, flags):
+                    hits.append((n.split("/")[-1], pat.decode("latin1")))
     return hits
 
 # ----------------------------------------------------------------------------
@@ -408,17 +414,31 @@ def luma_status(slug):
         return "unknown"
 
 # ----------------------------------------------------------------------------
-def clone_and_rebrand(folder_id, parent, name, ctx, indent=""):
-    """Recursively copy `folder_id` into `parent` as `name`, rebranding files."""
-    new_id = create_folder(name, parent)
-    print("%s+ %s/" % (indent, name))
+def clone_and_rebrand(folder_id, parent, name, ctx, indent="", existing_id=None):
+    """Recursively copy `folder_id` into `parent` as `name`, rebranding files.
+
+    Under --resume, `existing_id` is an already-created target folder: it is
+    entered instead of recreated, its children are listed by (rebranded) name,
+    name-matching children are skipped, and only missing items are cloned — so
+    resuming into a fully-cloned folder is a no-op."""
+    if existing_id:
+        new_id = existing_id
+        print("%s= %s/ (exists, resumed)" % (indent, name))
+    else:
+        new_id = create_folder(name, parent)
+        print("%s+ %s/" % (indent, name))
+    have = {c["name"]: c for c in list_children(new_id)} if existing_id else {}
     for child in list_children(folder_id):
         cname, cid, mime = child["name"], child["id"], child["mimeType"]
         # Names (not just file content) can carry the source city, e.g. "San
         # Francisco CRM.xlsx" -> "New York CRM.xlsx" — same transform as content.
         new_cname = transform_text(cname, ctx["name"], ctx["upper"], ctx["slug"])
+        hit = have.get(new_cname)
         if mime == FOLDER:
-            clone_and_rebrand(cid, new_id, new_cname, ctx, indent + "  ")
+            clone_and_rebrand(cid, new_id, new_cname, ctx, indent + "  ",
+                              existing_id=hit["id"] if hit and hit["mimeType"] == FOLDER else None)
+        elif hit:
+            print("%s  - %s (exists, skipped)" % (indent, new_cname))
         else:
             copy_id = copy_file(cid, new_cname, new_id)
             ext = os.path.splitext(cname)[1].lower()
@@ -454,6 +474,10 @@ def main():
     ap.add_argument("--city", required=True, help='Full city name, e.g. "New York"')
     ap.add_argument("--slug", help="Luma slug override (default: city, lowercased, no spaces)")
     ap.add_argument("--dry-run", action="store_true", help="Plan only; create nothing")
+    ap.add_argument("--resume", action="store_true",
+                    help="Enter an existing target folder instead of aborting: skip "
+                         "name-matching children and clone only what's missing "
+                         "(recovery for a failed/partial run)")
     ap.add_argument("--lat", type=float, help="City latitude (use with --lon) to override geocoding of the map dot")
     ap.add_argument("--lon", type=float, help="City longitude (use with --lat) to override geocoding of the map dot")
     ap.add_argument("--rebrand-local", metavar="DIR",
@@ -466,6 +490,12 @@ def main():
     print("City : %s" % name)
     print("Upper: %s" % upper)
     print("Slug : aaif-%s  ->  https://luma.com/aaif-%s" % (slug, slug))
+
+    # --rebrand-local is documented "no Drive, for testing" — it must not make a
+    # live geocoding call either. Require the coordinates explicitly.
+    if a.rebrand_local and (a.lat is None or a.lon is None):
+        sys.exit("ABORT: --rebrand-local is offline-only and does not geocode; "
+                 "pass --lat and --lon explicitly (they place the slide-5 map dot).")
 
     # Coordinates for the slide-5 network-map dot (explicit -> geocode -> none).
     latlon = resolve_latlon(name, a.lat, a.lon)
@@ -505,11 +535,23 @@ def main():
 
     existing = [c for c in list_children(CHAPTERS_PARENT)
                 if c["name"].lower() == name.lower() and c["mimeType"] == FOLDER]
+    resume_id = None
     if existing:
-        sys.exit("ABORT: a chapter folder named %r already exists (%s)" % (name, existing[0]["id"]))
+        if a.resume:
+            resume_id = existing[0]["id"]
+            print("Resume: entering existing folder %s — children already present "
+                  "are skipped; only missing items are cloned." % resume_id)
+        else:
+            sys.exit("ABORT: a chapter folder named %r already exists (%s). To fill "
+                     "in missing items from a failed/partial run, re-run with "
+                     "--resume." % (name, existing[0]["id"]))
 
     if a.dry_run:
-        print("\n[dry-run] Would clone TemplateCity -> %r under Chapters and rebrand all files." % name)
+        if resume_id:
+            print("\n[dry-run] Would resume into the existing %r folder under Chapters "
+                  "and clone only the missing items." % name)
+        else:
+            print("\n[dry-run] Would clone TemplateCity -> %r under Chapters and rebrand all files." % name)
         if status == "absent":
             print("[dry-run] WARNING: Luma page aaif-%s is not live yet." % slug)
         elif status == "unknown":
@@ -520,7 +562,8 @@ def main():
            "tmp": os.path.join(os.environ.get("TMPDIR", "/tmp"), "aaif_chapter")}
     os.makedirs(ctx["tmp"], exist_ok=True)
     print()
-    new_id = clone_and_rebrand(TEMPLATE_FOLDER, CHAPTERS_PARENT, name, ctx)
+    new_id = clone_and_rebrand(TEMPLATE_FOLDER, CHAPTERS_PARENT, name, ctx,
+                               existing_id=resume_id)
     print("\nDone. New chapter folder id: %s" % new_id)
     print("https://drive.google.com/drive/folders/%s" % new_id)
     if status == "absent":

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -398,6 +398,11 @@ def copy_file(file_id, name, parent):
                     params={"fileId": file_id, "supportsAllDrives": True},
                     body={"name": name, "parents": [parent]})["id"]
 
+def rename_file(file_id, name):
+    gws_json("drive", "files", "update",
+             params={"fileId": file_id, "supportsAllDrives": True},
+             body={"name": name})
+
 def luma_status(slug):
     """Return 'live' (HTTP 200), 'absent' (HTTP 404), or 'unknown' (could not
     verify: timeout, DNS/SSL, 403/429/5xx). Never report a hard 404 for a
@@ -418,9 +423,13 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent="", existing_id=None)
     """Recursively copy `folder_id` into `parent` as `name`, rebranding files.
 
     Under --resume, `existing_id` is an already-created target folder: it is
-    entered instead of recreated, its children are listed by (rebranded) name,
-    name-matching children are skipped, and only missing items are cloned — so
-    resuming into a fully-cloned folder is a no-op."""
+    entered instead of recreated, its children are listed, name-matching children
+    are skipped, and only missing items are cloned — so resuming into a
+    fully-cloned folder is a no-op. Matching is by rebranded OR original template
+    name (a survivor of the pre-rename engine is renamed in place, never
+    re-cloned as a duplicate), and every skipped Office file is residual-checked:
+    one that was copied but never rebranded — the likeliest crash state — is
+    repaired in place rather than trusted."""
     if existing_id:
         new_id = existing_id
         print("%s= %s/ (exists, resumed)" % (indent, name))
@@ -434,11 +443,57 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent="", existing_id=None)
         # Francisco CRM.xlsx" -> "New York CRM.xlsx" — same transform as content.
         new_cname = transform_text(cname, ctx["name"], ctx["upper"], ctx["slug"])
         hit = have.get(new_cname)
+        if hit is None and new_cname != cname:
+            # A child cloned by the pre-rename engine (or a hand copy) still holds
+            # the ORIGINAL template name — treat it as a hit and rename it, or the
+            # backfill re-clones a duplicate (two CRMs; sync_crm picks the wrong one).
+            hit = have.get(cname)
+            if hit is not None:
+                rename_file(hit["id"], new_cname)
+                print("%s  ~ %s -> %s (renamed to rebranded name)"
+                      % (indent, cname, new_cname))
         if mime == FOLDER:
             clone_and_rebrand(cid, new_id, new_cname, ctx, indent + "  ",
                               existing_id=hit["id"] if hit and hit["mimeType"] == FOLDER else None)
         elif hit:
-            print("%s  - %s (exists, skipped)" % (indent, new_cname))
+            ext = os.path.splitext(cname)[1].lower()
+            if ext in MIME_BY_EXT:
+                # Never trust a skip on faith: the likeliest partial-run state is
+                # copied-under-the-new-name but never rebranded (crash between
+                # copy_file and gws_upload). Residual-check the EXISTING file, and
+                # repair a dirty one in place (download -> rebrand -> upload).
+                tmp = os.path.join(ctx["tmp"], "f" + hit["id"] + ext)
+                try:
+                    gws_download(hit["id"], tmp)
+                    left = residual_tokens(tmp)
+                    if left:
+                        n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
+                        # The dot was never moved either if the rebrand never ran.
+                        if cname == "Slides.pptx" and ctx.get("latlon"):
+                            moved = reposition_map_marker(tmp, *ctx["latlon"])
+                        else:
+                            moved = 0
+                        if n or moved:
+                            gws_upload(hit["id"], tmp, MIME_BY_EXT[ext])
+                        left = residual_tokens(tmp)
+                        if left:   # repair didn't clear it — fail the run like a clone would
+                            ctx["residuals"].append((new_cname, left))
+                            print("%s  - %s (exists, was not rebranded; repaired %d "
+                                  "parts%s)  !! residual (skipped) %s"
+                                  % (indent, new_cname, n,
+                                     " +map dot" if moved else "", left))
+                        else:
+                            print("%s  - %s (exists, was not rebranded — repaired, "
+                                  "%d parts%s)" % (indent, new_cname, n,
+                                                   " +map dot" if moved else ""))
+                    else:
+                        print("%s  - %s (exists, skipped — residual-checked clean)"
+                              % (indent, new_cname))
+                finally:
+                    if os.path.exists(tmp):
+                        os.remove(tmp)
+            else:
+                print("%s  - %s (exists, skipped)" % (indent, new_cname))
         else:
             copy_id = copy_file(cid, new_cname, new_id)
             ext = os.path.splitext(cname)[1].lower()

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -411,11 +411,13 @@ class TestRewriteZipHardening(unittest.TestCase):
 
 
 class FakeDrive:
-    """In-memory Drive: {folder_id: [child dicts]}. Records creates/copies."""
+    """In-memory Drive: {folder_id: [child dicts]}. Records creates/copies/
+    renames/uploads."""
 
     def __init__(self, folders):
         self.folders = {k: list(v) for k, v in folders.items()}
-        self.created, self.copied, self.next = [], [], 0
+        self.created, self.copied, self.renamed, self.uploaded = [], [], [], []
+        self.next = 0
 
     def list_children(self, fid):
         return list(self.folders.get(fid, []))
@@ -437,12 +439,33 @@ class FakeDrive:
         self.copied.append(name)
         return fid
 
+    def rename_file(self, fid, name):
+        for kids in self.folders.values():
+            for c in kids:
+                if c["id"] == fid:
+                    c["name"] = name
+        self.renamed.append((fid, name))
+
 
 def fake_download(_file_id, out):
     """Every downloaded Office file is a minimal xlsx whose sharedStrings carries
-    the source city — the real rebrand engine then runs on it, offline."""
+    the source city — the real rebrand engine then runs on it, offline. Under
+    --resume this doubles as the copied-but-never-rebranded crash state."""
     make_zip(out, {"xl/sharedStrings.xml":
                    "<sst><si><t>San Francisco</t></si></sst>"})
+
+
+def clean_download(_file_id, out):
+    """An already-rebranded file — what a healthy resume skip downloads."""
+    make_zip(out, {"xl/sharedStrings.xml":
+                   "<sst><si><t>New York</t></si></sst>"})
+
+
+def sticky_download(_file_id, out):
+    """A residual the rebrand engine can NOT rewrite (lowercase city name is a
+    case-insensitive residual hit but not a transform_text token)."""
+    make_zip(out, {"xl/sharedStrings.xml":
+                   "<sst><si><t>visit san francisco</t></si></sst>"})
 
 
 CLONE_TEMPLATE = {
@@ -461,7 +484,7 @@ class TestCloneResume(unittest.TestCase):
     """clone_and_rebrand with the Drive layer faked — covers the --resume
     skip-by-name decision (network paths excluded by design)."""
 
-    def run_clone(self, drive, existing_id=None):
+    def run_clone(self, drive, existing_id=None, download=fake_download):
         from unittest import mock
         ctx = {"name": "New York", "upper": "NEW YORK", "slug": "newyork",
                "residuals": [], "latlon": None}
@@ -469,8 +492,10 @@ class TestCloneResume(unittest.TestCase):
                 mock.patch.object(cc, "list_children", drive.list_children), \
                 mock.patch.object(cc, "create_folder", drive.create_folder), \
                 mock.patch.object(cc, "copy_file", drive.copy_file), \
-                mock.patch.object(cc, "gws_download", fake_download), \
-                mock.patch.object(cc, "gws_upload", lambda *a, **k: None):
+                mock.patch.object(cc, "rename_file", drive.rename_file), \
+                mock.patch.object(cc, "gws_download", download), \
+                mock.patch.object(cc, "gws_upload",
+                                  lambda fid, path, mime: drive.uploaded.append(fid)):
             ctx["tmp"] = d
             return cc.clone_and_rebrand("tpl", "parent", "New York", ctx,
                                         existing_id=existing_id), ctx
@@ -487,9 +512,12 @@ class TestCloneResume(unittest.TestCase):
             "ex": [{"id": "e1", "name": "New York CRM.xlsx",
                     "mimeType": "application/x-copied"}],
         }))
-        self.run_clone(drive, existing_id="ex")
+        _, ctx = self.run_clone(drive, existing_id="ex", download=clean_download)
         self.assertEqual(sorted(drive.copied), ["About.txt", "notes.txt"])
         self.assertEqual(drive.created, ["Event Template"])
+        # the clean skip was residual-checked but not touched
+        self.assertEqual(drive.uploaded, [])
+        self.assertEqual(ctx["residuals"], [])
 
     def test_resume_into_fully_cloned_folder_is_a_noop(self):
         drive = FakeDrive(dict(CLONE_TEMPLATE, **{
@@ -500,10 +528,11 @@ class TestCloneResume(unittest.TestCase):
             ],
             "esub": [{"id": "e3", "name": "notes.txt", "mimeType": "application/x-copied"}],
         }))
-        new_id, _ = self.run_clone(drive, existing_id="ex")
+        new_id, _ = self.run_clone(drive, existing_id="ex", download=clean_download)
         self.assertEqual(new_id, "ex")
         self.assertEqual(drive.copied, [])
         self.assertEqual(drive.created, [])
+        self.assertEqual(drive.uploaded, [])
 
     def test_resume_recurses_into_partial_subfolder(self):
         drive = FakeDrive(dict(CLONE_TEMPLATE, **{
@@ -517,6 +546,57 @@ class TestCloneResume(unittest.TestCase):
         self.run_clone(drive, existing_id="ex")
         self.assertEqual(drive.copied, ["notes.txt"])
         self.assertEqual(drive.created, [])
+
+    def test_resume_repairs_a_skipped_but_unrebranded_file(self):
+        # The likeliest partial-run state: copied under the rebranded name, crash
+        # before the rebrand's upload. The skip must residual-check the existing
+        # file and repair it in place — not report "exists, skipped" on
+        # wrong-city content.
+        drive = FakeDrive(dict(CLONE_TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "New York CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        _, ctx = self.run_clone(drive, existing_id="ex")  # fake_download = SF content
+        self.assertNotIn("New York CRM.xlsx", drive.copied)   # still a skip, no dupe
+        self.assertIn("e1", drive.uploaded)                   # repaired in place
+        self.assertEqual(ctx["residuals"], [])                # flag cleared by repair
+
+    def test_resume_flags_a_skip_the_repair_cannot_clean(self):
+        # A residual the rebrand engine can't rewrite must survive as a flag and
+        # fail the run — exactly as it would on a fresh clone.
+        drive = FakeDrive(dict(CLONE_TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "New York CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        _, ctx = self.run_clone(drive, existing_id="ex", download=sticky_download)
+        self.assertEqual([fn for fn, _ in ctx["residuals"]], ["New York CRM.xlsx"])
+
+    def test_resume_matches_original_name_file_and_renames(self):
+        # A survivor of the pre-rename engine holds the ORIGINAL template name —
+        # it must be renamed and treated as a hit, never re-cloned as a duplicate
+        # (two CRMs would send sync_crm's find_crm to the wrong one).
+        drive = FakeDrive(dict(CLONE_TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "San Francisco CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        _, ctx = self.run_clone(drive, existing_id="ex")
+        self.assertEqual(sorted(drive.copied), ["About.txt", "notes.txt"])
+        self.assertEqual(drive.renamed, [("e1", "New York CRM.xlsx")])
+        self.assertIn("e1", drive.uploaded)     # and residual-checked -> repaired
+        self.assertEqual(ctx["residuals"], [])
+
+    def test_resume_matches_original_name_subfolder_and_renames(self):
+        drive = FakeDrive({
+            "tpl": [{"id": "sub", "name": "SF Assets", "mimeType": cc.FOLDER}],
+            "sub": [{"id": "f3", "name": "notes.txt", "mimeType": "application/x"}],
+            "ex": [{"id": "esub", "name": "SF Assets", "mimeType": cc.FOLDER}],
+            "esub": [{"id": "e3", "name": "notes.txt",
+                      "mimeType": "application/x-copied"}],
+        })
+        self.run_clone(drive, existing_id="ex")
+        self.assertEqual(drive.copied, [])        # recursed into the renamed hit
+        self.assertEqual(drive.created, [])
+        self.assertEqual(drive.renamed, [("esub", "New York Assets")])
 
 
 if __name__ == "__main__":

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -351,5 +351,173 @@ class TestRebrandWorksheetInlineStrings(unittest.TestCase):
         self.assertEqual(out, self.SHEET_XML.encode("utf-8"))
 
 
+def make_zip(path, members):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, data in members.items():
+            z.writestr(name, data)
+
+
+class TestResidualTokens(unittest.TestCase):
+    """City name / slug residuals are case-insensitive; the bare "SF"
+    abbreviation is case-SENSITIVE — lowercase "sf" tokens in theme/font XML
+    must not sys.exit a clean clone."""
+
+    def check(self, content, expect_hit):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"xl/theme/theme1.xml": content})
+            hits = cc.residual_tokens(p)
+            if expect_hit:
+                self.assertTrue(hits, "expected a residual hit for %r" % content)
+            else:
+                self.assertEqual(hits, [], "false positive for %r" % content)
+
+    def test_city_name_is_case_insensitive(self):
+        self.check(b"visit san francisco soon", True)
+        self.check(b"SAN FRANCISCO tonight", True)
+
+    def test_slug_is_case_insensitive(self):
+        self.check(b"https://luma.com/aaif-SF", True)
+
+    def test_uppercase_sf_hits(self):
+        self.check(b"AAIF SF CHAPTER", True)
+
+    def test_lowercase_sf_token_does_not_false_positive(self):
+        self.check(b'<a:latin typeface="sf pro display"/>', False)
+
+    def test_duplicate_city_pattern_removed(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"xl/theme/theme1.xml": b"San Francisco SAN FRANCISCO"})
+            # one hit for the (case-insensitive) city pattern, not two duplicates
+            self.assertEqual(len(cc.residual_tokens(p)), 1)
+
+
+class TestRewriteZipHardening(unittest.TestCase):
+    def test_mid_loop_failure_cleans_temp_and_keeps_original(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"a.xml": b"one", "b.xml": b"two"})
+
+            def boom(name, data):
+                if name == "b.xml":
+                    raise RuntimeError("transform failed")
+                return data
+            with self.assertRaises(RuntimeError):
+                cc._rewrite_zip(p, boom)
+            self.assertFalse(os.path.exists(p + ".new"))   # no leftover temp
+            with zipfile.ZipFile(p) as z:                  # original intact
+                self.assertEqual(z.read("a.xml"), b"one")
+
+
+class FakeDrive:
+    """In-memory Drive: {folder_id: [child dicts]}. Records creates/copies."""
+
+    def __init__(self, folders):
+        self.folders = {k: list(v) for k, v in folders.items()}
+        self.created, self.copied, self.next = [], [], 0
+
+    def list_children(self, fid):
+        return list(self.folders.get(fid, []))
+
+    def create_folder(self, name, parent):
+        self.next += 1
+        fid = "fld%d" % self.next
+        self.folders.setdefault(parent, []).append(
+            {"id": fid, "name": name, "mimeType": cc.FOLDER})
+        self.folders[fid] = []
+        self.created.append(name)
+        return fid
+
+    def copy_file(self, src, name, parent):
+        self.next += 1
+        fid = "cp%d" % self.next
+        self.folders.setdefault(parent, []).append(
+            {"id": fid, "name": name, "mimeType": "application/x-copied"})
+        self.copied.append(name)
+        return fid
+
+
+def fake_download(_file_id, out):
+    """Every downloaded Office file is a minimal xlsx whose sharedStrings carries
+    the source city — the real rebrand engine then runs on it, offline."""
+    make_zip(out, {"xl/sharedStrings.xml":
+                   "<sst><si><t>San Francisco</t></si></sst>"})
+
+
+CLONE_TEMPLATE = {
+    "tpl": [
+        {"id": "f1", "name": "San Francisco CRM.xlsx", "mimeType": "application/x"},
+        {"id": "f2", "name": "About.txt", "mimeType": "application/x"},
+        {"id": "sub", "name": "Event Template", "mimeType": cc.FOLDER},
+    ],
+    "sub": [
+        {"id": "f3", "name": "notes.txt", "mimeType": "application/x"},
+    ],
+}
+
+
+class TestCloneResume(unittest.TestCase):
+    """clone_and_rebrand with the Drive layer faked — covers the --resume
+    skip-by-name decision (network paths excluded by design)."""
+
+    def run_clone(self, drive, existing_id=None):
+        from unittest import mock
+        ctx = {"name": "New York", "upper": "NEW YORK", "slug": "newyork",
+               "residuals": [], "latlon": None}
+        with tempfile.TemporaryDirectory() as d, \
+                mock.patch.object(cc, "list_children", drive.list_children), \
+                mock.patch.object(cc, "create_folder", drive.create_folder), \
+                mock.patch.object(cc, "copy_file", drive.copy_file), \
+                mock.patch.object(cc, "gws_download", fake_download), \
+                mock.patch.object(cc, "gws_upload", lambda *a, **k: None):
+            ctx["tmp"] = d
+            return cc.clone_and_rebrand("tpl", "parent", "New York", ctx,
+                                        existing_id=existing_id), ctx
+
+    def test_fresh_clone_renames_children(self):
+        drive = FakeDrive(CLONE_TEMPLATE)
+        self.run_clone(drive)
+        self.assertEqual(sorted(drive.copied),
+                         ["About.txt", "New York CRM.xlsx", "notes.txt"])
+        self.assertEqual(sorted(drive.created), ["Event Template", "New York"])
+
+    def test_resume_skips_existing_and_clones_missing(self):
+        drive = FakeDrive(dict(CLONE_TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "New York CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        self.run_clone(drive, existing_id="ex")
+        self.assertEqual(sorted(drive.copied), ["About.txt", "notes.txt"])
+        self.assertEqual(drive.created, ["Event Template"])
+
+    def test_resume_into_fully_cloned_folder_is_a_noop(self):
+        drive = FakeDrive(dict(CLONE_TEMPLATE, **{
+            "ex": [
+                {"id": "e1", "name": "New York CRM.xlsx", "mimeType": "application/x-copied"},
+                {"id": "e2", "name": "About.txt", "mimeType": "application/x-copied"},
+                {"id": "esub", "name": "Event Template", "mimeType": cc.FOLDER},
+            ],
+            "esub": [{"id": "e3", "name": "notes.txt", "mimeType": "application/x-copied"}],
+        }))
+        new_id, _ = self.run_clone(drive, existing_id="ex")
+        self.assertEqual(new_id, "ex")
+        self.assertEqual(drive.copied, [])
+        self.assertEqual(drive.created, [])
+
+    def test_resume_recurses_into_partial_subfolder(self):
+        drive = FakeDrive(dict(CLONE_TEMPLATE, **{
+            "ex": [
+                {"id": "e1", "name": "New York CRM.xlsx", "mimeType": "application/x-copied"},
+                {"id": "e2", "name": "About.txt", "mimeType": "application/x-copied"},
+                {"id": "esub", "name": "Event Template", "mimeType": cc.FOLDER},
+            ],
+            "esub": [],
+        }))
+        self.run_clone(drive, existing_id="ex")
+        self.assertEqual(drive.copied, ["notes.txt"])
+        self.assertEqual(drive.created, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/aaif-create-event/SKILL.md
+++ b/skills/aaif-create-event/SKILL.md
@@ -115,7 +115,10 @@ keys are per-calendar). The script detects this itself and its dry-run says so:
 3. **Create — only after the user says yes:** re-run the same command with
    `--create`. It uploads the cover, creates the event, adds hosts, writes the
    new event URL into the tracker's LUMA URL field (re-upload the docx to Drive),
-   and prints the URL.
+   and prints the URL. Note the same caveat as `--luma` in step 3 above: the
+   write-back sets the cell's **displayed URL text only** — if the template
+   pre-fills that cell as a hyperlink, the clickable link target still points at
+   the old destination and must be fixed on the doc (or on the Luma page link).
 
 4. **Verify**: open the printed URL and check name/time/venue/cover/description
    against the proposal; confirm the hosts appear. Later detail changes go

--- a/skills/aaif-create-event/scripts/create_event.py
+++ b/skills/aaif-create-event/scripts/create_event.py
@@ -27,8 +27,7 @@ def title_exists(root, title):
     return any(key == e["title"].strip().lower() for e in tracker.list_events(root))
 
 
-def apply_local(path, fields, event_date):
-    root = office.read_document(path)
+def apply_local(path, fields, event_date, root):
     tracker.add_event(root, fields, event_date)
     office.save_document(path, root, path)
 
@@ -63,7 +62,7 @@ def main():
     if a.dry_run:
         print("[dry-run] would clone the example section and stamp dates; no write.")
         return
-    apply_local(a.docx, fields, event_date)
+    apply_local(a.docx, fields, event_date, root=root)
     print("Done. New event section added to %s and due-dates stamped." % a.docx)
 
 

--- a/skills/aaif-create-event/scripts/test_create_event.py
+++ b/skills/aaif-create-event/scripts/test_create_event.py
@@ -24,7 +24,7 @@ class TestCreateCore(unittest.TestCase):
             create_event.apply_local(local, {
                 "EVENT TITLE": "Eval Night",
                 "DATE & TIME": "Wed · August 12, 2026 · 18:00 — late",
-            }, dt.date(2026, 8, 12))
+            }, dt.date(2026, 8, 12), office.read_document(local))
             root = office.read_document(local)
             titles = [e["title"] for e in tracker.list_events(root)]
             self.assertIn("Eval Night", titles)
@@ -39,7 +39,7 @@ class TestCreateCore(unittest.TestCase):
                     "EVENT TITLE": "X",
                     "DATE & TIME": "Wed · August 12, 2026 · 18:00 — late",
                     "PLATFORM": "Zoom",
-                }, dt.date(2026, 8, 12))
+                }, dt.date(2026, 8, 12), office.read_document(local))
 
     def test_title_exists_is_exact_not_substring(self):
         root = office.read_document(FIX)

--- a/skills/aaif-create-online-series/SKILL.md
+++ b/skills/aaif-create-online-series/SKILL.md
@@ -91,12 +91,24 @@ placeholder the organizer fills in).
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/create_series.py --series "Reading Group" --resume
    ```
-   It enters the existing folder, skips every child whose (rebranded) name is
-   already present (logged `exists, skipped`), and clones/rebrands only what's
-   missing — so resuming a fully-cloned series is a no-op. It is also the
-   backfill path when an existing series folder is missing part of the template
-   (the Luxembourg-chapter situation, series-side). Note it matches by **name
-   only**: a present-but-corrupt file is skipped, not repaired.
+   It enters the existing folder and clones/rebrands only what's missing — so
+   resuming a fully-cloned series is a no-op. It is also the backfill path when
+   an existing series folder is missing part of the template (the
+   Luxembourg-chapter situation, series-side). Two safeguards make the skip
+   decision trustworthy:
+   - Existing children are matched by their **rebranded or original** template
+     name. A survivor still under its original name (a folder part-cloned by the
+     pre-rename engine, or a hand copy) is renamed in place (logged `~ old ->
+     new`) and treated as present — never re-cloned as a duplicate.
+   - Every skipped Office file is **residual-checked**, because the likeliest
+     crash state is copied-but-never-rebranded. A clean file logs `exists,
+     skipped — residual-checked clean`; a dirty one is repaired in place
+     (downloaded, rebranded, re-uploaded) and logged as repaired. Only a
+     residual that survives the repair is flagged `!! residual (skipped)` and
+     fails the run, same as on a fresh clone.
+
+   A present file whose *content* is corrupt but token-clean is still skipped,
+   not repaired.
 
 4. **Verify & hand off.** Confirm the run printed no `!! residual` flags and report
    the new folder URL. Remind the user to (a) fill the `[bracketed]` About-the-

--- a/skills/aaif-create-online-series/SKILL.md
+++ b/skills/aaif-create-online-series/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-create-online-series
 description: Create a new AAIF online event series in the "Online" Google Drive folder by cloning TemplateSeries and rebranding all assets. Use when asked to add/launch/set up a new AAIF online series (reading group, paper club, webinar, online discussion) — not a city chapter.
-argument-hint: '<Series Name> [--slug <lumaslug>]'
+argument-hint: '<Series Name> [--slug <lumaslug>] [--resume]'
 ---
 
 # Create AAIF Online Series
@@ -51,6 +51,7 @@ placeholder the organizer fills in).
 | `San Francisco` / `SAN FRANCISCO` | new series, case-matched | contiguous in the clean template |
 | `SF` abbreviation (`AAIF SF …`, doc metadata) | full series name | **UPPER** in all-caps contexts, **Title case** in prose |
 | `aaif-sanfrancisco` / `aaif-sf` (Luma slug, incl. hyperlink targets) | `aaif-<slug>` | see slug rules below |
+| File/folder **names** carrying any of the above (e.g. `San Francisco CRM.xlsx`) | renamed with the same transform | not just file contents; unit-tested |
 
 ## Luma slug rules
 
@@ -83,6 +84,20 @@ placeholder the organizer fills in).
    downloads, rebrands, and re-uploads each `.pptx/.docx/.xlsx` in place. It prints
    a tree and flags any file with `!! residual` tokens.
 
+   **Recovering a failed or partial run — `--resume`.** If a run dies midway
+   (a `gws` 403, template drift raising in the rebrand engine, network loss),
+   the half-created series folder is already in Drive and a plain re-run aborts
+   on the name collision. Don't trash the folder — re-run with `--resume`:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/create_series.py --series "Reading Group" --resume
+   ```
+   It enters the existing folder, skips every child whose (rebranded) name is
+   already present (logged `exists, skipped`), and clones/rebrands only what's
+   missing — so resuming a fully-cloned series is a no-op. It is also the
+   backfill path when an existing series folder is missing part of the template
+   (the Luxembourg-chapter situation, series-side). Note it matches by **name
+   only**: a present-but-corrupt file is skipped, not repaired.
+
 4. **Verify & hand off.** Confirm the run printed no `!! residual` flags and report
    the new folder URL. Remind the user to (a) fill the `[bracketed]` About-the-
    series blurb in `Event Tracker.docx`, and (b) create the Luma page if it wasn't
@@ -104,6 +119,7 @@ and check for residuals + that identity reads right:
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/create_series.py \
     --series "Reading Group" --rebrand-local /path/to/templateseries-copy
+python3 ${CLAUDE_SKILL_DIR}/scripts/test_create_series.py   # unit tests (offline)
 ```
 
 The template must stay "clean": `San Francisco` contiguous and the slug normalized

--- a/skills/aaif-create-online-series/scripts/create_series.py
+++ b/skills/aaif-create-online-series/scripts/create_series.py
@@ -256,6 +256,11 @@ def copy_file(file_id, name, parent):
                     params={"fileId": file_id, "supportsAllDrives": True},
                     body={"name": name, "parents": [parent]})["id"]
 
+def rename_file(file_id, name):
+    gws_json("drive", "files", "update",
+             params={"fileId": file_id, "supportsAllDrives": True},
+             body={"name": name})
+
 def luma_status(slug):
     """Return 'live' (HTTP 200), 'absent' (HTTP 404), or 'unknown' (could not
     verify: timeout, DNS/SSL, 403/429/5xx). Never report a hard 404 for a
@@ -276,9 +281,13 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent="", existing_id=None)
     """Recursively copy `folder_id` into `parent` as `name`, rebranding files.
 
     Under --resume, `existing_id` is an already-created target folder: it is
-    entered instead of recreated, its children are listed by (rebranded) name,
-    name-matching children are skipped, and only missing items are cloned — so
-    resuming into a fully-cloned folder is a no-op."""
+    entered instead of recreated, its children are listed, name-matching children
+    are skipped, and only missing items are cloned — so resuming into a
+    fully-cloned folder is a no-op. Matching is by rebranded OR original template
+    name (a survivor of the pre-rename engine is renamed in place, never
+    re-cloned as a duplicate), and every skipped Office file is residual-checked:
+    one that was copied but never rebranded — the likeliest crash state — is
+    repaired in place rather than trusted."""
     if existing_id:
         new_id = existing_id
         print("%s= %s/ (exists, resumed)" % (indent, name))
@@ -292,11 +301,50 @@ def clone_and_rebrand(folder_id, parent, name, ctx, indent="", existing_id=None)
         # Francisco CRM.xlsx" -> "Reading Group CRM.xlsx" — same transform as content.
         new_cname = transform_text(cname, ctx["name"], ctx["upper"], ctx["slug"])
         hit = have.get(new_cname)
+        if hit is None and new_cname != cname:
+            # A child cloned by the pre-rename engine (or a hand copy) still holds
+            # the ORIGINAL template name — treat it as a hit and rename it, or the
+            # backfill re-clones a duplicate (two CRMs; sync_crm picks the wrong one).
+            hit = have.get(cname)
+            if hit is not None:
+                rename_file(hit["id"], new_cname)
+                print("%s  ~ %s -> %s (renamed to rebranded name)"
+                      % (indent, cname, new_cname))
         if mime == FOLDER:
             clone_and_rebrand(cid, new_id, new_cname, ctx, indent + "  ",
                               existing_id=hit["id"] if hit and hit["mimeType"] == FOLDER else None)
         elif hit:
-            print("%s  - %s (exists, skipped)" % (indent, new_cname))
+            ext = os.path.splitext(cname)[1].lower()
+            if ext in MIME_BY_EXT:
+                # Never trust a skip on faith: the likeliest partial-run state is
+                # copied-under-the-new-name but never rebranded (crash between
+                # copy_file and gws_upload). Residual-check the EXISTING file, and
+                # repair a dirty one in place (download -> rebrand -> upload).
+                tmp = os.path.join(ctx["tmp"], "f" + hit["id"] + ext)
+                try:
+                    gws_download(hit["id"], tmp)
+                    left = residual_tokens(tmp)
+                    if left:
+                        n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
+                        if n:
+                            gws_upload(hit["id"], tmp, MIME_BY_EXT[ext])
+                        left = residual_tokens(tmp)
+                        if left:   # repair didn't clear it — fail the run like a clone would
+                            ctx["residuals"].append((new_cname, left))
+                            print("%s  - %s (exists, was not rebranded; repaired %d "
+                                  "parts)  !! residual (skipped) %s"
+                                  % (indent, new_cname, n, left))
+                        else:
+                            print("%s  - %s (exists, was not rebranded — repaired, "
+                                  "%d parts)" % (indent, new_cname, n))
+                    else:
+                        print("%s  - %s (exists, skipped — residual-checked clean)"
+                              % (indent, new_cname))
+                finally:
+                    if os.path.exists(tmp):
+                        os.remove(tmp)
+            else:
+                print("%s  - %s (exists, skipped)" % (indent, new_cname))
         else:
             copy_id = copy_file(cid, new_cname, new_id)
             ext = os.path.splitext(cname)[1].lower()

--- a/skills/aaif-create-online-series/scripts/create_series.py
+++ b/skills/aaif-create-online-series/scripts/create_series.py
@@ -120,6 +120,10 @@ def rebrand_part(part_name, data, name, upper, newslug):
         xml = _process_paragraphs(xml, "w:p", "w:t", tx)
     elif part_name == "xl/sharedStrings.xml":
         xml = _process_paragraphs(xml, "si", "t", tx)
+    elif re.match(r"xl/worksheets/sheet\d+\.xml$", part_name):
+        # Cells can hold inline strings (<is><t>...</t></is>) instead of a
+        # sharedStrings.xml reference — e.g. the CRM's "Guide" sheet title.
+        xml = _process_paragraphs(xml, "is", "t", tx)
     elif part_name in ("docProps/core.xml", "docProps/app.xml"):
         # metadata: labelled "AAIF SF" -> "AAIF <UPPER>"
         xml = xml.replace("AAIF SF", "AAIF " + upper)
@@ -134,37 +138,54 @@ def rebrand_part(part_name, data, name, upper, newslug):
         return data
     return xml.encode("utf-8")
 
-def rebrand_file(path, name, upper, newslug):
-    """Rewrite an .pptx/.docx/.xlsx in place. Returns number of parts changed."""
+def _rewrite_zip(path, transform):
+    """Rewrite an OOXML zip in place, mapping each member's bytes through
+    transform(name, data) -> bytes while preserving its ZipInfo, then validating
+    the repackaged zip with testzip(). Returns the number of members whose bytes
+    changed. On a bad repack, removes the temp file and raises (original intact)."""
     tmp = path + ".new"
-    zin = zipfile.ZipFile(path, "r")
-    zout = zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED)
     changed = 0
-    for it in zin.infolist():
-        data = zin.read(it.filename)
-        new = rebrand_part(it.filename, data, name, upper, newslug)
-        if new != data:
-            changed += 1
-        zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
-        zi.compress_type = it.compress_type
-        zi.external_attr = it.external_attr
-        zout.writestr(zi, new)
-    zin.close(); zout.close()
-    if zipfile.ZipFile(tmp).testzip() is not None:
-        os.remove(tmp); raise RuntimeError("repackaged zip failed validation: " + path)
-    os.replace(tmp, path)
+    try:
+        with zipfile.ZipFile(path) as zin, \
+                zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zout:
+            for it in zin.infolist():
+                data = zin.read(it.filename)
+                new = transform(it.filename, data)
+                if new != data:
+                    changed += 1
+                zi = zipfile.ZipInfo(it.filename, date_time=it.date_time)
+                zi.compress_type = it.compress_type
+                zi.external_attr = it.external_attr
+                zout.writestr(zi, new)
+        with zipfile.ZipFile(tmp) as zt:   # close the handle before os.replace
+            if zt.testzip() is not None:
+                raise RuntimeError("repackaged zip failed validation: " + path)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):   # cleared on success by os.replace; else a leftover
+            os.remove(tmp)
     return changed
 
+def rebrand_file(path, name, upper, newslug):
+    """Rewrite an .pptx/.docx/.xlsx in place. Returns number of parts changed."""
+    return _rewrite_zip(path, lambda n, d: rebrand_part(n, d, name, upper, newslug))
+
 def residual_tokens(path):
-    """List any stale San Francisco / SF / aaif-sf tokens still present."""
-    z = zipfile.ZipFile(path); hits = []
-    for n in z.namelist():
-        if not n.endswith((".xml", ".rels")):
-            continue
-        d = z.read(n)
-        for pat in (rb"San Francisco", rb"SAN FRANCISCO", rb"aaif-sf(?![a-z])", rb"\bSF\b"):
-            if re.search(pat, d, re.I):
-                hits.append((n.split("/")[-1], pat.decode("latin1")))
+    """List any stale San Francisco / SF / aaif-sf tokens still present. The city
+    name and slug are matched case-insensitively; the bare "SF" abbreviation is
+    matched case-SENSITIVELY (uppercase only) — theme/font XML legitimately holds
+    lowercase "sf" tokens that are not stale brand text."""
+    hits = []
+    with zipfile.ZipFile(path) as z:
+        for n in z.namelist():
+            if not n.endswith((".xml", ".rels")):
+                continue
+            d = z.read(n)
+            for pat, flags in ((rb"San Francisco", re.I),
+                               (rb"aaif-sf(?![a-z])", re.I),
+                               (rb"\bSF\b", 0)):
+                if re.search(pat, d, flags):
+                    hits.append((n.split("/")[-1], pat.decode("latin1")))
     return hits
 
 # ----------------------------------------------------------------------------
@@ -251,31 +272,51 @@ def luma_status(slug):
         return "unknown"
 
 # ----------------------------------------------------------------------------
-def clone_and_rebrand(folder_id, parent, name, ctx, indent=""):
-    """Recursively copy `folder_id` into `parent` as `name`, rebranding files."""
-    new_id = create_folder(name, parent)
-    print("%s+ %s/" % (indent, name))
+def clone_and_rebrand(folder_id, parent, name, ctx, indent="", existing_id=None):
+    """Recursively copy `folder_id` into `parent` as `name`, rebranding files.
+
+    Under --resume, `existing_id` is an already-created target folder: it is
+    entered instead of recreated, its children are listed by (rebranded) name,
+    name-matching children are skipped, and only missing items are cloned — so
+    resuming into a fully-cloned folder is a no-op."""
+    if existing_id:
+        new_id = existing_id
+        print("%s= %s/ (exists, resumed)" % (indent, name))
+    else:
+        new_id = create_folder(name, parent)
+        print("%s+ %s/" % (indent, name))
+    have = {c["name"]: c for c in list_children(new_id)} if existing_id else {}
     for child in list_children(folder_id):
         cname, cid, mime = child["name"], child["id"], child["mimeType"]
+        # Names (not just file content) can carry the source city, e.g. "San
+        # Francisco CRM.xlsx" -> "Reading Group CRM.xlsx" — same transform as content.
+        new_cname = transform_text(cname, ctx["name"], ctx["upper"], ctx["slug"])
+        hit = have.get(new_cname)
         if mime == FOLDER:
-            clone_and_rebrand(cid, new_id, cname, ctx, indent + "  ")
+            clone_and_rebrand(cid, new_id, new_cname, ctx, indent + "  ",
+                              existing_id=hit["id"] if hit and hit["mimeType"] == FOLDER else None)
+        elif hit:
+            print("%s  - %s (exists, skipped)" % (indent, new_cname))
         else:
-            copy_id = copy_file(cid, cname, new_id)
+            copy_id = copy_file(cid, new_cname, new_id)
             ext = os.path.splitext(cname)[1].lower()
             if ext in MIME_BY_EXT:
                 tmp = os.path.join(ctx["tmp"], "f" + copy_id + ext)
-                gws_download(copy_id, tmp)
-                n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
-                if n:
-                    gws_upload(copy_id, tmp, MIME_BY_EXT[ext])
-                left = residual_tokens(tmp)
-                if left:
-                    ctx["residuals"].append((cname, left))
-                flag = "  !! residual %s" % left if left else ""
-                print("%s  - %s (%d parts)%s" % (indent, cname, n, flag))
-                os.remove(tmp)
+                try:
+                    gws_download(copy_id, tmp)
+                    n = rebrand_file(tmp, ctx["name"], ctx["upper"], ctx["slug"])
+                    if n:
+                        gws_upload(copy_id, tmp, MIME_BY_EXT[ext])
+                    left = residual_tokens(tmp)
+                    if left:
+                        ctx["residuals"].append((new_cname, left))
+                    flag = "  !! residual %s" % left if left else ""
+                    print("%s  - %s (%d parts)%s" % (indent, new_cname, n, flag))
+                finally:
+                    if os.path.exists(tmp):
+                        os.remove(tmp)
             else:
-                print("%s  - %s (copied)" % (indent, cname))
+                print("%s  - %s (copied)" % (indent, new_cname))
     return new_id
 
 def main():
@@ -283,6 +324,10 @@ def main():
     ap.add_argument("--series", required=True, help='Series display name, e.g. "Reading Group" or "Online Reading Group"')
     ap.add_argument("--slug", help="Luma slug override (default: series, lowercased, no spaces)")
     ap.add_argument("--dry-run", action="store_true", help="Plan only; create nothing")
+    ap.add_argument("--resume", action="store_true",
+                    help="Enter an existing target folder instead of aborting: skip "
+                         "name-matching children and clone only what's missing "
+                         "(recovery for a failed/partial run)")
     ap.add_argument("--rebrand-local", metavar="DIR",
                     help="Rebrand .pptx/.docx/.xlsx in a local dir (no Drive); for testing")
     a = ap.parse_args()
@@ -318,11 +363,23 @@ def main():
 
     existing = [c for c in list_children(ONLINE_PARENT)
                 if c["name"].lower() == name.lower() and c["mimeType"] == FOLDER]
+    resume_id = None
     if existing:
-        sys.exit("ABORT: an Online series folder named %r already exists (%s)" % (name, existing[0]["id"]))
+        if a.resume:
+            resume_id = existing[0]["id"]
+            print("Resume: entering existing folder %s — children already present "
+                  "are skipped; only missing items are cloned." % resume_id)
+        else:
+            sys.exit("ABORT: an Online series folder named %r already exists (%s). "
+                     "To fill in missing items from a failed/partial run, re-run "
+                     "with --resume." % (name, existing[0]["id"]))
 
     if a.dry_run:
-        print("\n[dry-run] Would clone TemplateSeries -> %r under Online and rebrand all files." % name)
+        if resume_id:
+            print("\n[dry-run] Would resume into the existing %r folder under Online "
+                  "and clone only the missing items." % name)
+        else:
+            print("\n[dry-run] Would clone TemplateSeries -> %r under Online and rebrand all files." % name)
         if status == "absent":
             print("[dry-run] WARNING: Luma page aaif-%s is not live yet." % slug)
         elif status == "unknown":
@@ -333,7 +390,8 @@ def main():
            "tmp": os.path.join(os.environ.get("TMPDIR", "/tmp"), "aaif_series")}
     os.makedirs(ctx["tmp"], exist_ok=True)
     print()
-    new_id = clone_and_rebrand(TEMPLATE_FOLDER, ONLINE_PARENT, name, ctx)
+    new_id = clone_and_rebrand(TEMPLATE_FOLDER, ONLINE_PARENT, name, ctx,
+                               existing_id=resume_id)
     print("\nDone. New series folder id: %s" % new_id)
     print("https://drive.google.com/drive/folders/%s" % new_id)
     print("REMINDER: fill the [bracketed] series blurb in Event Tracker.docx (the template ships a placeholder).")

--- a/skills/aaif-create-online-series/scripts/test_create_series.py
+++ b/skills/aaif-create-online-series/scripts/test_create_series.py
@@ -139,11 +139,13 @@ class TestRewriteZip(unittest.TestCase):
 
 
 class FakeDrive:
-    """In-memory Drive: {folder_id: [child dicts]}. Records creates/copies."""
+    """In-memory Drive: {folder_id: [child dicts]}. Records creates/copies/
+    renames/uploads."""
 
     def __init__(self, folders):
         self.folders = {k: list(v) for k, v in folders.items()}
-        self.created, self.copied, self.next = [], [], 0
+        self.created, self.copied, self.renamed, self.uploaded = [], [], [], []
+        self.next = 0
 
     def list_children(self, fid):
         return list(self.folders.get(fid, []))
@@ -165,12 +167,33 @@ class FakeDrive:
         self.copied.append(name)
         return fid
 
+    def rename_file(self, fid, name):
+        for kids in self.folders.values():
+            for c in kids:
+                if c["id"] == fid:
+                    c["name"] = name
+        self.renamed.append((fid, name))
+
 
 def fake_download(_file_id, out):
     """Every downloaded Office file is a minimal xlsx whose sharedStrings carries
-    the source name — the real rebrand engine then runs on it, offline."""
+    the source name — the real rebrand engine then runs on it, offline. Under
+    --resume this doubles as the copied-but-never-rebranded crash state."""
     make_zip(out, {"xl/sharedStrings.xml":
                    "<sst><si><t>San Francisco</t></si></sst>"})
+
+
+def clean_download(_file_id, out):
+    """An already-rebranded file — what a healthy resume skip downloads."""
+    make_zip(out, {"xl/sharedStrings.xml":
+                   "<sst><si><t>Reading Group</t></si></sst>"})
+
+
+def sticky_download(_file_id, out):
+    """A residual the rebrand engine can NOT rewrite (lowercase city name is a
+    case-insensitive residual hit but not a transform_text token)."""
+    make_zip(out, {"xl/sharedStrings.xml":
+                   "<sst><si><t>visit san francisco</t></si></sst>"})
 
 
 TEMPLATE = {
@@ -189,15 +212,17 @@ class TestCloneResume(unittest.TestCase):
     """clone_and_rebrand with the Drive layer faked — covers the --resume
     skip-by-name decision (network paths excluded by design)."""
 
-    def run_clone(self, drive, existing_id=None):
+    def run_clone(self, drive, existing_id=None, download=fake_download):
         ctx = {"name": "Reading Group", "upper": "READING GROUP",
                "slug": "readinggroup", "residuals": [], "latlon": None}
         with tempfile.TemporaryDirectory() as d, \
                 mock.patch.object(cs, "list_children", drive.list_children), \
                 mock.patch.object(cs, "create_folder", drive.create_folder), \
                 mock.patch.object(cs, "copy_file", drive.copy_file), \
-                mock.patch.object(cs, "gws_download", fake_download), \
-                mock.patch.object(cs, "gws_upload", lambda *a, **k: None):
+                mock.patch.object(cs, "rename_file", drive.rename_file), \
+                mock.patch.object(cs, "gws_download", download), \
+                mock.patch.object(cs, "gws_upload",
+                                  lambda fid, path, mime: drive.uploaded.append(fid)):
             ctx["tmp"] = d
             return cs.clone_and_rebrand("tpl", "parent", "Reading Group", ctx,
                                         existing_id=existing_id), ctx
@@ -214,10 +239,13 @@ class TestCloneResume(unittest.TestCase):
             "ex": [{"id": "e1", "name": "Reading Group CRM.xlsx",
                     "mimeType": "application/x-copied"}],
         }))
-        self.run_clone(drive, existing_id="ex")
+        _, ctx = self.run_clone(drive, existing_id="ex", download=clean_download)
         # the already-present (rebranded-name) file is skipped; the rest cloned
         self.assertEqual(sorted(drive.copied), ["About.txt", "notes.txt"])
         self.assertEqual(drive.created, ["Event Template"])
+        # the clean skip was residual-checked but not touched
+        self.assertEqual(drive.uploaded, [])
+        self.assertEqual(ctx["residuals"], [])
 
     def test_resume_into_fully_cloned_folder_is_a_noop(self):
         drive = FakeDrive(dict(TEMPLATE, **{
@@ -228,10 +256,11 @@ class TestCloneResume(unittest.TestCase):
             ],
             "esub": [{"id": "e3", "name": "notes.txt", "mimeType": "application/x-copied"}],
         }))
-        new_id, _ = self.run_clone(drive, existing_id="ex")
+        new_id, _ = self.run_clone(drive, existing_id="ex", download=clean_download)
         self.assertEqual(new_id, "ex")
         self.assertEqual(drive.copied, [])
         self.assertEqual(drive.created, [])
+        self.assertEqual(drive.uploaded, [])
 
     def test_resume_recurses_into_partial_subfolder(self):
         # subfolder exists but is empty -> re-entered, its missing child cloned
@@ -246,6 +275,57 @@ class TestCloneResume(unittest.TestCase):
         self.run_clone(drive, existing_id="ex")
         self.assertEqual(drive.copied, ["notes.txt"])
         self.assertEqual(drive.created, [])
+
+    def test_resume_repairs_a_skipped_but_unrebranded_file(self):
+        # The likeliest partial-run state: copied under the rebranded name, crash
+        # before the rebrand's upload. The skip must residual-check the existing
+        # file and repair it in place — not report "exists, skipped" on
+        # wrong-name content.
+        drive = FakeDrive(dict(TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "Reading Group CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        _, ctx = self.run_clone(drive, existing_id="ex")  # fake_download = SF content
+        self.assertNotIn("Reading Group CRM.xlsx", drive.copied)  # still a skip
+        self.assertIn("e1", drive.uploaded)                   # repaired in place
+        self.assertEqual(ctx["residuals"], [])                # flag cleared by repair
+
+    def test_resume_flags_a_skip_the_repair_cannot_clean(self):
+        # A residual the rebrand engine can't rewrite must survive as a flag and
+        # fail the run — exactly as it would on a fresh clone.
+        drive = FakeDrive(dict(TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "Reading Group CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        _, ctx = self.run_clone(drive, existing_id="ex", download=sticky_download)
+        self.assertEqual([fn for fn, _ in ctx["residuals"]], ["Reading Group CRM.xlsx"])
+
+    def test_resume_matches_original_name_file_and_renames(self):
+        # A survivor of the pre-rename engine holds the ORIGINAL template name —
+        # it must be renamed and treated as a hit, never re-cloned as a duplicate
+        # (two CRMs would send sync_crm's find_crm to the wrong one).
+        drive = FakeDrive(dict(TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "San Francisco CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        _, ctx = self.run_clone(drive, existing_id="ex")
+        self.assertEqual(sorted(drive.copied), ["About.txt", "notes.txt"])
+        self.assertEqual(drive.renamed, [("e1", "Reading Group CRM.xlsx")])
+        self.assertIn("e1", drive.uploaded)     # and residual-checked -> repaired
+        self.assertEqual(ctx["residuals"], [])
+
+    def test_resume_matches_original_name_subfolder_and_renames(self):
+        drive = FakeDrive({
+            "tpl": [{"id": "sub", "name": "SF Assets", "mimeType": cs.FOLDER}],
+            "sub": [{"id": "f3", "name": "notes.txt", "mimeType": "application/x"}],
+            "ex": [{"id": "esub", "name": "SF Assets", "mimeType": cs.FOLDER}],
+            "esub": [{"id": "e3", "name": "notes.txt",
+                      "mimeType": "application/x-copied"}],
+        })
+        self.run_clone(drive, existing_id="ex")
+        self.assertEqual(drive.copied, [])        # recursed into the renamed hit
+        self.assertEqual(drive.created, [])
+        self.assertEqual(drive.renamed, [("esub", "Reading Group Assets")])
 
 
 class TestRebrandFileCleansTemp(unittest.TestCase):

--- a/skills/aaif-create-online-series/scripts/test_create_series.py
+++ b/skills/aaif-create-online-series/scripts/test_create_series.py
@@ -1,0 +1,266 @@
+"""Unit tests for the rebrand engine + resume logic in create_series.py.
+
+The engine is a deliberate copy of aaif-create-chapter's (see the comment in
+create_series.py) — these tests keep the copy honest, covering the pieces that
+once drifted: the worksheets inline-string branch, child-name rebranding, the
+residual-token check, and the hardened zip rewrite. All offline, synthetic data
+only.
+
+Run: python3 skills/aaif-create-online-series/scripts/test_create_series.py
+"""
+import os
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+import create_series as cs  # noqa: E402
+
+
+def make_zip(path, members):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, data in members.items():
+            z.writestr(name, data)
+
+
+class TestTransformText(unittest.TestCase):
+    """transform_text() on filename-shaped strings — child NAMES are rebranded
+    with the same transform as content (a template file named "SF …" must clone
+    renamed)."""
+
+    def test_full_name_in_filename(self):
+        self.assertEqual(
+            cs.transform_text("San Francisco CRM.xlsx", "Reading Group", "READING GROUP", "readinggroup"),
+            "Reading Group CRM.xlsx")
+
+    def test_bare_sf_abbreviation_in_filename(self):
+        self.assertEqual(
+            cs.transform_text("SF Kickoff Deck.pptx", "Reading Group", "READING GROUP", "readinggroup"),
+            "Reading Group Kickoff Deck.pptx")
+
+    def test_luma_slug_in_filename(self):
+        self.assertEqual(
+            cs.transform_text("aaif-sanfrancisco-banner.png", "Reading Group", "READING GROUP", "readinggroup"),
+            "aaif-readinggroup-banner.png")
+
+    def test_filename_with_no_source_tokens_is_unchanged(self):
+        self.assertEqual(
+            cs.transform_text("About.docx", "Reading Group", "READING GROUP", "readinggroup"),
+            "About.docx")
+
+
+class TestRebrandWorksheetInlineStrings(unittest.TestCase):
+    """Regression test for the xl/worksheets/sheetN.xml branch of rebrand_part:
+    cells can hold an inline string (<is><t>...</t></is>) instead of a
+    sharedStrings.xml reference, e.g. the CRM's "Guide" sheet title — the stale
+    fork of this engine left those untouched."""
+
+    SHEET_XML = (
+        '<worksheet><sheetData><row r="2">'
+        '<c r="B2" t="inlineStr"><is><t>AAIF SF — Attendee CRM</t></is></c>'
+        '</row></sheetData></worksheet>'
+    )
+
+    def test_inline_string_cell_is_rebranded(self):
+        out = cs.rebrand_part("xl/worksheets/sheet2.xml", self.SHEET_XML.encode("utf-8"),
+                              "Reading Group", "READING GROUP", "readinggroup")
+        text = out.decode("utf-8")
+        self.assertIn("AAIF Reading Group — Attendee CRM", text)
+        self.assertNotIn(">AAIF SF", text)
+
+    def test_unrelated_part_type_is_left_untouched(self):
+        out = cs.rebrand_part("xl/drawings/drawing1.xml",
+                              self.SHEET_XML.encode("utf-8"),
+                              "Reading Group", "READING GROUP", "readinggroup")
+        self.assertEqual(out, self.SHEET_XML.encode("utf-8"))
+
+
+class TestResidualTokens(unittest.TestCase):
+    def check(self, content, expect_hit):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"xl/theme/theme1.xml": content})
+            hits = cs.residual_tokens(p)
+            if expect_hit:
+                self.assertTrue(hits, "expected a residual hit for %r" % content)
+            else:
+                self.assertEqual(hits, [], "false positive for %r" % content)
+
+    def test_city_name_is_case_insensitive(self):
+        self.check(b"visit san francisco soon", True)
+        self.check(b"SAN FRANCISCO tonight", True)
+
+    def test_slug_is_case_insensitive(self):
+        self.check(b"https://luma.com/aaif-SF", True)
+
+    def test_uppercase_sf_hits(self):
+        self.check(b"AAIF SF CHAPTER", True)
+
+    def test_lowercase_sf_token_does_not_false_positive(self):
+        # theme/font XML holds lowercase "sf" tokens that are not brand text
+        self.check(b'<a:latin typeface="sf pro display"/>', False)
+
+    def test_duplicate_city_pattern_removed(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"xl/theme/theme1.xml": b"San Francisco SAN FRANCISCO"})
+            # one hit for the (case-insensitive) city pattern, not two duplicates
+            self.assertEqual(len(cs.residual_tokens(p)), 1)
+
+
+class TestRewriteZip(unittest.TestCase):
+    def test_success_replaces_in_place_and_counts(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"a.xml": b"old", "b.xml": b"keep"})
+            n = cs._rewrite_zip(p, lambda name, data: b"new" if name == "a.xml" else data)
+            self.assertEqual(n, 1)
+            self.assertFalse(os.path.exists(p + ".new"))
+            with zipfile.ZipFile(p) as z:
+                self.assertEqual(z.read("a.xml"), b"new")
+                self.assertEqual(z.read("b.xml"), b"keep")
+
+    def test_mid_loop_failure_cleans_temp_and_keeps_original(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"a.xml": b"one", "b.xml": b"two"})
+
+            def boom(name, data):
+                if name == "b.xml":
+                    raise RuntimeError("transform failed")
+                return data
+            with self.assertRaises(RuntimeError):
+                cs._rewrite_zip(p, boom)
+            self.assertFalse(os.path.exists(p + ".new"))   # no leftover temp
+            with zipfile.ZipFile(p) as z:                  # original intact
+                self.assertEqual(z.read("a.xml"), b"one")
+
+
+class FakeDrive:
+    """In-memory Drive: {folder_id: [child dicts]}. Records creates/copies."""
+
+    def __init__(self, folders):
+        self.folders = {k: list(v) for k, v in folders.items()}
+        self.created, self.copied, self.next = [], [], 0
+
+    def list_children(self, fid):
+        return list(self.folders.get(fid, []))
+
+    def create_folder(self, name, parent):
+        self.next += 1
+        fid = "fld%d" % self.next
+        self.folders.setdefault(parent, []).append(
+            {"id": fid, "name": name, "mimeType": cs.FOLDER})
+        self.folders[fid] = []
+        self.created.append(name)
+        return fid
+
+    def copy_file(self, src, name, parent):
+        self.next += 1
+        fid = "cp%d" % self.next
+        self.folders.setdefault(parent, []).append(
+            {"id": fid, "name": name, "mimeType": "application/x-copied"})
+        self.copied.append(name)
+        return fid
+
+
+def fake_download(_file_id, out):
+    """Every downloaded Office file is a minimal xlsx whose sharedStrings carries
+    the source name — the real rebrand engine then runs on it, offline."""
+    make_zip(out, {"xl/sharedStrings.xml":
+                   "<sst><si><t>San Francisco</t></si></sst>"})
+
+
+TEMPLATE = {
+    "tpl": [
+        {"id": "f1", "name": "San Francisco CRM.xlsx", "mimeType": "application/x"},
+        {"id": "f2", "name": "About.txt", "mimeType": "application/x"},
+        {"id": "sub", "name": "Event Template", "mimeType": cs.FOLDER},
+    ],
+    "sub": [
+        {"id": "f3", "name": "notes.txt", "mimeType": "application/x"},
+    ],
+}
+
+
+class TestCloneResume(unittest.TestCase):
+    """clone_and_rebrand with the Drive layer faked — covers the --resume
+    skip-by-name decision (network paths excluded by design)."""
+
+    def run_clone(self, drive, existing_id=None):
+        ctx = {"name": "Reading Group", "upper": "READING GROUP",
+               "slug": "readinggroup", "residuals": [], "latlon": None}
+        with tempfile.TemporaryDirectory() as d, \
+                mock.patch.object(cs, "list_children", drive.list_children), \
+                mock.patch.object(cs, "create_folder", drive.create_folder), \
+                mock.patch.object(cs, "copy_file", drive.copy_file), \
+                mock.patch.object(cs, "gws_download", fake_download), \
+                mock.patch.object(cs, "gws_upload", lambda *a, **k: None):
+            ctx["tmp"] = d
+            return cs.clone_and_rebrand("tpl", "parent", "Reading Group", ctx,
+                                        existing_id=existing_id), ctx
+
+    def test_fresh_clone_renames_children(self):
+        drive = FakeDrive(TEMPLATE)
+        self.run_clone(drive)
+        self.assertEqual(sorted(drive.copied),
+                         ["About.txt", "Reading Group CRM.xlsx", "notes.txt"])
+        self.assertEqual(sorted(drive.created), ["Event Template", "Reading Group"])
+
+    def test_resume_skips_existing_and_clones_missing(self):
+        drive = FakeDrive(dict(TEMPLATE, **{
+            "ex": [{"id": "e1", "name": "Reading Group CRM.xlsx",
+                    "mimeType": "application/x-copied"}],
+        }))
+        self.run_clone(drive, existing_id="ex")
+        # the already-present (rebranded-name) file is skipped; the rest cloned
+        self.assertEqual(sorted(drive.copied), ["About.txt", "notes.txt"])
+        self.assertEqual(drive.created, ["Event Template"])
+
+    def test_resume_into_fully_cloned_folder_is_a_noop(self):
+        drive = FakeDrive(dict(TEMPLATE, **{
+            "ex": [
+                {"id": "e1", "name": "Reading Group CRM.xlsx", "mimeType": "application/x-copied"},
+                {"id": "e2", "name": "About.txt", "mimeType": "application/x-copied"},
+                {"id": "esub", "name": "Event Template", "mimeType": cs.FOLDER},
+            ],
+            "esub": [{"id": "e3", "name": "notes.txt", "mimeType": "application/x-copied"}],
+        }))
+        new_id, _ = self.run_clone(drive, existing_id="ex")
+        self.assertEqual(new_id, "ex")
+        self.assertEqual(drive.copied, [])
+        self.assertEqual(drive.created, [])
+
+    def test_resume_recurses_into_partial_subfolder(self):
+        # subfolder exists but is empty -> re-entered, its missing child cloned
+        drive = FakeDrive(dict(TEMPLATE, **{
+            "ex": [
+                {"id": "e1", "name": "Reading Group CRM.xlsx", "mimeType": "application/x-copied"},
+                {"id": "e2", "name": "About.txt", "mimeType": "application/x-copied"},
+                {"id": "esub", "name": "Event Template", "mimeType": cs.FOLDER},
+            ],
+            "esub": [],
+        }))
+        self.run_clone(drive, existing_id="ex")
+        self.assertEqual(drive.copied, ["notes.txt"])
+        self.assertEqual(drive.created, [])
+
+
+class TestRebrandFileCleansTemp(unittest.TestCase):
+    def test_rebrand_file_end_to_end(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "t.xlsx")
+            make_zip(p, {"xl/sharedStrings.xml":
+                         "<sst><si><t>San Francisco</t></si></sst>"})
+            n = cs.rebrand_file(p, "Reading Group", "READING GROUP", "readinggroup")
+            self.assertEqual(n, 1)
+            self.assertEqual(cs.residual_tokens(p), [])
+            with zipfile.ZipFile(p) as z:
+                self.assertIn("Reading Group",
+                              z.read("xl/sharedStrings.xml").decode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-dayof-slides/SKILL.md
+++ b/skills/aaif-dayof-slides/SKILL.md
@@ -35,15 +35,15 @@ then the fields, slide for slide, then paste into the template.
 - Host : `[HOST VENUE]`   Members: `[MEMBER LOGOS]`
 - Speakers : `[FOR EACH: NAME | ROLE | TALK or DEMO | "QUOTE"]`
 - Agenda : `[RUN-OF-SHOW: TIME | BLOCK | NOTE]`
-- Next : `[NEXT EVENT + DATE]`   Links: `[LUMA / DISCORD / NEWSLETTER]`
+- Next : `[NEXT EVENT + DATE]`   Links: `[LUMA / SLACK / NEWSLETTER]`
 
 ## Slides (in order)
 ```
- 1 Cover            6 Tonight's theme    11 Demo lineup
- 2 Welcome          7 Run-of-show        12 Thank you
- 3 About AAIF[FIXED]8 On mic (speakers)  13 Join the chapter
- 4 Local chapter    9 Talk one           14 Networking
- 5 Network [FIXED] 10 Demos              15 Next up
+ 1 Cover                  6 Tonight's theme      11 Demo lineup
+ 2 Welcome                7 Run-of-show          12 Thank you
+ 3 About AAIF [FIXED]     8 On mic (speakers)    13 Join the chapter
+ 4 Local chapter          9 Talk one             14 Networking
+ 5 Network [FIXED]       10 Demos                15 Next up
 ```
 
 ## Example (tested — match this format and voice; abbreviated)
@@ -51,7 +51,7 @@ Agentic AI Night:
 
 > **Slide 1 — Cover:**
 >   Kicker: THE AAIF COMMUNITY · Title: Agentic AI Night. · Sub: Launch Series —
->   San Francisco · Date: TUE — JUNE 24, 2026 — 17:30 — LATE · Hosted by: Host
+>   San Francisco · Date: WED — JUNE 24, 2026 — 17:30 — LATE · Hosted by: Host
 >   Venue Co. · With: [member logos]
 >
 > **Slide 6 — Tonight's theme:**

--- a/skills/aaif-event-status/scripts/luma_stats.py
+++ b/skills/aaif-event-status/scripts/luma_stats.py
@@ -39,7 +39,7 @@ def stats_for_tracker(docx, event_filter):
     refs = tracker.list_events(root)
     if event_filter:
         refs = [e for e in refs if event_filter.lower() in e["title"].lower()]
-    shown, errors = 0, 0
+    errors = 0
     for ref in refs:
         view = tracker.view_event(ref)
         cell = (view["details"].get("LUMA URL") or "").strip()
@@ -60,12 +60,11 @@ def stats_for_tracker(docx, event_filter):
             errors += 1
             continue
         print_stats(live, label=view["title"])
-        shown += 1
     if not refs:
         print("No matching events in %s." % docx)
     if errors:
         print("!! %d event(s) errored — stats above are incomplete." % errors)
-    return shown, errors
+    return errors
 
 
 def main():
@@ -82,12 +81,19 @@ def main():
               "Read the numbers off the event page manually, or set up the key "
               "(see aaif-create-event's SKILL.md).")
         return
-    if a.event_id:
-        print_stats(luma.get_event(a.event_id))
-    elif a.url:
-        print_stats(luma.get_event(luma.resolve_event_id(a.url)))
+    # The direct paths get the same clean messages as the tracker loop — a bad
+    # id/URL or a network failure must not surface as a raw traceback.
+    if a.event_id or a.url:
+        try:
+            event_id = a.event_id or luma.resolve_event_id(a.url)
+            print_stats(luma.get_event(event_id))
+        except luma.NotAnEventUrl:
+            sys.exit("!! %s doesn't point to an event page — likely a calendar "
+                     "link; pass the event's own URL or --event-id." % a.url)
+        except luma.LumaError as e:
+            sys.exit("!! %s" % e)
     elif a.docx:
-        _, errors = stats_for_tracker(a.docx, a.event)
+        errors = stats_for_tracker(a.docx, a.event)
         if errors:
             sys.exit(1)   # partial digest — don't let the caller read it as complete
     else:

--- a/skills/aaif-event-status/scripts/test_luma_stats.py
+++ b/skills/aaif-event-status/scripts/test_luma_stats.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Unit tests for luma_stats.py's error contracts (offline — luma and the
+tracker layer are mocked; no network, no Drive).
+
+What must hold: a bad URL or a Luma failure surfaces as a clean sys.exit
+message, never a raw traceback, and a tracker digest with any errored event
+exits 1 so a partial digest can't read as complete.
+
+Run: python3 skills/aaif-event-status/scripts/test_luma_stats.py
+"""
+import contextlib
+import io
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 "..", "..", "..", "lib")))
+sys.path.insert(0, os.path.dirname(__file__))
+import luma_stats  # noqa: E402
+from aaif_events import luma  # noqa: E402
+
+fails = 0
+def check(label, got, want):
+    global fails
+    ok = got == want
+    fails += 0 if ok else 1
+    print("%s %s" % ("ok  " if ok else "FAIL", label))
+    if not ok:
+        print("      got : %r\n      want: %r" % (got, want))
+
+
+LIVE = {"name": "Eval Night", "url": "https://luma.com/evt", "start_at": "2026-09-01",
+        "timezone": "UTC", "registration_open": True, "waitlist_status": "off",
+        "guest_counts": {"approved": {"guests": 12}}}
+
+
+def run_main(argv, **luma_attrs):
+    """Run main() with sys.argv patched and the given luma attributes mocked
+    (available() always True). Returns (SystemExit-or-None, stdout)."""
+    buf = io.StringIO()
+    patches = [mock.patch.object(sys, "argv", ["luma_stats.py"] + argv),
+               mock.patch.object(luma, "available", lambda: True)]
+    patches += [mock.patch.object(luma, k, v) for k, v in luma_attrs.items()]
+    exc = None
+    with contextlib.ExitStack() as st:
+        for p in patches:
+            st.enter_context(p)
+        st.enter_context(contextlib.redirect_stdout(buf))
+        try:
+            luma_stats.main()
+        except SystemExit as e:
+            exc = e
+    return exc, buf.getvalue()
+
+
+def _raise(e):
+    def f(*_a, **_k):
+        raise e
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Direct --url / --event-id paths: clean sys.exit messages, no tracebacks
+# ---------------------------------------------------------------------------
+def test_url_not_an_event_page_exits_cleanly():
+    exc, _ = run_main(["--url", "https://luma.com/aaif-sanjose"],
+                      resolve_event_id=_raise(luma.NotAnEventUrl("calendar link")))
+    check("NotAnEventUrl exits via SystemExit", isinstance(exc, SystemExit), True)
+    check("NotAnEventUrl message names the problem",
+          "doesn't point to an event page" in str(exc.code), True)
+
+def test_luma_error_exits_with_bang_message():
+    exc, _ = run_main(["--event-id", "evt-x"],
+                      get_event=_raise(luma.LumaError("HTTP 500 from Luma")))
+    check("LumaError exits via SystemExit", isinstance(exc, SystemExit), True)
+    check("LumaError message is the '!! ' form",
+          str(exc.code).startswith("!! "), True)
+    check("LumaError message carries the cause",
+          "HTTP 500 from Luma" in str(exc.code), True)
+
+def test_happy_direct_path_prints_stats_and_exits_zero():
+    exc, out = run_main(["--event-id", "evt-x"], get_event=lambda _id: dict(LIVE))
+    check("happy path does not exit", exc, None)
+    check("happy path prints the going count", "going: 12" in out, True)
+
+
+# ---------------------------------------------------------------------------
+# stats_for_tracker: per-event errors count, partial digest never reads complete
+# ---------------------------------------------------------------------------
+def run_tracker(views, **luma_attrs):
+    """Run stats_for_tracker over synthetic tracker views (title -> LUMA URL)."""
+    refs = [{"title": t} for t in views]
+    buf = io.StringIO()
+    with contextlib.ExitStack() as st:
+        st.enter_context(mock.patch.object(luma_stats.office, "read_document",
+                                           lambda _p: object()))
+        st.enter_context(mock.patch.object(luma_stats.tracker, "list_events",
+                                           lambda _r: refs))
+        st.enter_context(mock.patch.object(
+            luma_stats.tracker, "view_event",
+            lambda ref: {"title": ref["title"],
+                         "details": {"LUMA URL": views[ref["title"]]}}))
+        for k, v in luma_attrs.items():
+            st.enter_context(mock.patch.object(luma, k, v))
+        st.enter_context(contextlib.redirect_stdout(buf))
+        errors = luma_stats.stats_for_tracker("t.docx", None)
+    return errors, buf.getvalue()
+
+def test_tracker_luma_error_counts_and_flags():
+    errors, out = run_tracker(
+        {"A": "https://luma.com/a", "B": "https://luma.com/b"},
+        resolve_event_id=lambda url: url,
+        get_event=lambda url: dict(LIVE) if url.endswith("/a")
+        else (_ for _ in ()).throw(luma.LumaError("timeout")))
+    check("errored event counted", errors, 1)
+    check("errored event printed with '!! '", "!! timeout" in out, True)
+    check("digest is marked incomplete", "stats above are incomplete" in out, True)
+    check("healthy event still printed", "going: 12" in out, True)
+
+def test_tracker_not_an_event_url_is_not_an_error():
+    errors, out = run_tracker(
+        {"A": "https://luma.com/aaif-sanjose"},
+        resolve_event_id=_raise(luma.NotAnEventUrl("calendar")))
+    check("calendar-link cell is not an error", errors, 0)
+    check("calendar-link cell explained", "not pushed to Luma yet" in out, True)
+
+def test_main_exits_1_on_partial_tracker_digest():
+    # the exit-1 contract: any errored event in the docx path exits nonzero.
+    with mock.patch.object(luma_stats, "stats_for_tracker", lambda d, e: 1):
+        exc, _ = run_main(["t.docx"])
+    check("partial digest exits", isinstance(exc, SystemExit), True)
+    check("partial digest exit code is 1", exc.code, 1)
+    with mock.patch.object(luma_stats, "stats_for_tracker", lambda d, e: 0):
+        exc, _ = run_main(["t.docx"])
+    check("complete digest does not exit", exc, None)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_"):
+            fn()
+    if fails:
+        sys.exit(1)
+    print("all ok")

--- a/skills/aaif-luma-description/SKILL.md
+++ b/skills/aaif-luma-description/SKILL.md
@@ -16,7 +16,7 @@ builder-to-builder. Signal, not numbers.
 
 **Standard footer (always include).** Close with the two standing AAIF attendee
 links — these are defaults on every event page:
-- Code of Conduct — https://events.linuxfoundation.org/about/code-of-conduct/
+- Code of Conduct — https://events.linuxfoundation.org/about/code-of-conduct
 - Privacy Policy — https://www.linuxfoundation.org/legal/privacy-policy
 
 One quiet line is enough; it sits below the vendor-neutral line, not in the body.
@@ -46,5 +46,5 @@ Agentic AI Night:
 > Curated, RSVP-based — signal, not numbers.
 >
 > By attending you agree to our Code of Conduct
-> (events.linuxfoundation.org/about/code-of-conduct) and Privacy Policy
-> (linuxfoundation.org/legal/privacy-policy).
+> (https://events.linuxfoundation.org/about/code-of-conduct) and Privacy Policy
+> (https://www.linuxfoundation.org/legal/privacy-policy).

--- a/skills/aaif-recap-post/SKILL.md
+++ b/skills/aaif-recap-post/SKILL.md
@@ -13,6 +13,11 @@ not promotional, **one emoji max**.
 
 **House voice:** share the practice, never sell the product. Signal, not numbers.
 
+**Standard footer (always include).** Below the next-event line, add one quiet
+line with the two standing AAIF attendee links (defaults on every recap):
+Code of Conduct (https://events.linuxfoundation.org/about/code-of-conduct) and
+Privacy Policy (https://www.linuxfoundation.org/legal/privacy-policy).
+
 ## Input (from the event tracker)
 - Event/speaker : `[EVENT TITLE] — [SPEAKER + TOPIC]`
 - Thank : `[VENUE / HOST]`
@@ -34,3 +39,6 @@ Agentic AI Night:
 > this vendor-neutral.
 >
 > Next: "AI in Finance," July 22 → lu.ma/aaif-sanfrancisco
+>
+> Code of Conduct: https://events.linuxfoundation.org/about/code-of-conduct ·
+> Privacy: https://www.linuxfoundation.org/legal/privacy-policy

--- a/skills/aaif-speaker-bio/SKILL.md
+++ b/skills/aaif-speaker-bio/SKILL.md
@@ -29,7 +29,7 @@ Maya Chen, Agentic AI Night:
 > tool-calling agents reliable once they leave the demo and hit real traffic. The
 > past year she has lived in what changes past ten million tool calls a day —
 > retries, idempotency, and the failure modes nobody warns you about. She brings
-> those lessons back to the community. At @mayabuilds.
+> those lessons back to the community, and shares her notes at @mayabuilds.
 >
 > **One-liner:** Maya Chen, Staff Engineer on payments — tool calling at scale,
 > and what broke at 10M requests a day.

--- a/skills/aaif-speaker-invite/SKILL.md
+++ b/skills/aaif-speaker-invite/SKILL.md
@@ -23,7 +23,7 @@ Maya Chen, Agentic AI Night:
 
 > Hi Maya — I help run AAIF San Francisco, a curated, vendor-neutral event for
 > people building agents (no pitches, just folks who ship). I'd love to have you
-> open our June night with a 25-minute talk on tool calling at scale — Tue June
+> open our June night with a 25-minute talk on tool calling at scale — Wed June
 > 24, evening, in SoMa, ~120 builders. Slides optional; a live walkthrough works
-> great too. Happy to flex on the date if that week's tight. Would June 24 work
-> for you?
+> great too. Would June 24 work for you? If that week's tight, happy to flex on
+> the date.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -210,7 +210,13 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
   chars, gets its row skipped with a loud per-row line (row, city, reason) while
   every other row still syncs — one hostile or fat-fingered submission must not
   freeze the whole engine, but a flagged value still reaches no cell, About doc
-  or CRM until the intake row is fixed.
+  or CRM until the intake row is fixed. The CRM engine enforces the same check
+  itself (`sync_crm.read_role_tab` reads the role tabs directly, not through
+  this engine's intake read). And because `sync_about` rewrites its section
+  **wholesale**, a chapter whose roster lost a row to this filter has its whole
+  About doc **held back** — not planned, not written, exit non-zero — rather
+  than rewritten minus the excluded organizer, which would silently delete an
+  accepted person from a shared doc over a data bug in their row.
 - **The run aborts rather than guessing** when: a header is duplicated (reads and
   writes would resolve to different columns); any written column is missing; a row
   below the last City row is non-empty (new rows are appended there and would wipe
@@ -303,6 +309,12 @@ are itemised in two classes, and both must be read before approving:
   at. The heading is matched on its **text**, not its style, because two of these
   docs have been round-tripped through desktop Word — a restyled heading must not
   make a chapter silently unsyncable.
+- **A chapter whose intake lost a row to the malformed-text filter is held back
+  wholesale** — the doc is neither planned nor written (report and `--write`
+  alike), the hold is named in the output beside the malformed rows, and the run
+  exits non-zero until the intake row is fixed. The rewrite is wholesale, so
+  proceeding would have deleted that accepted organizer from the doc as a side
+  effect of a data bug — the one removal class the report could never itemise.
 
 ## Editing the docs
 
@@ -489,8 +501,13 @@ used instead of inventing one.
   not name fail closed; the row is a pipeline **organizer** for a chapter below
   the self-serve threshold (held back under central approval — see "Who syncs"
   above); the email is missing or unparsable (there'd be no dedupe key, so
-  every run would re-add them); or the row has no chapter or city at all.
-  Pipeline hosts and speakers are never skipped for their status alone.
+  every run would re-add them); the row's name or city fails the same
+  `bad_public_text` check the feed engine runs (markup, control characters,
+  absurd length) — enforced here directly, since the role tabs are read
+  without passing through `sync_chapters.read_intake`, so a flagged value
+  really does reach no cell, no About doc and no CRM; or the row has no
+  chapter or city at all. Pipeline hosts and speakers are never skipped for
+  their status alone.
 - **The run aborts** when `Form Responses` or a role tab comes back empty, or a
   role tab has no `Status`/`Email` header. A workbook whose `Attendees` tab is
   missing a column is **skipped with a reason**, never written by column letter.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -97,10 +97,12 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/nightly.py --write        # apply, unattende
 python3 ${CLAUDE_SKILL_DIR}/scripts/nightly.py crm resources  # a subset
 ```
 
-Note `--write` keeps each engine's own refusals: `sync_chapters` still aborts on
-a new row whose Luma page is not live, and `sync_access --write` still runs its
-pin/grant/lock sequence — so an unattended write run is the same set of
-decisions the interactive flow would have made, minus the pause for approval.
+Note `--write` keeps each engine's own refusals: `sync_chapters` still holds
+back a new row whose Luma page is not live, and `sync_access --write` runs its
+grant/lock sequence (**never** the pin phase — that needs the explicit `--pins`
+flag, which `nightly.py` must never pass; pending pins stay named in the
+report) — so an unattended write run is the same set of decisions the
+interactive flow would have made, minus the pause for approval.
 Wiring this into GitHub Actions (auth, secrets, where the digest goes) is a
 separate change; the runner is deliberately CI-agnostic.
 
@@ -203,13 +205,18 @@ Prereq: the `gws` CLI must be installed and authenticated (see the user's
 - Duplicate intake rows for the same person+city are deduped (first wins, reported).
   Duplicate **chapter** rows (two rows for one city) are reported too — only the
   last is ever updated, so merge them by hand.
+- **Malformed public-form text is excluded and reported, never written.** An
+  intake name or city containing markup or control characters, or exceeding 120
+  chars, gets its row skipped with a loud per-row line (row, city, reason) while
+  every other row still syncs — one hostile or fat-fingered submission must not
+  freeze the whole engine, but a flagged value still reaches no cell, About doc
+  or CRM until the intake row is fixed.
 - **The run aborts rather than guessing** when: a header is duplicated (reads and
   writes would resolve to different columns); any written column is missing; a row
   below the last City row is non-empty (new rows are appended there and would wipe
-  it); a city has no ASCII characters, so its Luma slug would be empty; intake text
-  contains markup or control characters, or exceeds 120 chars; or the sheet changed
-  between building the proposal and writing it (row numbers are snapshot indices,
-  and the per-city Luma checks sit in that window).
+  it); a city has no ASCII characters, so its Luma slug would be empty; or the
+  sheet changed between building the proposal and writing it (row numbers are
+  snapshot indices, and the per-city Luma checks sit in that window).
 
 ---
 
@@ -242,9 +249,12 @@ San Francisco organizers) — correct for San Francisco, wrong everywhere else.
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/sync_about.py --write
    ```
-   Recomputes from a fresh read, uploads each changed doc, then re-downloads
-   **every** written doc and confirms a fresh plan is empty. One failed upload is
-   reported and the rest still finish.
+   Recomputes from a fresh read, re-downloads each doc right before its upload
+   and **skips it if it changed since the plan was built** (a human edit in the
+   approval window is never silently reverted; the skip is loud and the doc
+   re-proposes next run), uploads the rest, then re-downloads **every** written
+   doc and confirms a fresh plan is empty. One failed upload is reported and
+   the rest still finish.
 
 ## The section is rewritten wholesale — and that is the point
 
@@ -376,10 +386,16 @@ are being onboarded (see the sharing note at the end of this section).
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/sync_crm.py --write
    ```
-   Saves each workbook's pre-edit bytes to a temp `before/` directory, uploads,
-   then re-downloads every written workbook and confirms a fresh plan is empty.
-   A workbook that fails is reported and the rest still finish — one bad file
-   must not abandon the rest.
+   Saves each workbook's pre-edit bytes to a temp `before/` directory (the
+   output names the path; report-only runs delete their downloads on exit
+   instead — the workbooks are full of real people), compares that fresh
+   download against the bytes the plan was built on and **skips any workbook
+   that changed in the window** (planning takes minutes, and a human edit must
+   never be silently reverted — the skip is loud, exits non-zero, and the
+   workbook re-proposes next run), uploads the rest, then re-downloads every
+   written workbook and confirms a fresh plan is empty. A workbook that fails
+   is reported and the rest still finish — one bad file must not abandon the
+   rest.
 
 ## Column mapping (intake → CRM `Attendees`)
 
@@ -467,10 +483,14 @@ used instead of inventing one.
   template writes `"…"`, older workbooks write `&quot;…&quot;`). A workbook with
   no Status list at all is reported, not guessed at.
 - **TemplateCity never receives people** — only the dropdown patch.
-- **Rows are skipped, and reported, when**: `Status` is anything other than
-  `Accepted` / `Existing (from MLOps)`; the email is missing or unparsable
-  (there'd be no dedupe key, so every run would re-add them); or the row has no
-  chapter or city at all.
+- **Rows are skipped, and reported, when**: `Status` is neither a decided-yes
+  (`Accepted` / `Existing (from MLOps)`) nor a recognised pipeline status —
+  `Denied` / `Inactive` / `Duplicate` and any dropdown value the allowlists do
+  not name fail closed; the row is a pipeline **organizer** for a chapter below
+  the self-serve threshold (held back under central approval — see "Who syncs"
+  above); the email is missing or unparsable (there'd be no dedupe key, so
+  every run would re-add them); or the row has no chapter or city at all.
+  Pipeline hosts and speakers are never skipped for their status alone.
 - **The run aborts** when `Form Responses` or a role tab comes back empty, or a
   role tab has no `Status`/`Email` header. A workbook whose `Attendees` tab is
   missing a column is **skipped with a reason**, never written by column letter.
@@ -526,10 +546,16 @@ Numbered as the console prints them:
    their only access.
 3. **lock** — remove `anyone:reader` from Chapters/.
 
-`--write` runs all three in that order; `--phase pin|grant|lock` runs one, and
-verifies whatever it ran. **`lock` refuses to run when any grant failed** —
-locking then would leave those organizers with no access at all; `--lock-anyway`
-overrides.
+`--write` runs **grant then lock**. The pin phase runs only behind the explicit
+**`--pins`** flag (`--write --pins` runs all three, pin first) or as
+`--phase pin` — publishing a file to the whole internet is a standing human
+decision, never a side effect of syncing grants, and `nightly.py` must never
+pass `--pins`. Unpinned banners stay named in every report and write run so the
+pending decision is visible. `--phase pin|grant|lock` runs one phase, and the
+run verifies whatever it ran; the final `Verified:` line claims **only** the
+phases that actually ran and checked something. **`lock` refuses to run when
+any grant failed** — locking then would leave those organizers with no access
+at all; `--lock-anyway` overrides.
 
 > **The website does not depend on this share — verified, not assumed.** The
 > chapters feed's `Image` column is full of `lh3.googleusercontent.com/d/<id>`
@@ -731,7 +757,9 @@ once the 2026-08-17 sweep's sheet cells were edited directly.
 
 A dead Slack token skips the three channel columns and still reports the folder
 column; the report says which half was skipped, so an empty channel section is
-never mistaken for "nothing to do". Run `slack auth login` and re-run for the rest.
+never mistaken for "nothing to do". Set `$AAIF_SLACK_WRITE_TOKEN` (env var, or
+`.env` in the working directory) and re-run for the rest — the Slack CLI
+credential expired for good in 2026-08 and is only the last-resort fallback.
 
 One check runs even without Slack: a **filled channel cell that cannot possibly
 name a channel** (whitespace, `/`, `:`, `#`, `@` or `,` in it — a pasted URL,
@@ -873,9 +901,11 @@ After any run (and after editing the engine):
 - After `--write`, each engine prints its OWN verify line — they differ:
   `sync_chapters` "a fresh run proposes zero changes"; `sync_about` "a fresh read
   of every written doc proposes zero changes"; `sync_crm` "a fresh read
-  of every written workbook proposes zero changes"; `sync_access` "banners are
-  directly public and Chapters/ is no longer link-shared"; `sync_resources` "a
-  fresh read of every written cell matches the proposal".
+  of every written workbook proposes zero changes"; `sync_access` a composed
+  line naming only the phases that ran (e.g. "every accepted organizer holds
+  their grant; Chapters/ is not link-shared" — the banner claim appears only
+  after a pin run); `sync_resources` "a fresh read of every written cell
+  matches the proposal".
 - Spot-check one touched row in the sheet: `Organizers` merged correctly, the
   MLOps and Luma columns untouched, and the version history shows a single edit
   for the whole sync.
@@ -898,6 +928,7 @@ After any run (and after editing the engine):
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_access.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_resources.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_invite_organizers.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_prune_organizers.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_nightly.py
   ```
 
@@ -932,11 +963,15 @@ After any run (and after editing the engine):
   contains `&` and spaces.
 - Unresolved rows already hand-placed on the chapters list are flagged
   "no action needed" so they don't nag every run.
-- `sync_crm.py` and `sync_about.py` import the `gws` wrapper, city folding, the
-  near-miss stoplist and `resolve_city()` **from `sync_chapters.py`** rather than
-  copying them. Two copies would drift, and a city that folds one way in one
-  engine and another way in the other would put a person in a CRM whose feed row
-  says something else.
+- `sync_crm.py` and `sync_about.py` import the `gws` wrapper, the Drive
+  `download()`/`upload()` helpers, city folding, the near-miss stoplist and
+  `resolve_city()` **from `sync_chapters.py`** rather than copying them. Two
+  copies would drift, and a city that folds one way in one engine and another
+  way in the other would put a person in a CRM whose feed row says something
+  else. In `sync_crm` the shared `resolve_city()` is the **fallback** beneath
+  the role tab's own `Chapter` formula, which additionally resolves the form's
+  free-text city (the one extra step documented in §2's chapter-resolution
+  note).
 - `sync_about.py` re-reads the intake a second time for its **roster** — every
   name the intake knows for a city, at any status. That is what tells a removal
   "applicant we decided against" apart from "line we cannot account for", and

--- a/skills/aaif-sync-chapters/scripts/migrate_resource_columns.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_resource_columns.py
@@ -364,7 +364,7 @@ def config_rows(cfg):
     return rows
 
 
-def migrate_config(path, gid_taken):
+def migrate_config(path):
     """Move the matching vocabularies onto a `Slack Config` tab, then delete the JSON.
 
     The file goes entirely. Leaving a config-only remnant was the half-measure
@@ -490,7 +490,7 @@ def main():
         # would destroy the seed source while the migration could still fail — so
         # the states this can leave behind are "not migrated", "columns only" and
         # "done", never a sheet seeded from a file that no longer exists.
-        migrate_config(a.map, None)
+        migrate_config(a.map)
 
 
 if __name__ == "__main__":

--- a/skills/aaif-sync-chapters/scripts/nightly.py
+++ b/skills/aaif-sync-chapters/scripts/nightly.py
@@ -25,7 +25,11 @@ The Slack write steps (provision_channels.py, invite_organizers.py,
 prune_organizers.py) are deliberately NOT here: they carry their own
 --i-have-approval gate because they notify or affect real people, and a nightly
 job must never hold that approval. sync_resources' Slack half degrades to
-folder-only on a dead token, which is the right nightly behaviour.
+folder-only on a dead token, which is the right nightly behaviour. For the same
+reason this runner passes ONLY --write and must never pass sync_access's
+--pins: publishing a banner to the internet is a standing human decision, and
+the engine leaves it pending (and visible in its report) until someone runs
+`sync_access.py --write --pins` by hand.
 
 Usage:
     python3 nightly.py                 # report-only run of all five engines

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -505,11 +505,12 @@ def main():
     a = ap.parse_args()
 
     # This estate's CLI credential expired for good in 2026-08 and cannot be
-    # re-scoped, so reads prefer the same env token the writes use — it
-    # carries the read scopes (the audits run on it). The load_token fallback
-    # exists for a DIFFERENT machine with its own live CLI credential; here it
-    # only produces a later auth failure, so name the actual fix up front
-    # instead of letting load_token's "run `slack auth login`" advice mislead.
+    # re-scoped, so reads run on the same env token the writes use — it
+    # carries the read scopes (the audits run on it). load_token now resolves
+    # that token itself (environment, then ./.env, then the CLI credential)
+    # and its error names it first, so this manual env read is belt-and-braces
+    # rather than a correction — kept so the note below can warn about the
+    # expired CLI fallback before any network call is made.
     token = os.environ.get(WRITE_TOKEN_ENV, "").strip()
     if not token:
         print("note: %s is not set — falling back to the Slack CLI credential, "

--- a/skills/aaif-sync-chapters/scripts/sync_about.py
+++ b/skills/aaif-sync-chapters/scripts/sync_about.py
@@ -25,7 +25,7 @@ Preserving that preserves the disclosure. So anything in the section that is not
 an accepted organizer is removed, and every removal is itemised in the report for
 the operator to approve BEFORE anything is written.
 """
-import argparse, html, io, json, os, re, sys, tempfile, zipfile
+import argparse, html, io, os, re, sys, tempfile, zipfile
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 
@@ -33,9 +33,10 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Imported, not copied: city folding, the near-miss stoplist and city resolution
 # must mean the same thing here as on the chapters list, or an organizer lands on
 # one city's feed row and in another city's About doc.
-from sync_chapters import (INTAKE_ID, INTAKE_TAB, SYNC_STATUSES, _gws, cell,
-                           city_tokens, fold, fold_city, get_values, gws_json,
-                           header_index, read_intake, resolve_city)
+from sync_chapters import (INTAKE_ID, INTAKE_TAB, SYNC_STATUSES, cell,
+                           city_tokens, download, fold, fold_city, get_values,
+                           gws_json, header_index, read_intake, resolve_city,
+                           upload)
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"
 TEMPLATE_FOLDER = "TemplateCity"
@@ -304,25 +305,6 @@ def find_about(folder_id):
     return hits[0], None
 
 
-def download(file_id, path):
-    # gws rejects --output paths outside its cwd, so run it in the file's dir.
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    _gws(["gws", "drive", "files", "get", "--params",
-          json.dumps({"fileId": file_id, "supportsAllDrives": True, "alt": "media"}),
-          "--output", os.path.basename(path)], cwd=os.path.dirname(path) or ".")
-    with open(path, "rb") as fh:
-        return fh.read()
-
-
-def upload(file_id, path, raw):
-    with open(path, "wb") as fh:
-        fh.write(raw)
-    _gws(["gws", "drive", "files", "update", "--params",
-          json.dumps({"fileId": file_id, "supportsAllDrives": True}),
-          "--upload", os.path.basename(path), "--upload-content-type", DOCX],
-         cwd=os.path.dirname(path) or ".")
-
-
 def read_document(raw):
     with zipfile.ZipFile(io.BytesIO(raw)) as z:
         return z.read("word/document.xml").decode("utf-8")
@@ -457,7 +439,7 @@ def print_report(docs, counts, orphans, near):
 # Run
 # ----------------------------------------------------------------------------
 def compute(args, workdir):
-    entries, _unresolved, counts, _dupes = read_intake()
+    entries, _unresolved, counts, _dupes, malformed = read_intake()
     roster = read_roster()
 
     by_city, display = {}, {}
@@ -477,18 +459,31 @@ def compute(args, workdir):
 
     with ThreadPoolExecutor(max_workers=6) as ex:
         docs = list(ex.map(lambda f: plan_one(f, by_city, roster, workdir), folders))
-    return docs, counts, orphans, near
+    return docs, counts, orphans, near, malformed
 
 
 def apply_writes(docs, workdir):
     """Upload every changed doc. A failure is collected, not raised — one bad
-    upload must not abandon the rest, and the operator needs the whole list."""
+    upload must not abandon the rest, and the operator needs the whole list.
+
+    Each doc is re-downloaded and compared against its compute()-time bytes
+    first: the plan window spans ~80 downloads plus the approval pause, and a
+    spliced document.xml uploaded over a human's edit from that window would
+    silently revert it. A changed doc is skipped (counted with the failures,
+    so the run exits non-zero) and re-proposes on the next run.
+    """
     ok, failed = [], []
     for d in sorted((d for d in docs if changed(d)), key=lambda d: d.folder["name"]):
+        safe = re.sub(r"[^\w.-]", "_", d.folder["name"])
         try:
+            fresh = download(d.about["id"], os.path.join(workdir, "re_%s.docx" % safe))
+            if fresh != d.raw:
+                failed.append((d.folder["name"],
+                               "changed since the plan was built — NOT written; re-run"))
+                print("  %-22s SKIPPED — changed since plan; re-run" % d.folder["name"])
+                continue
             raw = write_document(d.raw, d.new_xml)
-            upload(d.about["id"], os.path.join(workdir, "up_%s.docx" % re.sub(
-                r"[^\w.-]", "_", d.folder["name"])), raw)
+            upload(d.about["id"], os.path.join(workdir, "up_%s.docx" % safe), raw, DOCX)
         except Exception as e:
             failed.append((d.folder["name"], "%s: %s" % (type(e).__name__, e)))
             print("  %-22s FAILED" % d.folder["name"])
@@ -508,8 +503,16 @@ def main():
 
     with tempfile.TemporaryDirectory(prefix="aaif-about-") as workdir:
         # --write recomputes from a fresh read here — a stale proposal is never applied.
-        docs, counts, orphans, near = compute(args, workdir)
+        docs, counts, orphans, near, malformed = compute(args, workdir)
         print_report(docs, counts, orphans, near)
+        if malformed:
+            # read_intake excluded these rows, so an accepted organizer listed
+            # here silently drops OUT of their chapter's rewritten section —
+            # say so, or the removal reads as a decision instead of a data bug.
+            print("\nMalformed public-form text — these intake rows are EXCLUDED "
+                  "(their names sync nowhere, About docs included) until fixed:")
+            for m in malformed:
+                print("  intake row %d (city %r): %s" % (m["row"], m["city"], m["why"]))
         drift = any(changed(d) for d in docs)
         # A doc that could not be READ (an About.docx was found but download or
         # parse raised) is UNKNOWN, not clean. Without this, a dead gws
@@ -545,7 +548,7 @@ def main():
         # The writes have already landed. A bare traceback here would leave the
         # operator unable to tell what was modified, so say so explicitly.
         try:
-            after, _c, _o, _n = compute(args, workdir)
+            after, _c, _o, _n, _m = compute(args, workdir)
         except (Exception, SystemExit) as e:
             sys.exit("WRITES WERE APPLIED (%d doc(s)) but verification could not run: "
                      "%s\nRe-run without --write to confirm." % (len(ok), e))

--- a/skills/aaif-sync-chapters/scripts/sync_about.py
+++ b/skills/aaif-sync-chapters/scripts/sync_about.py
@@ -34,9 +34,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # must mean the same thing here as on the chapters list, or an organizer lands on
 # one city's feed row and in another city's About doc.
 from sync_chapters import (INTAKE_ID, INTAKE_TAB, SYNC_STATUSES, cell,
-                           city_tokens, download, fold, fold_city, get_values,
-                           gws_json, header_index, read_intake, resolve_city,
-                           upload)
+                           city_tokens, download, fold, fold_city,
+                           fresh_if_unchanged, get_values, gws_json,
+                           header_index, read_intake, resolve_city, upload)
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"
 TEMPLATE_FOLDER = "TemplateCity"
@@ -457,9 +457,21 @@ def compute(args, workdir):
         if not folders:
             sys.exit("ABORT: no chapter folder named %r." % args.city)
 
+    # A chapter whose intake lost a row to `malformed` is HELD — not planned,
+    # not written. The section is rewritten WHOLESALE, so planning it anyway
+    # would delete that accepted organizer from the doc as a side effect of a
+    # data bug in their row, and --write would apply it and exit 0. Held docs
+    # are reported beside the malformed rows and count as drift, like
+    # changed/unread docs, until the intake text is fixed. (A malformed CITY
+    # may fold to no folder at all; then there is no doc to hold and the row
+    # is only ever an orphan — the malformed report still names it.)
+    held_keys = {fold_city(m["city"]) for m in malformed if m["city"]}
+    held = sorted(f["name"] for f in folders if fold_city(f["name"]) in held_keys)
+    folders = [f for f in folders if f["name"] not in held]
+
     with ThreadPoolExecutor(max_workers=6) as ex:
         docs = list(ex.map(lambda f: plan_one(f, by_city, roster, workdir), folders))
-    return docs, counts, orphans, near, malformed
+    return docs, counts, orphans, near, malformed, held
 
 
 def apply_writes(docs, workdir):
@@ -476,8 +488,9 @@ def apply_writes(docs, workdir):
     for d in sorted((d for d in docs if changed(d)), key=lambda d: d.folder["name"]):
         safe = re.sub(r"[^\w.-]", "_", d.folder["name"])
         try:
-            fresh = download(d.about["id"], os.path.join(workdir, "re_%s.docx" % safe))
-            if fresh != d.raw:
+            _fresh, drifted = fresh_if_unchanged(
+                d.about["id"], os.path.join(workdir, "re_%s.docx" % safe), d.raw)
+            if drifted:
                 failed.append((d.folder["name"],
                                "changed since the plan was built — NOT written; re-run"))
                 print("  %-22s SKIPPED — changed since plan; re-run" % d.folder["name"])
@@ -503,16 +516,27 @@ def main():
 
     with tempfile.TemporaryDirectory(prefix="aaif-about-") as workdir:
         # --write recomputes from a fresh read here — a stale proposal is never applied.
-        docs, counts, orphans, near, malformed = compute(args, workdir)
+        docs, counts, orphans, near, malformed, held = compute(args, workdir)
         print_report(docs, counts, orphans, near)
         if malformed:
             # read_intake excluded these rows, so an accepted organizer listed
-            # here silently drops OUT of their chapter's rewritten section —
-            # say so, or the removal reads as a decision instead of a data bug.
+            # here would drop OUT of their chapter's rewritten section — which
+            # is why compute() holds those chapters' docs back entirely.
             print("\nMalformed public-form text — these intake rows are EXCLUDED "
-                  "(their names sync nowhere, About docs included) until fixed:")
+                  "(their names sync nowhere) until fixed:")
             for m in malformed:
                 print("  intake row %d (city %r): %s" % (m["row"], m["city"], m["why"]))
+        if held:
+            # The malformed rows above cost these chapters a roster entry, and
+            # a wholesale rewrite without it would DELETE that organizer from
+            # a doc shared with the chapter — on the strength of a data bug,
+            # with a clean exit. Held like changed/unread: not planned, not
+            # written, counted as drift until the intake row is fixed.
+            print("\nHELD BACK %d About doc(s) — their chapter lost an intake "
+                  "row to the malformed text above, so a rewrite would remove "
+                  "that organizer from the doc: %s.\nNothing was planned or "
+                  "written for them; fix the intake row(s) and re-run."
+                  % (len(held), ", ".join(held)))
         drift = any(changed(d) for d in docs)
         # A doc that could not be READ (an About.docx was found but download or
         # parse raised) is UNKNOWN, not clean. Without this, a dead gws
@@ -533,10 +557,11 @@ def main():
                   "unknown, not clean: %s" % (len(unread), ", ".join(unread)))
         if not args.write:
             # Shared engine exit convention: report mode exits 0 when in sync,
-            # 2 when it proposes changes (consumed by nightly.py).
-            return 2 if (drift or unread) else 0
+            # 2 when it proposes changes (consumed by nightly.py). A held doc
+            # is pending work exactly like a proposed change.
+            return 2 if (drift or unread or held) else 0
         if not drift:
-            return 2 if unread else 0
+            return 2 if (unread or held) else 0
 
         print("\nWriting %d About doc(s)..." % sum(1 for d in docs if changed(d)))
         ok, failed = apply_writes(docs, workdir)
@@ -548,7 +573,7 @@ def main():
         # The writes have already landed. A bare traceback here would leave the
         # operator unable to tell what was modified, so say so explicitly.
         try:
-            after, _c, _o, _n, _m = compute(args, workdir)
+            after, _c, _o, _n, _m, _h = compute(args, workdir)
         except (Exception, SystemExit) as e:
             sys.exit("WRITES WERE APPLIED (%d doc(s)) but verification could not run: "
                      "%s\nRe-run without --write to confirm." % (len(ok), e))
@@ -572,7 +597,7 @@ def main():
         print("Verified: a fresh read of every written doc proposes zero changes.")
         if failed:
             sys.exit(1)
-        return 2 if unread else 0
+        return 2 if (unread or held) else 0
 
 
 if __name__ == "__main__":

--- a/skills/aaif-sync-chapters/scripts/sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/sync_access.py
@@ -524,6 +524,11 @@ def phases_to_run(phase, pins):
     joins only under `--pins`, so an unattended write (nightly.py never
     passes `--pins`) can never publish a file to the internet as a side
     effect of syncing grants.
+
+    `phase` and `pins` never arrive together: main() rejects `--phase --pins`
+    at parse time (the combination used to discard --pins silently, and a
+    silently dropped consent flag is the one thing a consent flag must not
+    be), so the `if phase` early return cannot swallow a pin request.
     """
     if phase:
         return [phase]
@@ -550,6 +555,16 @@ def main():
                     help="email only the organizers whose address has no Google "
                          "account, where Drive refuses to share without it")
     a = ap.parse_args()
+    # Refuse, never reinterpret: both flags speak for the pin phase, and each
+    # combination below used to be silently inert — the worst behaviour for a
+    # flag whose whole job is recording explicit human consent.
+    if a.phase and a.pins:
+        ap.error("--pins cannot be combined with --phase: --phase names the ONE "
+                 "phase to run, so --pins would be discarded. Use --phase pin "
+                 "to run pins alone, or drop --phase to run pin + grant + lock.")
+    if a.pins and not a.write:
+        ap.error("--pins does nothing without --write — the report already "
+                 "shows pending pins. Add --write to apply them.")
 
     p = plan(a.role)
     report(p, a.role)
@@ -610,26 +625,25 @@ def main():
     # Verify whatever ran, including a single --phase. `--write --phase lock` is
     # the most destructive invocation available and used to be the one path with
     # no re-read at all, reporting a PLANNED count as its result.
-    ran = selected  # phases_to_run() already returns the ordered subset
-    if ran:
-        print("\nVerifying...")
-        bad = verify(p, ran)
-        if bad:
-            print("VERIFY FAILED:")
-            for b in bad:
-                print("  " + b)
-            return 1
-        # Claim only what this run actually re-read — the old fixed line said
-        # "banners are directly public" even on runs that never touched a pin,
-        # or when zero pins exist to check.
-        bits = []
-        if "pin" in ran and (p["pins"] or p["already_pinned_ids"]):
-            bits.append("every banner holds its own public share")
-        if "grant" in ran and (p["grants"] or p["already_granted_ids"]):
-            bits.append("every accepted organizer holds their grant")
-        if "lock" in ran:
-            bits.append("Chapters/ is not link-shared")
-        print("Verified: %s." % "; ".join(bits))
+    # `selected` is never empty (phases_to_run returns at least ["grant", "lock"]).
+    print("\nVerifying...")
+    bad = verify(p, selected)
+    if bad:
+        print("VERIFY FAILED:")
+        for b in bad:
+            print("  " + b)
+        return 1
+    # Claim only what this run actually re-read — the old fixed line said
+    # "banners are directly public" even on runs that never touched a pin,
+    # or when zero pins exist to check.
+    bits = []
+    if "pin" in selected and (p["pins"] or p["already_pinned_ids"]):
+        bits.append("every banner holds its own public share")
+    if "grant" in selected and (p["grants"] or p["already_granted_ids"]):
+        bits.append("every accepted organizer holds their grant")
+    if "lock" in selected:
+        bits.append("Chapters/ is not link-shared")
+    print("Verified: %s." % "; ".join(bits))
     return 0
 
 

--- a/skills/aaif-sync-chapters/scripts/sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/sync_access.py
@@ -29,9 +29,17 @@ the tree. It is a NO-OP while the parent is still shared: Drive merges a child's
 hold its own public share AFTER the parent's is gone. Never trust its "N changes"
 line — re-read the permission and check `permissionDetails[].inherited`.
 
+Pinning runs ONLY behind the explicit `--pins` flag (or `--phase pin`).
+Publishing a file to the whole internet is a standing human decision, not
+drift: the site serves from Sanity, nothing needs the banners public, and an
+unattended `--write` (nightly.py, which must never pass `--pins`) has no
+business making that call. `--write` alone therefore runs grant + lock; the
+report keeps naming any unpinned banners so the pending decision stays visible.
+
 Usage:
   python3 sync_access.py                    # full plan, changes nothing
-  python3 sync_access.py --write            # apply every phase, in order
+  python3 sync_access.py --write            # apply grant + lock, in order
+  python3 sync_access.py --write --pins     # also run the pin phase first
   python3 sync_access.py --write --phase grant
   python3 sync_access.py --role reader      # grant something other than writer
   python3 sync_access.py --write --mail-if-required   # email only the addresses
@@ -240,6 +248,11 @@ def report(p, role):
         print("     %-20s %s" % (x["chapter"], x["file_id"]))
     if len(p["pins"]) > 6:
         print("     … and %d more" % (len(p["pins"]) - 6))
+    if p["pins"]:
+        # Keep the standing decision visible without letting an unattended
+        # --write make it: pins never run unless explicitly asked for.
+        print("  (pins run ONLY with --pins or --phase pin — a plain --write "
+              "applies grant + lock and leaves these pending)")
     if p["no_banner"]:
         print("  !! %d chapter(s) have no resolvable Image id on the feed (the cell is "
               "empty or not a Drive URL): %s"
@@ -503,13 +516,31 @@ def verify(p, ran):
     return bad
 
 
+def phases_to_run(phase, pins):
+    """The pin/grant/lock subset this invocation applies, in order.
+
+    `--phase` names exactly one — pin included, because naming it IS the
+    explicit consent. Without `--phase`, `--write` runs grant + lock; pin
+    joins only under `--pins`, so an unattended write (nightly.py never
+    passes `--pins`) can never publish a file to the internet as a side
+    effect of syncing grants.
+    """
+    if phase:
+        return [phase]
+    return (["pin"] if pins else []) + ["grant", "lock"]
+
+
 def main():
     ap = argparse.ArgumentParser(description="Plan/apply per-chapter access for the Chapters folder.")
     ap.add_argument("--write", action="store_true", help="apply (default: report only)")
     ap.add_argument("--role", default="writer", choices=("writer", "reader", "commenter"),
                     help="role granted to each organizer on their chapter (default: writer)")
     ap.add_argument("--phase", choices=("pin", "grant", "lock"),
-                    help="apply only one phase (default: all three, in order)")
+                    help="apply only one phase (default with --write: grant "
+                         "then lock; add --pins to run pin first)")
+    ap.add_argument("--pins", action="store_true",
+                    help="also run the pin phase (make each banner directly "
+                         "public) — never run by a plain --write or by nightly.py")
     ap.add_argument("--notify", action="store_true",
                     help="let Drive email EVERY organizer about their new access")
     ap.add_argument("--lock-anyway", action="store_true",
@@ -536,17 +567,19 @@ def main():
     # so printing it unconditionally would label every in-sync write night
     # "wrote+verified" and exit 2 forever. The other engines' no-drift early
     # return, in this engine's terms.
-    if not a.phase and not (p["grants"] or p["public"]):
+    if not a.phase and not (p["grants"] or p["public"] or (a.pins and p["pins"])):
         print("\nNo changes needed — every accepted organizer holds their "
               "grant and the folder is not link-shared. (Pending banner pins, "
-              "if any, are a standing decision: run --phase pin explicitly.)")
+              "if any, are a standing decision: run --pins or --phase pin "
+              "explicitly.)")
         return 0
 
+    selected = phases_to_run(a.phase, a.pins)
     order = [("pin", apply_pins, (p,)), ("grant", apply_grants, (p, a.notify, a.mail_if_required)),
              ("lock", apply_lock, (p,))]
     grant_failures = []
     for name, fn, args in order:
-        if a.phase and a.phase != name:
+        if name not in selected:
             continue
         # Removing the public share is the last thing that happens, and only if
         # every organizer actually has their own grant. Skipping a no-Google-
@@ -569,10 +602,15 @@ def main():
             n, grant_failures = n
         print("  phase %r: %d change(s)" % (name, n))
 
+    if p["pins"] and "pin" not in selected:
+        # The skipped standing decision stays visible on every write run.
+        print("\nNOTE: %d banner(s) still lack their own public share — pins run "
+              "only with --pins or --phase pin." % len(p["pins"]))
+
     # Verify whatever ran, including a single --phase. `--write --phase lock` is
     # the most destructive invocation available and used to be the one path with
     # no re-read at all, reporting a PLANNED count as its result.
-    ran = [n for n, _, _ in order if not a.phase or a.phase == n]
+    ran = selected  # phases_to_run() already returns the ordered subset
     if ran:
         print("\nVerifying...")
         bad = verify(p, ran)
@@ -581,7 +619,17 @@ def main():
             for b in bad:
                 print("  " + b)
             return 1
-        print("Verified: banners are directly public and Chapters/ is no longer link-shared.")
+        # Claim only what this run actually re-read — the old fixed line said
+        # "banners are directly public" even on runs that never touched a pin,
+        # or when zero pins exist to check.
+        bits = []
+        if "pin" in ran and (p["pins"] or p["already_pinned_ids"]):
+            bits.append("every banner holds its own public share")
+        if "grant" in ran and (p["grants"] or p["already_granted_ids"]):
+            bits.append("every accepted organizer holds their grant")
+        if "lock" in ran:
+            bits.append("Chapters/ is not link-shared")
+        print("Verified: %s." % "; ".join(bits))
     return 0
 
 

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -158,6 +158,20 @@ def upload(file_id, path, raw, content_type):
           "--upload", os.path.basename(path), "--upload-content-type", content_type],
          cwd=os.path.dirname(path) or ".")
 
+def fresh_if_unchanged(file_id, tmp_path, planned_bytes):
+    """Re-download a Drive file and say whether it drifted from a plan's bytes.
+
+    Returns (fresh_bytes, changed). Shared by sync_crm.write_workbooks and
+    sync_about.apply_writes — the one compare both engines' write gates hang
+    on: planning spans minutes plus the approval pause, so a human edit in
+    that window is NORMAL, and uploading over it would silently revert it.
+    Each caller keeps its own backup and skip-reporting behaviour; only the
+    "did the remote move under the plan" question lives here, so the two
+    twins cannot drift apart in what "unchanged" means.
+    """
+    fresh = download(file_id, tmp_path)
+    return fresh, fresh != planned_bytes
+
 # ----------------------------------------------------------------------------
 # Text helpers
 # ----------------------------------------------------------------------------
@@ -294,9 +308,13 @@ def read_intake():
                                "events": cell(row, i_events), "why": cell(row, i_why),
                                "placed": [], "inferred": []})
             continue
-        # Skip-and-report, never write: excluding the row here is what keeps
-        # the injection-safety property — a flagged value can reach no cell,
-        # no About doc and no CRM, because it never becomes an entry at all.
+        # Skip-and-report, never write: excluding the row here keeps the
+        # injection-safety property — a flagged value reaches no cell and no
+        # About doc, because it never becomes an entry at all. The CRM path
+        # does NOT pass through here (sync_crm.read_role_tab reads the role
+        # tabs directly), so it runs the same bad_public_text check itself;
+        # together the two checks are what make "no cell, no About doc and
+        # no CRM" a true statement rather than a hopeful one.
         bad = bad_public_text("name", name) or bad_public_text("city", city)
         if bad:
             malformed.append({"row": rownum, "name": name, "city": city, "why": bad})

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -16,7 +16,7 @@ near-miss city names (never auto-matched), and a "no changes" line when the
 sheets are already in sync. --write recomputes the proposal from a fresh read,
 applies it atomically, then re-reads and verifies the diff is empty.
 """
-import argparse, json, re, subprocess, sys, time, unicodedata, urllib.error, urllib.request
+import argparse, json, os, re, subprocess, sys, time, unicodedata, urllib.error, urllib.request
 from collections import namedtuple
 
 INTAKE_ID = "1cWkjCI5AGK9RX_fs23P5jRA4I2nixgnHuapvwHseZ5o"
@@ -97,7 +97,7 @@ def _transient(msg):
 
 def _gws(cmd, retries=5, cwd=None):
     # cwd: gws rejects --output/--upload paths outside its working directory, so
-    # the Drive callers in sync_crm.py run it from the file's own directory.
+    # the shared download()/upload() below run it from the file's own directory.
     for i in range(max(1, retries)):   # retries<=0 must raise below, not return None
         r = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
         if r.returncode == 0:
@@ -134,6 +134,30 @@ def get_values(sheet_id, rng):
                    params={"spreadsheetId": sheet_id, "ranges": [rng]})
     return res["valueRanges"][0].get("values", [])
 
+# Shared by sync_about.py (.docx) and sync_crm.py (.xlsx) — one copy, here with
+# the other gws plumbing, because two byte-identical Drive helpers inside one
+# skill had already drifted apart once in comment text alone.
+def download(file_id, path):
+    """Fetch a Drive file's bytes to `path` and return them.
+
+    gws rejects --output paths outside its cwd, so it runs in the file's dir.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    _gws(["gws", "drive", "files", "get", "--params",
+          json.dumps({"fileId": file_id, "supportsAllDrives": True, "alt": "media"}),
+          "--output", os.path.basename(path)], cwd=os.path.dirname(path) or ".")
+    with open(path, "rb") as fh:
+        return fh.read()
+
+def upload(file_id, path, raw, content_type):
+    """Replace a Drive file's content with `raw` (staged at `path` for gws)."""
+    with open(path, "wb") as fh:
+        fh.write(raw)
+    _gws(["gws", "drive", "files", "update", "--params",
+          json.dumps({"fileId": file_id, "supportsAllDrives": True}),
+          "--upload", os.path.basename(path), "--upload-content-type", content_type],
+         cwd=os.path.dirname(path) or ".")
+
 # ----------------------------------------------------------------------------
 # Text helpers
 # ----------------------------------------------------------------------------
@@ -161,19 +185,25 @@ def city_tokens(s):
     """Discriminating tokens only — see GENERIC_CITY_TOKENS."""
     return set(fold_city(s).split()) - GENERIC_CITY_TOKENS
 
-def check_public_text(kind, s, row):
-    """Reject intake free-text that must not reach the public website feed.
+def bad_public_text(kind, s):
+    """Why this intake free-text must not reach the public website feed — or None.
 
     The intake sheet is fed by a public Google Form, and this script is the last
     controlled point before a name or city is republished. RAW input mode already
     stops formula injection; this stops markup and control characters.
+
+    The caller EXCLUDES the offending row and reports it — one hostile or fat-
+    fingered form submission used to sys.exit the whole engine, report mode
+    included, holding every other chapter's sync hostage to a row only a human
+    can fix. The safety property is unchanged: a row this flags is never
+    written anywhere.
     """
     if _UNSAFE_PUBLIC_TEXT.search(s):
-        sys.exit("ABORT: intake row %d %s %r contains control characters or angle "
-                 "brackets, which must never reach the public feed." % (row, kind, s))
+        return ("%s %r contains control characters or angle brackets, which "
+                "must never reach the public feed" % (kind, s))
     if len(s) > MAX_PUBLIC_TEXT:
-        sys.exit("ABORT: intake row %d %s is %d characters (max %d)."
-                 % (row, kind, len(s), MAX_PUBLIC_TEXT))
+        return "%s is %d characters (max %d)" % (kind, len(s), MAX_PUBLIC_TEXT)
+    return None
 
 def resolve_city(existing, new):
     """Resolve an intake row's chapter city: `City (New)` wins if non-empty, else
@@ -228,11 +258,12 @@ def luma_status(slug):
 # Read the two sheets
 # ----------------------------------------------------------------------------
 def read_intake():
-    """Return (entries, unresolved, status_counts, dupes).
+    """Return (entries, unresolved, status_counts, dupes, malformed).
 
     entries    = [{row, name, city, status}]                        city resolved, deduped
     unresolved = [{row, name, status, g, h, events, why,
                    placed, inferred}]                               needs a human
+    malformed  = [{row, name, city, why}]      public-unsafe text — never written
     """
     rows = get_values(INTAKE_ID, "%s!A:U" % INTAKE_TAB)
     if not rows:
@@ -241,7 +272,7 @@ def read_intake():
         rows[0], INTAKE_TAB, "Status", "Full name", "City (Existing)", "City (New)",
         "Run events before?", "Why organize / ties")
 
-    entries, unresolved, dupes = [], [], []
+    entries, unresolved, dupes, malformed = [], [], [], []
     counts = {s: 0 for s in SYNC_STATUSES}
     seen = set()
     for rownum, row in enumerate(rows[1:], start=2):
@@ -263,15 +294,20 @@ def read_intake():
                                "events": cell(row, i_events), "why": cell(row, i_why),
                                "placed": [], "inferred": []})
             continue
-        check_public_text("name", name, rownum)
-        check_public_text("city", city, rownum)
+        # Skip-and-report, never write: excluding the row here is what keeps
+        # the injection-safety property — a flagged value can reach no cell,
+        # no About doc and no CRM, because it never becomes an entry at all.
+        bad = bad_public_text("name", name) or bad_public_text("city", city)
+        if bad:
+            malformed.append({"row": rownum, "name": name, "city": city, "why": bad})
+            continue
         key = (fold(name), fold(city))
         if key in seen:
             dupes.append({"row": rownum, "name": name, "city": city})
             continue
         seen.add(key)
         entries.append({"row": rownum, "name": name, "city": city, "status": status})
-    return entries, unresolved, counts, dupes
+    return entries, unresolved, counts, dupes, malformed
 
 def read_chapters():
     """Return (chapters, last_row, layout). chapters = [{row, city, organizers_raw}].
@@ -465,6 +501,14 @@ def print_report(st):
         print("\nDuplicate intake rows (deduped, first occurrence wins):")
         for d in dupes:
             print("  intake row %d: %s / %s" % (d["row"], d["name"], d["city"]))
+    if st.malformed:
+        # Excluded, loudly: everything else still syncs, but a row listed here
+        # reaches nothing until the intake text is fixed — the values are
+        # printed repr'd so control characters are visible.
+        print("\nMalformed public-form text — EXCLUDED from every write until the "
+              "intake row is fixed:")
+        for m in st.malformed:
+            print("  intake row %d (city %r): %s" % (m["row"], m["city"], m["why"]))
 
     # The chapters side has its own duplicate problem, and only the intake side
     # was ever reported. chap_by_fold is last-wins, so an earlier duplicate row
@@ -486,15 +530,15 @@ def print_report(st):
 # takes the State itself, not *state), so adding a field can't silently rebind a
 # positional parameter the way it did when `layout` landed.
 State = namedtuple("State", "entries unresolved counts dupes chapters last_row "
-                            "adds new_rows near_misses layout")
+                            "adds new_rows near_misses layout malformed")
 
 def compute():
-    entries, unresolved, counts, dupes = read_intake()
+    entries, unresolved, counts, dupes, malformed = read_intake()
     chapters, last_row, layout = read_chapters()
     adds, new_rows, near_misses = build_proposal(entries, chapters, last_row)
     annotate_unresolved(unresolved, chapters)
     return State(entries, unresolved, counts, dupes, chapters, last_row,
-                 adds, new_rows, near_misses, layout)
+                 adds, new_rows, near_misses, layout, malformed)
 
 def new_row_values(n, layout):
     """Full-width feed row for a brand-new city.

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -60,9 +60,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # city-folding rule, one near-miss stoplist. Two copies would drift, and a city
 # that folds one way here and another way there syncs a person to a chapter whose
 # feed row says something else.
-from sync_chapters import (INTAKE_ID, gws_json, get_values, download, upload,
-                           fold, fold_city, city_tokens, cell, header_index,
-                           resolve_city)
+from sync_chapters import (INTAKE_ID, bad_public_text, gws_json, get_values,
+                           download, upload, fold, fold_city, fresh_if_unchanged,
+                           city_tokens, cell, header_index, resolve_city)
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
 TEMPLATE_FOLDER = "TemplateCity"                        # cloned per city; never gets people
@@ -679,6 +679,17 @@ def read_role_tab(tab, interests, include_pipeline=False):
             rejected.append({"row": rownum, "tab": tab, "name": name,
                              "why": "no chapter/city on the intake row"})
             continue
+        # The same public-text gate sync_chapters.read_intake runs, enforced
+        # here too because this reader does NOT go through it: the role tabs
+        # are read directly, and without this check a name or city full of
+        # markup or control characters walked straight into a chapter CRM —
+        # and, via sync_access's roster read, toward a Drive grant target.
+        # This is what makes the documented property ("a flagged value can
+        # reach no cell, no About doc and no CRM") true on the CRM path.
+        bad = bad_public_text("name", name) or bad_public_text("city", city)
+        if bad:
+            rejected.append({"row": rownum, "tab": tab, "name": name, "why": bad})
+            continue
         detail = first_of(row, headers, f["detail"])
         # A failed join is invisible once written: the generic branch text is
         # indistinguishable from a real answer, and the cell is then non-empty
@@ -1107,13 +1118,16 @@ def write_workbooks(touched, workdir, backup_dir):
         try:
             # Keep the pre-edit bytes before touching anything: an upload that
             # lands a workbook Excel won't open is otherwise only recoverable by
-            # hand, through Drive's revision history.
-            current = download(book.crm["id"], os.path.join(workdir, "reread.xlsx"))
-            with open(os.path.join(backup_dir, os.path.basename(book.path)), "wb") as fh:
-                fh.write(current)
+            # hand, through Drive's revision history. The compare itself is the
+            # shared fresh_if_unchanged — one definition of "unchanged" for
+            # this gate and sync_about's.
             with open(book.path, "rb") as fh:
                 planned = fh.read()
-            if current != planned:
+            current, drifted = fresh_if_unchanged(
+                book.crm["id"], os.path.join(workdir, "reread.xlsx"), planned)
+            with open(os.path.join(backup_dir, os.path.basename(book.path)), "wb") as fh:
+                fh.write(current)
+            if drifted:
                 changed.append(name)
                 print("  SKIPPED %s — workbook changed since the plan was built; "
                       "NOT written, re-run to sync it" % name, file=sys.stderr)

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -51,7 +51,7 @@ Usage:
   python3 sync_crm.py --verbose          # also list every intake row NOT synced
   python3 sync_crm.py --write            # apply, then re-read and verify
 """
-import argparse, datetime, io, json, os, re, sys, tempfile, zipfile
+import argparse, datetime, io, os, re, shutil, sys, tempfile, zipfile
 from collections import Counter, namedtuple
 from xml.etree import ElementTree as ET
 
@@ -60,8 +60,9 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # city-folding rule, one near-miss stoplist. Two copies would drift, and a city
 # that folds one way here and another way there syncs a person to a chapter whose
 # feed row says something else.
-from sync_chapters import (INTAKE_ID, _gws, gws_json, get_values, fold, fold_city,
-                           city_tokens, cell, header_index)
+from sync_chapters import (INTAKE_ID, gws_json, get_values, download, upload,
+                           fold, fold_city, city_tokens, cell, header_index,
+                           resolve_city)
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
 TEMPLATE_FOLDER = "TemplateCity"                        # cloned per city; never gets people
@@ -666,12 +667,14 @@ def read_role_tab(tab, interests, include_pipeline=False):
                              "why": "no usable email (%r) — the CRM dedupes on it" % email})
             continue
         # Chapter wins — the role tab's OWN resolved city (a formula, not a human
-        # assignment); then the resolved city, then the submitted dropdown unless
-        # it is an "Other…" placeholder.
+        # assignment); the fallback is the shared resolve_city(), imported from
+        # sync_chapters so the two engines cannot disagree on what a row's city
+        # means. The Chapter formula's extra free-text step lives in the sheet,
+        # not here (see the header_index comment above).
         chapter = cell(row, i_chapter)
         g = cell(row, i_g) if i_g is not None else ""
         h = cell(row, i_h) if i_h is not None else ""
-        city = chapter or h or (g if g and not fold(g).startswith("other") else "")
+        city = chapter or resolve_city(g, h)
         if not city:
             rejected.append({"row": rownum, "tab": tab, "name": name,
                              "why": "no chapter/city on the intake row"})
@@ -1018,25 +1021,6 @@ def find_crm(folder_id):
     return crms[0], None
 
 
-def download(file_id, path):
-    # gws rejects --output paths outside its cwd, so run it in the file's dir.
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    _gws(["gws", "drive", "files", "get", "--params",
-          json.dumps({"fileId": file_id, "supportsAllDrives": True, "alt": "media"}),
-          "--output", os.path.basename(path)], cwd=os.path.dirname(path) or ".")
-    with open(path, "rb") as fh:
-        return fh.read()
-
-
-def upload(file_id, path, raw):
-    with open(path, "wb") as fh:
-        fh.write(raw)
-    _gws(["gws", "drive", "files", "update", "--params",
-          json.dumps({"fileId": file_id, "supportsAllDrives": True}),
-          "--upload", os.path.basename(path), "--upload-content-type", XLSX],
-         cwd=os.path.dirname(path) or ".")
-
-
 # ----------------------------------------------------------------------------
 # Chapter matching
 # ----------------------------------------------------------------------------
@@ -1105,7 +1089,58 @@ def open_crm(folder, workdir):
     return Book(folder, crm, names, parts, part, att, path), None
 
 
+def write_workbooks(touched, workdir, backup_dir):
+    """Upload every planned workbook. Returns (written, changed, failed).
+
+    Right before each upload the workbook is re-downloaded — that fresh copy is
+    also the pre-edit backup. Planning takes minutes across ~80 workbooks and
+    the approval pause adds more, so a human edit in that window is a NORMAL
+    event: if the fresh bytes differ from the bytes the plan was built on
+    (still sitting at book.path), the workbook is skipped loudly instead of
+    silently reverting the edit, and re-proposes on the next run. `changed`
+    counts as a failure for exit-code purposes; nothing was written to those.
+    """
+    written, changed, failed = [], [], []
+    for t in touched:
+        book = t["book"]
+        name = book.folder["name"]
+        try:
+            # Keep the pre-edit bytes before touching anything: an upload that
+            # lands a workbook Excel won't open is otherwise only recoverable by
+            # hand, through Drive's revision history.
+            current = download(book.crm["id"], os.path.join(workdir, "reread.xlsx"))
+            with open(os.path.join(backup_dir, os.path.basename(book.path)), "wb") as fh:
+                fh.write(current)
+            with open(book.path, "rb") as fh:
+                planned = fh.read()
+            if current != planned:
+                changed.append(name)
+                print("  SKIPPED %s — workbook changed since the plan was built; "
+                      "NOT written, re-run to sync it" % name, file=sys.stderr)
+                continue
+            upload(book.crm["id"], book.path, finalize(book, t["ops"], t["dv"]), XLSX)
+            written.append(name)
+            print("  wrote %s (%s)" % (name, book.crm["name"]))
+        except Exception as e:                     # one bad workbook must not
+            failed.append((name, str(e)))          # abandon the other eighty
+            print("  FAILED %s — %s" % (name, e), file=sys.stderr)
+    return written, changed, failed
+
+
 def run(args):
+    # Every opened workbook — real names, emails and survey answers — lands in
+    # this temp dir. A report-only run must not strand ~80 of them there
+    # forever, so the directory is removed on the way out; --write keeps it,
+    # because its before/ backups are the recovery path (the output says where).
+    workdir = tempfile.mkdtemp(prefix="aaif-crm-")
+    try:
+        return _run(args, workdir)
+    finally:
+        if not args.write:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _run(args, workdir):
     today = datetime.date.today().isoformat()
     interests = read_survey_interests()
 
@@ -1164,7 +1199,6 @@ def run(args):
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
     touched, skipped, no_dropdown, keepers = [], [], [], []
-    workdir = tempfile.mkdtemp(prefix="aaif-crm-")
     # Every folder is opened, not just the ones with people: the Status dropdown
     # patch has to reach chapters that gained nobody this run, and TemplateCity
     # most of all — otherwise every chapter created from it re-inherits a list
@@ -1270,23 +1304,12 @@ def run(args):
     print("\nWriting %d workbook(s)..." % len(touched))
     backup_dir = os.path.join(workdir, "before")
     os.makedirs(backup_dir, exist_ok=True)
-    written, failed = [], []
-    for t in touched:
-        book = t["book"]
-        name = book.folder["name"]
-        try:
-            # Keep the pre-edit bytes before touching anything: an upload that
-            # lands a workbook Excel won't open is otherwise only recoverable by
-            # hand, through Drive's revision history.
-            with open(os.path.join(backup_dir, os.path.basename(book.path)), "wb") as fh:
-                fh.write(download(book.crm["id"], os.path.join(workdir, "reread.xlsx")))
-            upload(book.crm["id"], book.path, finalize(book, t["ops"], t["dv"]))
-            written.append(name)
-            print("  wrote %s (%s)" % (name, book.crm["name"]))
-        except Exception as e:                     # one bad workbook must not
-            failed.append((name, str(e)))          # abandon the other eighty
-            print("  FAILED %s — %s" % (name, e), file=sys.stderr)
-    print("Wrote %d workbook(s); pre-edit copies in %s" % (len(written), backup_dir))
+    written, changed, failed = write_workbooks(touched, workdir, backup_dir)
+    print("Wrote %d workbook(s); pre-edit copies kept in %s" % (len(written), backup_dir))
+    if changed:
+        print("\n%d workbook(s) changed since the plan was built and were NOT "
+              "written — re-run to sync them:\n  %s"
+              % (len(changed), ", ".join(changed)))
 
     print("\nRe-verifying...")
     stale = []
@@ -1303,10 +1326,13 @@ def run(args):
             stale.append((folder["name"], "%d op(s) still pending" % len(left)))
         elif t["dv"] == "patched" and patch_status_dropdown(dict(book.parts), book.part) != "already":
             stale.append((folder["name"], 'Status dropdown still lacks "Host"'))
-    if failed or stale:
-        print("VERIFY FAILED:")
-        for name, why in failed + stale:
-            print("  %s — %s" % (name, why))
+    if failed or stale or changed:
+        if failed or stale:
+            print("VERIFY FAILED:")
+            for name, why in failed + stale:
+                print("  %s — %s" % (name, why))
+        # `changed` was already reported above; it shares the failure exit so a
+        # wrapper never reads a run with unwritten workbooks as complete.
         return 1
     print("Verified: a fresh read of every written workbook proposes zero changes.")
     return 0

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -925,7 +925,8 @@ def slack_half(chapters, plan=False):
         chans = slackmod.channels(api)
     except (slackmod.SlackError, SystemExit) as exc:
         print("Slack unavailable (%s) — channel columns skipped.\n"
-              "Run `slack auth login`, then re-run for those.\n" % exc,
+              "Set AAIF_SLACK_WRITE_TOKEN (env or .env — the Slack CLI credential "
+              "expired for good in 2026-08), then re-run for those.\n" % exc,
               file=sys.stderr)
         return [], [], {}, [], False
 

--- a/skills/aaif-sync-chapters/scripts/test_sync_about.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_about.py
@@ -5,8 +5,10 @@ The document fixtures below are the real markup TemplateCity ships — the same
 <w:pPr>, the same numId 1, the same after="0"/after="140" spacing — so a change
 that would corrupt a live About.docx fails here first.
 """
-import sys, os, zipfile, io
+import sys, os, tempfile, zipfile, io
+from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sync_about
 from sync_about import (PLACEHOLDER, TEMPLATE_NAMES, clone_bullet,
                         find_section, is_list, para_text, paragraphs, plan_doc,
                         read_document, removals, render, set_spacing,
@@ -220,6 +222,32 @@ with zipfile.ZipFile(io.BytesIO(repacked)) as _z:
     check("write_document keeps the member order",
           _z.namelist(), ["[Content_Types].xml", "word/document.xml",
                           "word/fonts/Manrope-bold.ttf"])
+
+# --- apply_writes: a doc edited during the plan window is skipped, not reverted --
+# compute() downloads ~80 docs and the approval pause adds more, so a human
+# edit in that window is normal. The pre-upload re-download must be compared
+# against the compute()-time bytes; uploading anyway silently reverts the edit.
+def _doc(name, about_id):
+    return sync_about.Doc({"name": name}, {"id": about_id}, RAW, TEMPLATE_DOC,
+                          list(TEMPLATE_NAMES), ["Asha Rao"],
+                          plan_doc(TEMPLATE_DOC, ["Asha Rao"], set())[0],
+                          None, [], [])
+
+_remote = {"a-same": RAW,              # untouched since compute()
+           "a-edit": RAW + b"\x00tail"}  # changed in the window
+_ups = []
+with tempfile.TemporaryDirectory() as _wd, \
+     mock.patch.object(sync_about, "download", lambda fid, path: _remote[fid]), \
+     mock.patch.object(sync_about, "upload",
+                       lambda fid, path, raw, ct: _ups.append((fid, ct))):
+    _ok, _failed = sync_about.apply_writes([_doc("Boston", "a-same"),
+                                            _doc("Pune", "a-edit")], _wd)
+check("an unchanged doc is written", _ok, ["Boston"])
+check("only the unchanged doc was uploaded", [u[0] for u in _ups], ["a-same"])
+check("uploads carry the docx content type", [u[1] for u in _ups], [sync_about.DOCX])
+check("a changed doc is skipped and counted with the failures",
+      [(n, "changed since the plan" in why) for n, why in _failed],
+      [("Pune", True)])
 
 print("\n%s (%d failure(s))" % ("ALL PASS" if not fails else "FAILURES", fails))
 sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_sync_about.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_about.py
@@ -9,6 +9,7 @@ import sys, os, tempfile, zipfile, io
 from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import sync_about
+import sync_chapters
 from sync_about import (PLACEHOLDER, TEMPLATE_NAMES, clone_bullet,
                         find_section, is_list, para_text, paragraphs, plan_doc,
                         read_document, removals, render, set_spacing,
@@ -236,8 +237,10 @@ def _doc(name, about_id):
 _remote = {"a-same": RAW,              # untouched since compute()
            "a-edit": RAW + b"\x00tail"}  # changed in the window
 _ups = []
+# The freshness compare goes through sync_chapters.fresh_if_unchanged, so the
+# download to intercept lives in THAT module's namespace, not sync_about's.
 with tempfile.TemporaryDirectory() as _wd, \
-     mock.patch.object(sync_about, "download", lambda fid, path: _remote[fid]), \
+     mock.patch.object(sync_chapters, "download", lambda fid, path: _remote[fid]), \
      mock.patch.object(sync_about, "upload",
                        lambda fid, path, raw, ct: _ups.append((fid, ct))):
     _ok, _failed = sync_about.apply_writes([_doc("Boston", "a-same"),
@@ -248,6 +251,54 @@ check("uploads carry the docx content type", [u[1] for u in _ups], [sync_about.D
 check("a changed doc is skipped and counted with the failures",
       [(n, "changed since the plan" in why) for n, why in _failed],
       [("Pune", True)])
+
+# --- a malformed intake row holds the whole chapter's doc back ----------------
+# read_intake EXCLUDES a malformed row, and the section is rewritten WHOLESALE,
+# so planning that chapter anyway would DELETE the accepted organizer the row
+# names — on --write, with a clean exit. The chapter must be held instead: not
+# planned, not written, exit non-zero, while every other chapter still syncs.
+_MAL = [{"row": 3, "name": "Bo <b>Lin</b>", "city": "Boston",
+         "why": "name %r contains control characters or angle brackets" % "Bo <b>Lin</b>"}]
+_ENTRIES = [{"row": 2, "name": "Asha Rao", "city": "Pune", "status": "Accepted"}]
+_COUNTS = {"Accepted": 2, "Existing (from MLOps)": 0}
+
+def _run_main(argv):
+    _rem = {"a-Boston": RAW, "a-Pune": RAW}
+    dl, ups = [], []
+
+    def _dl(fid, path):
+        dl.append(fid)
+        return _rem[fid]
+
+    def _up(fid, path, raw, ct):
+        ups.append(fid)
+        _rem[fid] = raw                     # so --write's re-verify converges
+
+    with mock.patch.object(sync_about, "read_intake",
+                           lambda: (_ENTRIES, [], _COUNTS, [], _MAL)), \
+         mock.patch.object(sync_about, "read_roster", lambda: {}), \
+         mock.patch.object(sync_about, "list_chapter_folders",
+                           lambda: [{"id": "f-Boston", "name": "Boston"},
+                                    {"id": "f-Pune", "name": "Pune"}]), \
+         mock.patch.object(sync_about, "find_about",
+                           lambda fid: ({"id": fid.replace("f-", "a-")}, None)), \
+         mock.patch.object(sync_about, "download", _dl), \
+         mock.patch.object(sync_chapters, "download", _dl), \
+         mock.patch.object(sync_about, "upload", _up), \
+         mock.patch.object(sys, "argv", ["sync_about.py"] + argv):
+        return sync_about.main(), dl, ups
+
+_rc, _dl, _up2 = _run_main([])
+check("a malformed row makes the report run exit non-zero", _rc, 2)
+check("report mode never even downloads the held chapter's doc",
+      "a-Boston" in _dl, False)
+check("the other chapter is still read and planned", "a-Pune" in _dl, True)
+
+_rc, _dl, _up2 = _run_main(["--write"])
+check("write mode writes only the unaffected chapter", _up2, ["a-Pune"])
+check("write mode neither reads nor writes the held chapter",
+      "a-Boston" in _dl, False)
+check("the hold keeps the write run's exit non-zero", _rc, 2)
 
 print("\n%s (%d failure(s))" % ("ALL PASS" if not fails else "FAILURES", fails))
 sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_access.py
@@ -294,6 +294,26 @@ check("--phase runs exactly the named phase",
       [sync_access.phases_to_run(p, False) for p in ("grant", "lock")],
       [["grant"], ["lock"]])
 
+
+# --- the flag combinations that used to be silently inert ----------------------
+# `--phase X --pins` discarded --pins (phases_to_run returns [phase]), and
+# `--pins` without `--write` did nothing at all — the worst behaviours for a
+# flag whose whole job is recording explicit consent. Both must now refuse at
+# parse time, before plan() touches the network (asserted by the plan mock).
+def _main_with(argv):
+    with mock.patch.object(sync_access, "plan",
+                           side_effect=AssertionError("plan() must not run")), \
+         mock.patch.object(sys, "argv", ["sync_access.py"] + argv):
+        return aborts(sync_access.main)
+
+
+check("--phase with --pins is refused loudly, never discarded",
+      _main_with(["--write", "--phase", "grant", "--pins"]), True)
+check("--phase pin with --pins is refused too — one spelling per consent",
+      _main_with(["--write", "--phase", "pin", "--pins"]), True)
+check("--pins without --write is refused, not silently inert",
+      _main_with(["--pins"]), True)
+
 print()
 print("FAILED %d check(s)" % fails if fails else "All checks passed.")
 sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_access.py
@@ -281,6 +281,19 @@ check("a direct writer passes",
       run_verify([{"type": "user", "emailAddress": "a@x.com",
                    "role": "writer", "inherited": False}]), [])
 
+# --- phases_to_run: pinning is a standing human decision, never a default -------
+# nightly.py passes only --write, so the unattended path must never publish a
+# banner to the internet as a side effect of syncing grants.
+check("a plain --write runs grant + lock only",
+      sync_access.phases_to_run(None, False), ["grant", "lock"])
+check("--pins adds the pin phase, first",
+      sync_access.phases_to_run(None, True), ["pin", "grant", "lock"])
+check("--phase pin is explicit consent on its own",
+      sync_access.phases_to_run("pin", False), ["pin"])
+check("--phase runs exactly the named phase",
+      [sync_access.phases_to_run(p, False) for p in ("grant", "lock")],
+      [["grant"], ["lock"]])
+
 print()
 print("FAILED %d check(s)" % fails if fails else "All checks passed.")
 sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_chapters.py
@@ -14,7 +14,10 @@ HEADERS = ["Title", "City", "Country",
            "Organizer Handles",
            "Generated Geolocation", "Summary", "Image",
            "CTA", "URL for CTA", "Organizers", "Chapter Luma Link",
-           "MLOps Community Organizers"]
+           "MLOps Community Organizers",
+           # Column Q since 2026-08-22: squatted/superseded channel names that
+           # provision_channels refuses to create or rename into.
+           "Erstwhile Channels"]
 
 def chap(row, city, orgs):
     return {"row": row, "city": city, "organizers_raw": orgs}
@@ -53,7 +56,7 @@ ROW2 = ["AAIF Boston Chapter", "Boston", "USA",
         "https://drive.google.com/drive/folders/F1", "boston", "boston-organizers", "none",
         "@ada",
         "42,-71", "blurb", "img",
-        "Stay Updated", "u", "Wedge Antilles", "luma", ""]
+        "Stay Updated", "u", "Wedge Antilles", "luma", "", ""]
 _chapters, _last, LAYOUT = read_chapters_over([HEADERS, ROW2])
 check("fixture row matches the header width", len(ROW2), len(HEADERS))
 check("read_chapters resolves the real layout", LAYOUT["index"]["Organizers"], 13)
@@ -190,14 +193,34 @@ except ValueError:
 check("col_letter(-1) raises", raised, True)
 
 # --- public-form text is charset/length checked before it can reach the feed ----
-check("markup in a name aborts",
-      aborts(lambda: sync_chapters.check_public_text("name", "<img src=x onerror=1>", 5)), True)
-check("control characters abort",
-      aborts(lambda: sync_chapters.check_public_text("city", "Bo\x00ston", 5)), True)
-check("over-long text aborts",
-      aborts(lambda: sync_chapters.check_public_text("name", "A" * 200, 5)), True)
+# Skip-and-report, not abort: one hostile row must not hold every other
+# chapter's sync hostage, but the flagged value must still never be written.
+check("markup in a name is flagged",
+      sync_chapters.bad_public_text("name", "<img src=x onerror=1>") is not None, True)
+check("control characters are flagged",
+      sync_chapters.bad_public_text("city", "Bo\x00ston") is not None, True)
+check("over-long text is flagged",
+      sync_chapters.bad_public_text("name", "A" * 200) is not None, True)
 check("an ordinary accented name passes",
-      aborts(lambda: sync_chapters.check_public_text("name", "Padmé Naberrie", 5)), False)
+      sync_chapters.bad_public_text("name", "Padmé Naberrie"), None)
+
+# read_intake excludes the offending ROW and reports it; everything else syncs.
+INTAKE_HEADERS = ["Status", "Full name", "City (Existing)", "City (New)",
+                  "Run events before?", "Why organize / ties"]
+def intake_row(status, name, city):
+    return [status, name, city, "", "", ""]
+with mock.patch.object(sync_chapters, "get_values", return_value=[
+        INTAKE_HEADERS,
+        intake_row("Accepted", "Ada Lovelace", "Boston"),
+        intake_row("Accepted", "<b>Mallory</b>", "Boston"),
+        intake_row("Accepted", "Owen Lars", "Pune")]):
+    _e, _u, _c, _d, _m = sync_chapters.read_intake()
+check("a malformed row is excluded, the rest still sync",
+      [e["name"] for e in _e], ["Ada Lovelace", "Owen Lars"])
+check("the malformed row is reported with its row and reason",
+      (_m[0]["row"], _m[0]["city"], "angle brackets" in _m[0]["why"]),
+      (3, "Boston", True))
+check("a malformed row is never an unresolved/dupe entry", (_u, _d), ([], []))
 
 # --- apply_changes: exact ranges, column order, RAW (gws mocked, no network) -----
 CITY_COL = [["City"], ["Boston"]]        # row 2 = Boston, row 6 still empty

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -11,6 +11,7 @@ from unittest import mock
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sync_chapters
 import sync_crm
 from sync_crm import (Attendees, CRM_HEADERS, DV_STATUS_NEW, DV_STATUS_OLD,
                       SELF_SERVE_MIN, X,
@@ -296,6 +297,31 @@ try:
           sorted(r["name"] for r in rr
                  if "declined, parked, or not a recognised" in r["why"]),
           ["Dan", "Zed"])
+finally:
+    sync_crm.get_values = _saved_gv
+
+# The injection-safety property, enforced on the CRM path itself: read_role_tab
+# does NOT go through sync_chapters.read_intake, so it runs the same
+# bad_public_text check on the public-facing fields (name, city) — without it,
+# a hostile form submission walked straight into a private workbook (and, via
+# sync_access's roster read, toward a Drive grant).
+_BAD_GRID = [
+    ["Status", "Full name", "Email", "Chapter", "City (Existing)", "City (New)"],
+    ["Accepted", "Ada", "ada@x.io", "Boston", "", ""],
+    ["Accepted", "<script>x</script>", "evil@x.io", "Boston", "", ""],   # markup name
+    ["Accepted", "Cy", "cy@x.io", "Bo\x07ston", "", ""],                 # control-char city
+    ["Accepted", "Dee " * 40, "dee@x.io", "Boston", "", ""],             # absurd length
+]
+sync_crm.get_values = lambda *_a, **_k: _BAD_GRID
+try:
+    pp, rr, _fb = sync_crm.read_role_tab("Organizers", {})
+    check("malformed public text never becomes a CRM person",
+          [p["name"] for p in pp], ["Ada"])
+    check("each malformed row lands in the skip report with its reason",
+          sorted(r["row"] for r in rr
+                 if "must never reach the public feed" in r["why"]
+                 or "characters (max" in r["why"]),
+          [3, 4, 5])
 finally:
     sync_crm.get_values = _saved_gv
 
@@ -676,7 +702,9 @@ with tempfile.TemporaryDirectory() as _wd:
 
     _backup = os.path.join(_wd, "before")
     os.makedirs(_backup)
-    with mock.patch.object(sync_crm, "download", _fake_download), \
+    # The freshness compare goes through sync_chapters.fresh_if_unchanged, so
+    # the download to intercept lives in THAT module's namespace.
+    with mock.patch.object(sync_chapters, "download", _fake_download), \
          mock.patch.object(sync_crm, "upload",
                            lambda fid, path, raw_b, ct: _uploads.append((fid, ct))):
         _written, _changed, _failed = sync_crm.write_workbooks(

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -6,7 +6,8 @@ same shape the real chapter CRMs have — inline strings, a styled sample row 2,
 pre-created empty rows, and the Status data-validation list. A checked-in binary
 would silently stop resembling the live workbooks; this can't.
 """
-import os, sys
+import os, sys, tempfile
+from unittest import mock
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -640,6 +641,56 @@ try:
     check("serialize refuses a non-<worksheet> root", "no error", "ValueError")
 except ValueError as e:
     check("serialize refuses a non-<worksheet> root", "refusing to write" in str(e), True)
+
+# ---------------------------------------------------------------------------
+# write_workbooks: a workbook edited during the plan window is never reverted
+# ---------------------------------------------------------------------------
+# Planning spans minutes over ~80 workbooks plus the approval pause. The bytes
+# the plan was built on still sit at book.path; the pre-upload re-download must
+# be COMPARED against them, and a mismatch skipped loudly — uploading anyway
+# silently reverts whatever a human typed in the window.
+with tempfile.TemporaryDirectory() as _wd:
+    def _touched(tag):
+        names_, parts_, att_ = book(sample_row=SAMPLE)
+        path = os.path.join(_wd, "%s.xlsx" % tag)
+        raw_ = save_parts(names_, parts_)          # the plan-time bytes
+        with open(path, "wb") as fh:
+            fh.write(raw_)
+        bk = sync_crm.Book(folder={"name": tag},
+                           crm={"id": "id-" + tag, "name": "%s CRM.xlsx" % tag},
+                           names=names_, parts=parts_,
+                           part=sheet_part(parts_, "Attendees"), att=att_, path=path)
+        return {"book": bk, "ops": plan_workbook(att_, people, TODAY), "dv": None}, raw_
+
+    t_same, raw_same = _touched("Boston")
+    t_edit, raw_edit = _touched("Pune")
+    _remote = {"id-Boston": raw_same,             # untouched since planning
+               "id-Pune": raw_edit + b"human-edit"}  # changed in the window
+    _uploads = []
+
+    def _fake_download(fid, path):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "wb") as fh:
+            fh.write(_remote[fid])
+        return _remote[fid]
+
+    _backup = os.path.join(_wd, "before")
+    os.makedirs(_backup)
+    with mock.patch.object(sync_crm, "download", _fake_download), \
+         mock.patch.object(sync_crm, "upload",
+                           lambda fid, path, raw_b, ct: _uploads.append((fid, ct))):
+        _written, _changed, _failed = sync_crm.write_workbooks(
+            [t_same, t_edit], _wd, _backup)
+    check("an unchanged workbook is written", _written, ["Boston"])
+    check("a changed workbook is skipped, not reverted", _changed, ["Pune"])
+    check("the skip is not a failure entry", _failed, [])
+    check("only the unchanged workbook was uploaded",
+          [u[0] for u in _uploads], [("id-Boston")])
+    check("uploads carry the xlsx content type", [u[1] for u in _uploads], [sync_crm.XLSX])
+    with open(os.path.join(_backup, "Pune.xlsx"), "rb") as fh:
+        check("the changed workbook's FRESH bytes are what got backed up",
+              fh.read(), raw_edit + b"human-edit")
+
 
 # An alias bound to the spreadsheetml namespace must not displace the default
 # binding — that is what made the root serialize as <x:worksheet>.

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -41,8 +41,9 @@ row older than 1 week (of a 2-week response SLA) — paints it pink. Acting on a
 `Reviewed at`, `Decision notes`, and a `Chapter` assignment.
 
 **City provenance colors** (on the two city columns, below the error rule; installed by
-`aaif-clean-data install-colors`): the role tabs show **`City (Existing)`** (col G, the
-submitted dropdown) and **`City (New)`** (col H, the resolved city for `Other` rows).
+`aaif-clean-data install-colors`): the role tabs show **`City (Existing)`** (the
+submitted dropdown) and **`City (New)`** (the resolved city for `Other` rows) — an
+adjacent pair, found by header name; its position has already moved once.
 `City (New)` is painted **amber** when it holds a net-new resolved city; `City
 (Existing)` is painted **green** when it holds a real submitted city (non-empty, not
 "Other"). These tell you at a glance whether an applicant is from an existing chapter

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -28,8 +28,10 @@ TABS = {
                    "Talk title", "Ships in production?", "Past talks / portfolio"],
 }
 
-# Rows in these Status states (or blank) are "awaiting review".
-DEFAULT_NEEDS_REVIEW = {"", "New", "In progress"}
+# Rows in these Status states are "awaiting review". A blank Status IS "New"
+# (the form writes none) and is normalized to it in collect(), so filters match
+# on "New" alone — a custom --status list never needs to know about blanks.
+DEFAULT_NEEDS_REVIEW = {"New", "In progress"}
 
 # The City columns were renamed to City (Existing)/City (New). They only carry
 # those headers after `aaif-clean-data install-colors` has run; until then the
@@ -40,8 +42,14 @@ LEGACY_ALIASES = {"City (Existing)": "City", "City (New)": "Resolved City"}
 
 def fetch(tab):
     """Return (headers, rows) for a tab; rows are padded to len(headers)."""
+    # The range is the bare tab name — deliberately NOT a bounded window: a
+    # hardcoded "A1:BB" silently drops any column added past the bound, and the
+    # column it drops first is the newest one (this is the same anti-pattern
+    # clean.py's read_tab removed from this very spreadsheet). Sheets trims
+    # trailing empty rows/columns. A bare title also needs no quoting, unlike an
+    # "A1"-style range where a name with spaces must be quoted before the "!".
     params = json.dumps({"spreadsheetId": SHEET_ID,
-                         "range": f"{tab}!A1:BB", "majorDimension": "ROWS"})
+                         "range": tab, "majorDimension": "ROWS"})
     out = subprocess.run(["gws", "sheets", "spreadsheets", "values", "get",
                           "--params", params, "--format", "json"],
                          capture_output=True, text=True)
@@ -88,10 +96,12 @@ def collect(status_filter, show_all):
         for rn, row in enumerate(rows, start=2):  # row 2 = first data row
             if not (row[ti] or "").strip():
                 continue  # skip empty trailing rows (no Timestamp)
-            status = (row[si].strip() if si is not None else "")
+            # Blank IS "New" — normalized once here, so the filter below and the
+            # reported status can never disagree about what a blank cell means.
+            status = (row[si].strip() if si is not None else "") or "New"
             if not show_all and status not in status_filter:
                 continue
-            rec = {"row": rn, "status": status or "New"}
+            rec = {"row": rn, "status": status}
             for f in fields:
                 ci = col(headers, f)
                 if ci is None and f in LEGACY_ALIASES:
@@ -107,10 +117,12 @@ def truncate(s, n=70):
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
-def text_digest(data):
+def text_digest(data, label="awaiting review"):
+    """`label` names the population actually selected — under --all or a custom
+    --status filter, "awaiting review" would misdescribe every count printed."""
     total = sum(len(v) for v in data.values())
     counts = " · ".join(f"{len(v)} {t.lower()}" for t, v in data.items())
-    print(f"AAIF intake — {total} awaiting review ({counts})\n")
+    print(f"AAIF intake — {total} {label} ({counts})\n")
     for tab, recs in data.items():
         if not recs:
             continue
@@ -136,13 +148,17 @@ def main():
                     help="Status values to include (default: blank/New/In progress)")
     args = ap.parse_args()
     sf = set(args.status) if args.status is not None else DEFAULT_NEEDS_REVIEW
-    if args.status is not None:
-        sf.add("") if "New" in sf else None
     data = collect(sf, args.all)
+    if args.all:
+        label = "row(s), all statuses"
+    elif args.status is not None:
+        label = "with status " + " / ".join(sorted(sf))
+    else:
+        label = "awaiting review"
     if args.json:
         print(json.dumps(data, indent=1))
     else:
-        text_digest(data)
+        text_digest(data, label)
 
 
 if __name__ == "__main__":

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -33,6 +33,14 @@ TABS = {
 # on "New" alone — a custom --status list never needs to know about blanks.
 DEFAULT_NEEDS_REVIEW = {"New", "In progress"}
 
+
+def normalize_filter(values):
+    """Normalize a --status list the same way collect() normalizes cells: a
+    requested blank means the blank-status rows — which the rows themselves
+    report as "New" by then, so an un-normalized --status "" would silently
+    select zero rows."""
+    return {(v.strip() or "New") for v in values}
+
 # The City columns were renamed to City (Existing)/City (New). They only carry
 # those headers after `aaif-clean-data install-colors` has run; until then the
 # role tabs still show the legacy City/Resolved City. Fall back so the digest
@@ -145,9 +153,10 @@ def main():
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--all", action="store_true")
     ap.add_argument("--status", nargs="*", default=None,
-                    help="Status values to include (default: blank/New/In progress)")
+                    help="Status values to include (default: New/In progress; "
+                         "blank counts as New)")
     args = ap.parse_args()
-    sf = set(args.status) if args.status is not None else DEFAULT_NEEDS_REVIEW
+    sf = normalize_filter(args.status) if args.status is not None else DEFAULT_NEEDS_REVIEW
     data = collect(sf, args.all)
     if args.all:
         label = "row(s), all statuses"

--- a/skills/aaif-triage-intake/scripts/test_intake.py
+++ b/skills/aaif-triage-intake/scripts/test_intake.py
@@ -34,10 +34,120 @@ class TestDigestCity(unittest.TestCase):
         self.assertEqual(out.count("Paris"), 1)
 
 
+class TestDigestLabel(unittest.TestCase):
+    def test_headline_names_the_selected_population(self):
+        # Under --all or --status Accepted, "awaiting review" would misdescribe
+        # every count on the line; the label follows the active filter.
+        data = {"Organizers": [dict(BASE)], "Hosts": [], "Speakers": []}
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            intake.text_digest(data, "with status Accepted")
+        self.assertIn("1 with status Accepted", buf.getvalue())
+        self.assertNotIn("awaiting review", buf.getvalue())
+
+    def test_default_label_is_awaiting_review(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            intake.text_digest({"Organizers": [], "Hosts": [], "Speakers": []})
+        self.assertIn("0 awaiting review", buf.getvalue())
+
+
 class TestLegacyAliases(unittest.TestCase):
     def test_new_headers_map_to_legacy(self):
         self.assertEqual(intake.LEGACY_ALIASES["City (Existing)"], "City")
         self.assertEqual(intake.LEGACY_ALIASES["City (New)"], "Resolved City")
+
+
+class CollectBase(unittest.TestCase):
+    """collect() is the selection logic the whole skill hangs on — drive it with
+    fetch() stubbed per tab; Hosts/Speakers stay empty unless a test fills them."""
+
+    def _collect(self, sheets, status_filter=None, show_all=False):
+        orig = intake.fetch
+        intake.fetch = lambda tab: sheets.get(tab, ([], []))
+        try:
+            return intake.collect(status_filter if status_filter is not None
+                                  else intake.DEFAULT_NEEDS_REVIEW, show_all)
+        finally:
+            intake.fetch = orig
+
+    HDR = ["Timestamp", "Status", "Full name", "Email"]
+
+    def _org(self, rows, hdr=None):
+        return {"Organizers": (hdr or self.HDR, rows)}
+
+
+class TestCollectStatusFilter(CollectBase):
+    ROWS = [["t1", "", "Ada", "a@x.com"],            # blank status = New
+            ["t2", "New", "Grace", "g@x.com"],
+            ["t3", "In progress", "Joan", "j@x.com"],
+            ["t4", "Accepted", "Mary", "m@x.com"],
+            ["", "New", "ghost", ""]]                # no Timestamp -> not a row
+
+    def test_default_filter_takes_blank_new_and_in_progress(self):
+        got = self._collect(self._org(self.ROWS))["Organizers"]
+        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace", "Joan"])
+
+    def test_blank_status_is_normalized_to_new(self):
+        got = self._collect(self._org(self.ROWS))["Organizers"]
+        self.assertEqual(got[0]["status"], "New")
+
+    def test_a_custom_new_filter_still_includes_blank_status_rows(self):
+        # The regression: filtering on "New" alone used to drop blank-status
+        # rows, even though a blank Status IS New per the skill's status model.
+        got = self._collect(self._org(self.ROWS), status_filter={"New"})["Organizers"]
+        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace"])
+
+    def test_a_custom_filter_without_new_excludes_blank_rows(self):
+        got = self._collect(self._org(self.ROWS),
+                            status_filter={"In progress"})["Organizers"]
+        self.assertEqual([r["Full name"] for r in got], ["Joan"])
+
+    def test_show_all_ignores_the_filter_but_not_the_timestamp_marker(self):
+        got = self._collect(self._org(self.ROWS), show_all=True)["Organizers"]
+        self.assertEqual(len(got), 4)                  # ghost row still skipped
+        self.assertEqual(got[3]["status"], "Accepted")
+
+    def test_row_numbers_are_sheet_rows(self):
+        got = self._collect(self._org(self.ROWS), status_filter={"Accepted"})["Organizers"]
+        self.assertEqual([r["row"] for r in got], [5])  # row 2 = first data row
+
+
+class TestCollectLegacyAliases(CollectBase):
+    def test_falls_back_to_legacy_city_headers(self):
+        hdr = ["Timestamp", "Status", "Full name", "Email", "City", "Resolved City"]
+        rows = [["t", "New", "Ada", "a@x.com", "Other", "Boston"]]
+        got = self._collect(self._org(rows, hdr))["Organizers"]
+        self.assertEqual(got[0]["City (Existing)"], "Other")
+        self.assertEqual(got[0]["City (New)"], "Boston")
+
+    def test_new_headers_win_when_present(self):
+        hdr = ["Timestamp", "Status", "Full name", "Email",
+               "City (Existing)", "City (New)"]
+        rows = [["t", "New", "Ada", "a@x.com", "Boston", ""]]
+        got = self._collect(self._org(rows, hdr))["Organizers"]
+        self.assertEqual(got[0]["City (Existing)"], "Boston")
+
+
+class TestCollectAborts(CollectBase):
+    def test_missing_timestamp_header_aborts(self):
+        # A rename is not an empty queue; "0 awaiting review" must not print.
+        hdr = ["When", "Status", "Full name", "Email"]
+        with self.assertRaises(SystemExit) as e:
+            self._collect(self._org([["t", "New", "Ada", "a@x.com"]], hdr))
+        self.assertIn("Timestamp", str(e.exception))
+
+    def test_missing_status_header_aborts_unless_show_all(self):
+        hdr = ["Timestamp", "Full name", "Email"]
+        sheets = self._org([["t", "Ada", "a@x.com"]], hdr)
+        with self.assertRaises(SystemExit) as e:
+            self._collect(sheets)
+        self.assertIn("Status", str(e.exception))
+        got = self._collect(sheets, show_all=True)["Organizers"]
+        self.assertEqual(got[0]["status"], "New")      # no column reads as New
+
+    def test_an_empty_tab_is_an_empty_queue_not_an_abort(self):
+        self.assertEqual(self._collect({})["Organizers"], [])
 
 
 if __name__ == "__main__":

--- a/skills/aaif-triage-intake/scripts/test_intake.py
+++ b/skills/aaif-triage-intake/scripts/test_intake.py
@@ -108,6 +108,18 @@ class TestCollectStatusFilter(CollectBase):
         self.assertEqual(len(got), 4)                  # ghost row still skipped
         self.assertEqual(got[3]["status"], "Accepted")
 
+    def test_explicit_blank_status_selects_blank_rows(self):
+        # The regression: --status "" used to silently select zero rows, because
+        # blank cells normalize to "New" before the filter ever sees them. The
+        # filter must be normalized the same way.
+        got = self._collect(self._org(self.ROWS),
+                            status_filter=intake.normalize_filter([""]))["Organizers"]
+        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace"])
+
+    def test_normalize_filter_maps_blank_to_new_and_keeps_the_rest(self):
+        self.assertEqual(intake.normalize_filter(["", "  ", "Accepted"]),
+                         {"New", "Accepted"})
+
     def test_row_numbers_are_sheet_rows(self):
         got = self._collect(self._org(self.ROWS), status_filter={"Accepted"})["Organizers"]
         self.assertEqual([r["row"] for r in got], [5])  # row 2 = first data row

--- a/skills/aaif-update-event/SKILL.md
+++ b/skills/aaif-update-event/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aaif-update-event
-description: Apply a change to an existing AAIF event (chapter or series) — edit detail fields like speakers/venue/capacity, or move the date and recompute all task due-dates, then flag which marketing/banner assets are now stale; can also sync the change to the live Luma event page (diff shown first, pushed only on explicit user approval). Use when asked to update/change/edit an event's details or date.
+description: Apply a change to an existing AAIF event (chapter or series) — edit detail fields like speakers/venue/capacity, or move the date and recompute all task due-dates, then flag which marketing/banner assets are now stale (speaker, venue/location, and date changes set flags); can also sync the change to the live Luma event page (diff shown first, pushed only on explicit user approval). Use when asked to update/change/edit an event's details or date.
 argument-hint: '<chapter|series> <event> [--set "LABEL=value"] [--date "..."]'
 ---
 
@@ -62,7 +62,13 @@ deterministic docx edit on a local file.** Prereq: `gws` installed and authentic
    - **series (online):** same, but `PLATFORM` and `STREAM / JOIN LINK` replace
      `LOCATION / CITY` and `VENUE`.
 
-   `--set` with a label absent from that tracker raises an error (it won't silently no-op).
+   `--set` with a label absent from that tracker raises an error (it won't silently
+   no-op). `--set "DATE & TIME=..."` is **refused** — a bare field write would skip
+   the due-date recompute, which must run against the original date; move a date
+   with `--date` only.
+
+   Add `--dry-run` to preview: it prints the field diff (old → new) and the
+   stale-asset list without writing the docx; re-run without it to apply.
 
 3. **Upload it back:**
 

--- a/skills/aaif-update-event/SKILL.md
+++ b/skills/aaif-update-event/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aaif-update-event
-description: Apply a change to an existing AAIF event (chapter or series) — edit detail fields like speakers/venue/capacity, or move the date and recompute all task due-dates, then flag which marketing/banner assets are now stale (speaker, venue/location, and date changes set flags); can also sync the change to the live Luma event page (diff shown first, pushed only on explicit user approval). Use when asked to update/change/edit an event's details or date.
+description: Apply a change to an existing AAIF event (chapter or series) — edit detail fields like speakers/venue/capacity, or move the date and recompute all task due-dates, then flag which marketing/banner assets are now stale (speaker, venue/location, platform/join-link, and date changes set flags); can also sync the change to the live Luma event page (diff shown first, pushed only on explicit user approval). Use when asked to update/change/edit an event's details or date.
 argument-hint: '<chapter|series> <event> [--set "LABEL=value"] [--date "..."]'
 ---
 
@@ -60,7 +60,8 @@ deterministic docx edit on a local file.** Prereq: `gws` installed and authentic
    - **chapter (in-person):** EVENT TITLE, DATE & TIME, LOCATION / CITY, VENUE,
      THEME / SERIES, FORMAT(S), SPEAKER(S), LUMA URL, CAPACITY / RSVPS, ORGANIZER ON POINT.
    - **series (online):** same, but `PLATFORM` and `STREAM / JOIN LINK` replace
-     `LOCATION / CITY` and `VENUE`.
+     `LOCATION / CITY` and `VENUE` — and changing either flags the same stale
+     assets a venue change does (the reminder and slides carry the join link).
 
    `--set` with a label absent from that tracker raises an error (it won't silently
    no-op). `--set "DATE & TIME=..."` is **refused** — a bare field write would skip

--- a/skills/aaif-update-event/scripts/luma_sync.py
+++ b/skills/aaif-update-event/scripts/luma_sync.py
@@ -108,7 +108,9 @@ def main():
 
     # verify: re-fetch and re-diff. description_md is excluded — Luma's Spark
     # round-trip isn't byte-stable, so it would always look dirty right after a
-    # push (cover_url likewise: the CDN rewrites the URL).
+    # push. cover_url needs no such pop: it is never part of `desired` (it only
+    # enters `changes` when --cover is given), so the CDN rewriting the uploaded
+    # URL can't make the verify look dirty either.
     desired.pop("description_md", None)
     still = luma.diff_payload(luma.get_event(event_id), desired)
     if still:

--- a/skills/aaif-update-event/scripts/test_update_event.py
+++ b/skills/aaif-update-event/scripts/test_update_event.py
@@ -50,6 +50,26 @@ class TestApplyChanges(unittest.TestCase):
         with self.assertRaises(ValueError):
             update_event.apply_changes(self.root, "Agentic AI Night", ["SPEAKER(S)"], None)
 
+    def test_set_venue_flags_stale(self):
+        stale = update_event.apply_changes(
+            self.root, "Agentic AI Night", ["VENUE=The Foundry, 2nd floor"], None)
+        ev = tracker.read_event(self.root, "Agentic AI Night")
+        self.assertEqual(ev["details"]["VENUE"], "The Foundry, 2nd floor")
+        self.assertIn("announcement post", stale)
+        self.assertIn("attendee reminder", stale)
+
+    def test_set_date_field_is_refused(self):
+        # a bare DATE & TIME write would silently skip the due-date recompute —
+        # it must abort and point at --date instead.
+        with self.assertRaises(ValueError) as ctx:
+            update_event.apply_changes(
+                self.root, "Agentic AI Night",
+                ["DATE & TIME=Wed · July 8, 2026 · 17:30 — late"], None)
+        self.assertIn("--date", str(ctx.exception))
+        # nothing was written
+        ev = tracker.read_event(self.root, "Agentic AI Night")
+        self.assertNotIn("July 8", ev["details"]["DATE & TIME"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/aaif-update-event/scripts/test_update_event.py
+++ b/skills/aaif-update-event/scripts/test_update_event.py
@@ -1,7 +1,12 @@
 import datetime as dt
+import io
 import os
+import shutil
 import sys
+import tempfile
 import unittest
+from contextlib import redirect_stdout
+from unittest import mock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                  "..", "..", "..", "lib")))
@@ -9,9 +14,10 @@ sys.path.insert(0, os.path.dirname(__file__))
 import update_event  # noqa: E402
 from aaif_events import office, tracker  # noqa: E402
 
-FIX = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
-                                   "lib", "aaif_events", "tests", "fixtures",
-                                   "event_tracker_irl.docx"))
+_FIXDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                                       "lib", "aaif_events", "tests", "fixtures"))
+FIX = os.path.join(_FIXDIR, "event_tracker_irl.docx")
+FIX_ONLINE = os.path.join(_FIXDIR, "event_tracker_online.docx")
 
 
 class TestApplyChanges(unittest.TestCase):
@@ -58,6 +64,22 @@ class TestApplyChanges(unittest.TestCase):
         self.assertIn("announcement post", stale)
         self.assertIn("attendee reminder", stale)
 
+    def test_set_platform_flags_stale_like_venue(self):
+        # Series trackers have no VENUE — their "where" is PLATFORM and
+        # STREAM / JOIN LINK, and changing either goes stale the same way.
+        root = office.read_document(FIX_ONLINE)
+        stale = update_event.apply_changes(
+            root, "Agentic AI Night", ["PLATFORM=Zoom"], None)
+        self.assertEqual(stale, set(update_event.STALE_ON_VENUE))
+
+    def test_set_join_link_flags_stale_like_venue(self):
+        root = office.read_document(FIX_ONLINE)
+        stale = update_event.apply_changes(
+            root, "Agentic AI Night",
+            ["STREAM / JOIN LINK=https://zoom.example/j/12345"], None)
+        self.assertIn("attendee reminder", stale)
+        self.assertIn("day-of slides", stale)
+
     def test_set_date_field_is_refused(self):
         # a bare DATE & TIME write would silently skip the due-date recompute —
         # it must abort and point at --date instead.
@@ -69,6 +91,26 @@ class TestApplyChanges(unittest.TestCase):
         # nothing was written
         ev = tracker.read_event(self.root, "Agentic AI Night")
         self.assertNotIn("July 8", ev["details"]["DATE & TIME"])
+
+
+class TestDryRunSafety(unittest.TestCase):
+    def test_dry_run_writes_nothing_to_the_docx(self):
+        # The safety promise --dry-run makes: apply_changes mutates the tree in
+        # memory, but the file on disk must come back byte-for-byte identical.
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "tracker.docx")
+            shutil.copyfile(FIX, p)
+            with open(p, "rb") as f:
+                before = f.read()
+            argv = ["update_event.py", p, "Agentic AI Night",
+                    "--set", "SPEAKER(S)=Jane Doe",
+                    "--date", "Wed · July 8, 2026 · 17:30 — late", "--dry-run"]
+            buf = io.StringIO()
+            with mock.patch.object(sys, "argv", argv), redirect_stdout(buf):
+                update_event.main()
+            with open(p, "rb") as f:
+                self.assertEqual(f.read(), before)
+            self.assertIn("nothing written", buf.getvalue())
 
 
 if __name__ == "__main__":

--- a/skills/aaif-update-event/scripts/update_event.py
+++ b/skills/aaif-update-event/scripts/update_event.py
@@ -12,6 +12,9 @@ from aaif_events import office, tracker  # noqa: E402
 STALE_ON_DATE = ["square banner", "Luma cover", "announcement post",
                  "carousel", "day-of slides", "attendee reminder"]
 STALE_ON_SPEAKER = ["speaker bio", "announcement post", "carousel", "day-of slides"]
+# "Where" changes: chapter trackers say VENUE / LOCATION; series trackers say
+# PLATFORM / STREAM / JOIN LINK (see tracker.py's label note). Same stale set —
+# the reminder/slides carry the join link exactly like they carry the venue.
 STALE_ON_VENUE = ["announcement post", "day-of slides", "attendee reminder"]
 
 
@@ -34,7 +37,8 @@ def apply_changes(root, event, set_pairs, date_str):
         tracker.set_field(root, event, label.strip(), value.strip())
         if "SPEAKER" in lab:
             stale.update(STALE_ON_SPEAKER)
-        if "VENUE" in lab or "LOCATION" in lab:
+        if ("VENUE" in lab or "LOCATION" in lab
+                or "PLATFORM" in lab or "JOIN LINK" in lab):
             stale.update(STALE_ON_VENUE)
     if date_str:
         # restamp DUE cells using the original date still in the doc, THEN overwrite

--- a/skills/aaif-update-event/scripts/update_event.py
+++ b/skills/aaif-update-event/scripts/update_event.py
@@ -12,6 +12,7 @@ from aaif_events import office, tracker  # noqa: E402
 STALE_ON_DATE = ["square banner", "Luma cover", "announcement post",
                  "carousel", "day-of slides", "attendee reminder"]
 STALE_ON_SPEAKER = ["speaker bio", "announcement post", "carousel", "day-of slides"]
+STALE_ON_VENUE = ["announcement post", "day-of slides", "attendee reminder"]
 
 
 def apply_changes(root, event, set_pairs, date_str):
@@ -23,9 +24,18 @@ def apply_changes(root, event, set_pairs, date_str):
         if "=" not in pair:
             raise ValueError("--set must be LABEL=VALUE (got %r)" % pair)
         label, _, value = pair.partition("=")
+        lab = label.strip().upper()
+        if lab == "DATE & TIME":
+            # A bare field write would skip the due-date recompute (which must run
+            # against the ORIGINAL date) — that's exactly what --date exists for.
+            raise ValueError('--set cannot write DATE & TIME - use --date "..." '
+                             "so every phase due-date is recomputed from the "
+                             "original date.")
         tracker.set_field(root, event, label.strip(), value.strip())
-        if "SPEAKER" in label.upper():
+        if "SPEAKER" in lab:
             stale.update(STALE_ON_SPEAKER)
+        if "VENUE" in lab or "LOCATION" in lab:
+            stale.update(STALE_ON_VENUE)
     if date_str:
         # restamp DUE cells using the original date still in the doc, THEN overwrite
         # DATE & TIME with the user's full string (so weekday/time are exactly as given).
@@ -42,10 +52,25 @@ def main():
     ap.add_argument("--set", action="append", default=[],
                     metavar="LABEL=VALUE", help='e.g. --set "SPEAKER(S)=Jane Doe"')
     ap.add_argument("--date", help="new DATE & TIME value; triggers due-date recompute")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the field diff and stale-asset list; write nothing")
     a = ap.parse_args()
 
     root = office.read_document(a.docx)
+    before = dict(tracker.read_event(root, a.event)["details"]) if a.dry_run else None
     stale = apply_changes(root, a.event, a.set, a.date)
+    if a.dry_run:
+        after = tracker.read_event(root, a.event)["details"]
+        print("[dry-run] would update %r in %s:" % (a.event, a.docx))
+        for label in sorted(set(before) | set(after)):
+            if before.get(label) != after.get(label):
+                print("  %-18s %r -> %r" % (label + ":", before.get(label), after.get(label)))
+        if a.date:
+            print("  (all phase due-dates recomputed from the original date)")
+        if stale:
+            print("[dry-run] now stale — re-run these skills: " + ", ".join(sorted(stale)))
+        print("[dry-run] nothing written; re-run without --dry-run to apply.")
+        return
     office.save_document(a.docx, root, a.docx)
     print("Updated %r in %s." % (a.event, a.docx))
     if stale:


### PR DESCRIPTION
## Summary
Full-repo review of the 18 skills plus the shared lib, then fixes for everything found: robustness holes (PII guards, lost-update races, unresumable clones), doc-code drift, and dead code. Five parallel reviewers produced ~40 findings; six fixer agents applied them; a 4-angle simplify pass and this branch's own test suites (145 lib + 13 skill suites) are green.

## Changesets

### 1. `fix(lib): harden shared modules and add app-token fallback`
**Files:** lib/aaif_events/* (+ tests)
Token fallback (env → .env → CLI credentials) unsticks every Slack consumer; PII gitignore guard aborts on git failure; retry/translation unified; caches fsync'd and workspace-stamped; dead code deleted.

### 2. `fix(audit-slack): survive mid-sweep messages, private-held aliases, stale caches`
**Files:** skills/aaif-audit-slack/*
Histogram clamp, held-private downgrade under --planned-ok, stale-cache re-fetch instead of an abort loop, 0600-from-first-byte reports.

### 3. `fix(sync-chapters): close the lost-update race and gate banner pins`
**Files:** skills/aaif-sync-chapters/*
CRM/About writes skip files a human edited since planning; pins need --pins (nightly can never publish banners); malformed intake rows skip-and-report; shared helpers hoisted.

### 4. `fix(data-ops): backup PII guard, clean-data doc footgun, triage window`
**Files:** skills/aaif-backup/*, skills/aaif-clean-data/*, skills/aaif-triage-intake/*
Backup refuses committable destinations; the Resolved-City write instruction (an ARRAYFORMULA #REF! footgun) is corrected; A1:BB window replaced with unbounded reads.

### 5. `feat(creators): re-sync the series engine and add --resume to both`
**Files:** skills/aaif-create-chapter/*, skills/aaif-create-online-series/*
The series engine had silently forked from create-chapter (missing worksheet branch, zip hardening, name transforms) with zero tests — now re-synced with an 18-test suite; --resume recovers failed runs and does Luxembourg-style backfills.

### 6. `fix(event-skills): update-event dry-run and DATE guard, status error paths`
**Files:** skills/aaif-create-event/*, skills/aaif-update-event/*, skills/aaif-event-status/*
--dry-run previews; --set refuses the date field; VENUE changes flag stale assets; clean error messages on the direct Luma paths.

### 7. `docs: align README, CONTRIBUTING, gitignore, and content-skill copy`
**Files:** README.md, CONTRIBUTING.md, .gitignore, 8 content SKILL.mds
All 18 skills listed; standalone-zip caveat; Discord→Slack; sanctioned pptx→PDF recipe; legal footer on recaps.

## Test Plan
- [x] `PYTHONPATH=lib python -m pytest lib/aaif_events/tests -q` — 145 passed
- [x] All 13 `skills/*/scripts/test_*.py` suites pass (2 new suites, ~40 new checks)
- [x] `pre-commit run --all-files` and `claude plugin validate .` pass
- [x] Live smokes: all three audit engines and the 5-engine nightly rehearsal ran end-to-end on the new token path### 8. `fix: address self-review findings across all seven review streams`
**Files:** 24 files (+~600 −~150)
Seven-stream self-review (5 pr-review-toolkit agents, security pass, deep /code-review) found 3 critical, 12 important, 6 suggestions — all fixed: malformed intake rows hold back the chapter's About doc instead of silently deleting the organizer; --resume repairs skipped files and renames original-name children instead of duplicating; the membership floor aborts loudly on channel renames; plus .env parsing, PDF permissions, LC_ALL pinning, flag-conflict rejection, CRM-path injection enforcement, and 30 new test checks.

## Review
Self-review posted and applied: see the two <code>Self-Review</code> comments. Final state: 154 lib tests, 14 skill suites, pre-commit, plugin validate — all green.

_Generated using hero-skills._