### PR TITLE
Rename intake status New to Prospect across sheet, CRMs, and code

### DIFF
--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -348,9 +348,10 @@ from the intake and carries each person's survey interest across.
 **Who syncs — the self-serve organizer policy (2026-08).**
 
 - `Accepted` and `Existing (from MLOps)` people always sync, all three role tabs.
-- **Hosts and speakers still in the pipeline** (`New` / blank / `In progress` /
-  `Tentative` / `Interviewing`) sync too, so a chapter sees its candidate venues
-  and talks without waiting on central triage.
+- **Hosts and speakers still in the pipeline** (`Prospect` — including its
+  legacy spelling `New`, retired 2026-08-22 by `migrate_status_prospect.py` — /
+  blank / `In progress` / `Tentative` / `Interviewing`) sync too, so a chapter
+  sees its candidate venues and talks without waiting on central triage.
 - **Organizers still in the pipeline** sync **only into a self-serve chapter** —
   one with **4+ accepted organizers** (`SELF_SERVE_MIN`), not counting AAIF ops
   people (`AAIF_OPS_NAMES`: Rahul, Demetrios, Ijeoma). Those chapters run their
@@ -468,7 +469,8 @@ used instead of inventing one.
   corrected spellings, hand-written notes and manually added companies all
   survive every re-run. Only genuinely blank cells are filled.
 - **`Status` is the one exception**: it is upgraded when it still holds a value
-  the automation itself wrote (`New`, `Prospect`, `Organizer`, `Speaker`,
+  the automation itself wrote (`Prospect` — or its legacy spelling `New` —
+  `Organizer`, `Speaker`,
   `Host`). That is how a person's role is corrected after re-triage — while a
   human's `Attended`, `Regular`, `Volunteer` or `Declined` is never undone.
 - **Fixture rows are cleared, and only fixture rows.** A row is wiped **only** if
@@ -492,7 +494,10 @@ used instead of inventing one.
   value for a venue host, so hosts had nowhere honest to land. Every workbook the
   script opens is patched — including **TemplateCity**, or every chapter cloned
   from it would re-inherit the gap. Both quote encodings are handled (the
-  template writes `"…"`, older workbooks write `&quot;…&quot;`). A workbook with
+  template writes `"…"`, older workbooks write `&quot;…&quot;`), and so are the
+  post-migration lists without the legacy `New` (removed by
+  `migrate_status_prospect.py`; the unrelated `New` on the **Signal** list is
+  untouched by that migration). A workbook with
   no Status list at all is reported, not guessed at.
 - **TemplateCity never receives people** — only the dropdown patch.
 - **Rows are skipped, and reported, when**: `Status` is neither a decided-yes

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -470,9 +470,9 @@ used instead of inventing one.
   survive every re-run. Only genuinely blank cells are filled.
 - **`Status` is the one exception**: it is upgraded when it still holds a value
   the automation itself wrote (`Prospect` — or its legacy spelling `New` —
-  `Organizer`, `Speaker`,
-  `Host`). That is how a person's role is corrected after re-triage — while a
-  human's `Attended`, `Regular`, `Volunteer` or `Declined` is never undone.
+  `Organizer`, `Speaker`, `Host`). That is how a person's role is corrected
+  after re-triage — while a human's `Attended`, `Regular`, `Volunteer` or
+  `Declined` is never undone.
 - **Fixture rows are cleared, and only fixture rows.** A row is wiped **only** if
   its `Email` is at a reserved example domain (`@example.com`, `.org`, `.net`,
   `.edu`) — that is the sole gate, deliberately narrow and anchored on the `@` so

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -271,7 +271,9 @@ hand-edited list in the estate is why:
 > **Melbourne's About doc grouped applicants under `Approved` / `Submitted
 > Application` / `Planning Application`** — publishing, in a doc shared with the
 > chapter, that two named people had applied and had **not** been approved (one
-> still `New` on the intake, one not on it at all). Skipping a hand-edited list
+> still `New` on the intake — the pre-2026-08-22 spelling of `Prospect`; this is
+> a record of what the doc said at the time, not current vocabulary — one not on
+> it at all). Skipping a hand-edited list
 > preserves that disclosure. So anything in the section that is not an accepted
 > organizer comes out.
 
@@ -942,7 +944,8 @@ After any run (and after editing the engine):
 - Report-mode exit codes are part of the contract now: `0` in sync, `2` drift,
   else failure (see the `nightly.py` section) — a wrapper that treats `2` as an
   error will misread every report that proposes anything.
-- Unit tests for the pure logic in all five engines (no network, no `gws`):
+- Unit tests for the pure logic in the five engines and the one-shot migration
+  (no network, no `gws`):
   ```bash
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_chapters.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_about.py
@@ -952,7 +955,45 @@ After any run (and after editing the engine):
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_invite_organizers.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_prune_organizers.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_nightly.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_status_prospect.py
   ```
+
+## One-shot: retiring the status `New` (`migrate_status_prospect.py`)
+
+Renames the intake status `New` → `Prospect` everywhere it is *stored*. Ran
+2026-08-21/22; kept because it is the tool that proves the estate is still
+consistent, and the pattern for the next status rename.
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_status_prospect.py             # report, writes nothing
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_status_prospect.py --city Boston
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_status_prospect.py --write     # apply, then verify
+```
+
+- **Phase A — the Intake Ops spreadsheet**: the Status dropdown, every Status
+  cell (column A only — B+ are ARRAYFORMULA mirrors, and it refuses a tab whose
+  Status column moved), the hand-made **conditional-format rules that test the
+  literal** (the blue row color and the pink SLA-breach rule — `clean.py` does
+  not own these, so nothing else would ever repair them), and the **"How to
+  use"** tab's status prose.
+- **Phase B — every chapter CRM** plus TemplateCity/TemplateSeries: the Status
+  column is located by header name, and only a validation whose sqref covers
+  *exactly* that column is touched, so the Signal list's unrelated `New`
+  survives. Zip-part surgery; every other part is repacked byte-identically.
+- **`--city` scopes Phase B only.** Phase A is the whole spreadsheet, so with
+  `--city` it is reported but **not** written unless you add `--include-intake`.
+- **Exit codes** follow the house contract: `0` in sync, `2` changes proposed or
+  applied, `1` failure. A **refusal** ("this is shaped in a way I will not
+  rewrite — a range-backed list, an `x14` validation, an `EXACT()` color rule")
+  is reported as *needs a human* and never counted as pending work, so it cannot
+  pin later runs to a permanent failure.
+- Pre-edit workbook copies are kept under a `before/` directory (printed at the
+  end) after a `--write`; the working copies are deleted, since they hold the
+  same member PII.
+
+Once a run over the full estate exits `0`, the legacy `New` entries in
+`sync_crm.PIPELINE_STATUSES` / `AUTO_STATUS` and `intake.normalize_status` can
+be deleted — that exit code is the evidence they are waiting on.
 
 ## Notes
 

--- a/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
@@ -22,7 +22,9 @@ Phase A — the Intake Ops role tabs (Organizers / Speakers / Hosts):
     unpaints every Prospect row and — the real damage — stops the 1-week SLA
     breach from ever firing again. These rules are hand-made on the sheet;
     clean.py owns only the red error rule and the city/violet rules, so nothing
-    else would ever repair them.
+    else would ever repair them;
+  * the "How to use" tab's status prose is migrated by exact whole-sentence
+    match — it is what an organizer reads before picking from the dropdown.
 
 Phase B — every chapter CRM workbook (the ~80 "<City> CRM.xlsx" under the
 Chapters Drive folder, plus the TemplateCity and TemplateSeries templates):
@@ -63,7 +65,8 @@ from xml.etree import ElementTree as ET
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from sync_chapters import (INTAKE_ID, download, fold_city, fresh_if_unchanged,  # noqa: E402
                            get_values, gws_json, upload)
-from sync_crm import (CRM_SHEET, X, XLSX, cell_text, col_of, find_crm,  # noqa: E402
+from sync_crm import (CRM_SHEET, X, XLSX, cell_ref, cell_text, col_of,  # noqa: E402
+                      find_crm,
                       list_chapter_folders, load_parts, register_namespaces,
                       save_parts, set_cell, shared_strings, sheet_part,
                       _XML_DECL)
@@ -136,6 +139,61 @@ def cf_refusal(formula):
         return None
     return ("tests the Status column for %r in a shape this script does not "
             "rewrite (%s) — migrate it by hand" % (OLD, f))
+
+
+HOWTO_TAB = "How to use"
+# The tab organizers actually read before they touch a dropdown: it teaches the
+# status flow in prose, so a rename that skips it leaves the sheet documenting
+# a value the dropdown no longer offers.
+#
+# Migrated by EXACT WHOLE-CELL match — never a word swap over the tab. The same
+# tab legitimately says "New submissions", "New city" and "City (New)" (a
+# column header, not a status), and a regex for the word would have rewritten
+# all three. Pinning the entire sentence is also what makes the single
+# first-occurrence swap below unambiguous: in each of these five cells the
+# first capital-N "New" IS the status. A sentence present in neither spelling
+# means the tab was reworded — reported, never guessed at.
+HOWTO_TEXTS = (
+    "New \u2192 In progress \u2192 Accepted / Denied",
+    "Every new submission defaults to New. Pick from the dropdown as you work "
+    "each person: Tentative once their LinkedIn checks out, Interviewing while "
+    "the interview is scheduled or under way, then Accepted / Denied. Use "
+    "Inactive to park one without deciding, and Duplicate for a repeat "
+    "submission from someone already in the queue.",
+    "New \u2014 untriaged.",
+    "Overdue \u2014 still New after 1 week (of a 2-week response SLA). Act on "
+    "it to clear.",
+    "Form submission  \u2192  \U0001f7e6 New",
+)
+
+
+def howto_new_text(old):
+    """The migrated text of one How-to-use sentence: the FIRST "New" only."""
+    return old.replace(OLD, NEW, 1)
+
+
+def plan_howto(rows):
+    """([(a1, old, new)], [refusals]) for the How-to-use tab's status prose.
+
+    `rows` is the tab as returned by get_values (ragged rows of strings). Each
+    sentence is located by its text, not by a fixed A1 — the tab gets rows
+    inserted as it is edited, and a coordinate would silently rewrite the wrong
+    cell after that.
+    """
+    where = {}
+    for i, row in enumerate(rows, start=1):
+        for j, cell in enumerate(row):
+            where.setdefault((cell or "").strip(), cell_ref(j, i))
+    plans, refusals = [], []
+    for old in HOWTO_TEXTS:
+        new = howto_new_text(old)
+        if old in where:
+            plans.append((where[old], old, new))
+        elif new not in where:
+            refusals.append("the sentence %r is on the tab in neither "
+                            "spelling \u2014 it was reworded; migrate it by hand"
+                            % (old[:48] + ("..." if len(old) > 48 else "")))
+    return plans, refusals
 
 
 def intake_status_guard(headers):
@@ -375,10 +433,13 @@ def intake_cf_plans(tab):
         vals = cond.get("values") or []
         old = vals[0].get("userEnteredValue", "") if vals else ""
         new = migrate_cf_formula(old)
+        # Judged on what the rule WILL say: one holding both the exact token
+        # and an unrecognised shape is migrated AND reported, never quietly
+        # half-done.
+        why = cf_refusal(new if new is not None else old)
+        if why:
+            refusals.append("conditional-format rule %d %s" % (i, why))
         if new is None:
-            why = cf_refusal(old)
-            if why:
-                refusals.append("conditional-format rule %d %s" % (i, why))
             continue
         rule = copy.deepcopy(cf)
         rule["booleanRule"]["condition"]["values"][0]["userEnteredValue"] = new
@@ -396,8 +457,25 @@ def apply_intake_cf(gid, plans):
                  for i, _old, rule in plans]})
 
 
+def intake_howto_plans():
+    """plan_howto over the live tab. Z200 covers it with room to grow."""
+    return plan_howto(get_values(INTAKE_ID, "'%s'!A1:Z200" % HOWTO_TAB))
+
+
+def apply_howto(plans):
+    """RAW writes to the located cells. The affected cells carry no rich-text
+    runs, so a value write keeps their formatting intact."""
+    gws_json("sheets", "spreadsheets", "values", "batchUpdate",
+             params={"spreadsheetId": INTAKE_ID},
+             body={"valueInputOption": "RAW",
+                   "data": [{"range": "'%s'!%s" % (HOWTO_TAB, a1),
+                             "values": [[new]]}
+                            for a1, _old, new in plans]})
+
+
 def plan_intake_tab(tab):
-    """One tab's plan: {tab, guard, cell_rows, gid, rule, r0, r1, new_list}."""
+    """One tab's plan: {tab, guard, cell_rows, gid, rule, r0, r1, new_list,
+    cf_gid, cf_plans, cf_refusals}."""
     col_a = [r[0] if r else "" for r in
              get_values(INTAKE_ID, "'%s'!A1:A" % tab)]
     headers = get_values(INTAKE_ID, "'%s'!1:1" % tab)
@@ -419,7 +497,8 @@ def plan_intake_tab(tab):
 
 
 def apply_intake_tab(plan):
-    """Apply one tab's plan: the dropdown rule, then the cell rewrites."""
+    """Apply one tab's plan: the dropdown rule, the color rules, then the cell
+    rewrites."""
     tab = plan["tab"]
     if plan["new_list"]:
         # An EXPLICIT full rule over the rule's own observed row span. Never a
@@ -573,6 +652,16 @@ def _run(args, workdir):
         proposed += (len(plan["cell_rows"]) + (1 if plan["new_list"] else 0)
                      + len(plan["cf_plans"]))
 
+    howto_plans, howto_refusals = intake_howto_plans()
+    for r in howto_refusals:
+        failures.append("%s: %s" % (HOWTO_TAB, r))
+        print("  %-10s REFUSED — %s" % (HOWTO_TAB, r))
+    print("  %-10s %s" % (HOWTO_TAB,
+                          ("%d status sentence(s) %r -> %r"
+                           % (len(howto_plans), OLD, NEW))
+                          if howto_plans else "in sync"))
+    proposed += len(howto_plans)
+
     print("\nPhase B — chapter CRMs:")
     backup_dir = os.path.join(workdir, "before")
     os.makedirs(backup_dir, exist_ok=True)
@@ -605,8 +694,8 @@ def _run(args, workdir):
             for f in failures:
                 print("  %s" % f)
             return 1
-        print("\nNothing to do — %r is gone from every dropdown, cell and "
-              "color rule." % OLD)
+        print("\nNothing to do — %r is gone from every dropdown, cell, color "
+              "rule and How-to-use sentence." % OLD)
         return 0
 
     if not args.write:
@@ -614,7 +703,7 @@ def _run(args, workdir):
               "Re-run with --write to apply."
               % (proposed, sum(1 for p in tab_plans
                                if p["cell_rows"] or p["new_list"]
-                               or p["cf_plans"]),
+                               or p["cf_plans"]) + (1 if howto_plans else 0),
                  len(crm_plans)))
         return 1 if failures else 2
 
@@ -629,6 +718,13 @@ def _run(args, workdir):
         except Exception as e:
             failures.append("%s: %s" % (plan["tab"], e))
             print("  FAILED %s — %s" % (plan["tab"], e), file=sys.stderr)
+    if howto_plans:
+        try:
+            apply_howto(howto_plans)
+            print("  wrote %s (%d sentence(s))" % (HOWTO_TAB, len(howto_plans)))
+        except Exception as e:
+            failures.append("%s: %s" % (HOWTO_TAB, e))
+            print("  FAILED %s — %s" % (HOWTO_TAB, e), file=sys.stderr)
     for folder, book, plan in crm_plans:
         try:
             why = write_crm(folder, book, plan, workdir, backup_dir)
@@ -649,6 +745,11 @@ def _run(args, workdir):
         bad = verify_intake_tab(plan["tab"])
         if bad:
             failures.append(bad)
+    if howto_plans:
+        left, still_refused = intake_howto_plans()
+        if left or still_refused:
+            failures.append("%s: %d status sentence(s) not migrated"
+                            % (HOWTO_TAB, len(left) + len(still_refused)))
 
     if failures:
         print("VERIFY FAILED / INCOMPLETE:")

--- a/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
@@ -40,6 +40,12 @@ Chapters Drive folder, plus the TemplateCity and TemplateSeries templates):
   Attendees sheet part is re-serialized; every other part is repacked
   byte-identically. Pre-edit bytes are kept in a mkdtemp backup dir.
 
+NOT in scope: the CRMs' free-text "Notes (CRM)" cells. Every row synced before
+the rename carries an audit note reading "Intake: Organizer - New - <date>",
+and those stay: the note records what the status WAS when the row was written,
+sync_crm never overwrites a non-blank note, and rewriting history in a
+human-editable column to match today's vocabulary is not this script's job.
+
 House rules: report is the default and writes nothing; --write applies, then
 re-downloads / re-reads and verifies, printing a Verified line. No member names
 or emails on stdout — counts, tab names and file names only.
@@ -47,11 +53,17 @@ or emails on stdout — counts, tab names and file names only.
 Exit codes: 0 everything already in sync; 2 changes proposed (or applied);
 1 failure (including a failed verify or a skipped workbook).
 
+A REFUSAL ("shaped in a way I will not rewrite": a range-backed list, an x14
+validation, an EXACT() color rule) is reported as needs-a-human and is NEVER
+folded into a verify verdict — it is still true after a perfectly successful
+write, so counting it would pin every later run to a permanent failure.
+
 Usage:
   python3 migrate_status_prospect.py            # report only, zero writes
   python3 migrate_status_prospect.py --city Boston   # scope Phase B to one CRM
-                                                    # (Phase A still runs whole)
   python3 migrate_status_prospect.py --write    # apply, then verify
+  # --city scopes Phase B ONLY; Phase A is the whole spreadsheet, so with
+  # --city it is reported but not written unless --include-intake is passed.
 """
 import argparse
 import copy
@@ -61,19 +73,19 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import zipfile
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from sync_chapters import (INTAKE_ID, download, fold_city, fresh_if_unchanged,  # noqa: E402
                            get_values, gws_json, upload)
-from sync_crm import (CRM_SHEET, X, XLSX, cell_ref, cell_text, col_of,  # noqa: E402
-                      find_crm,
+from sync_crm import (CRM_SHEET, ROLE_TABS, X, XLSX, cell_ref,  # noqa: E402
+                      cell_text, col_of, find_crm,
                       list_chapter_folders, load_parts, register_namespaces,
                       save_parts, set_cell, shared_strings, sheet_part,
                       _XML_DECL)
 
 OLD, NEW = "New", "Prospect"
-ROLE_TABS = ("Organizers", "Speakers", "Hosts")
 
 # The template workbooks must migrate too, or every future chapter/series is
 # born with the legacy dropdown. Ids as declared by their own creation scripts
@@ -84,6 +96,13 @@ TEMPLATE_FOLDERS = (
     {"id": "1PHvEgqnHo0RrsFyA47O9iRJGaKehC8Eg", "name": "TemplateCity"},
     {"id": "1M15wzKvQqd_jQz5cG16NO_YcbWU3EH1j", "name": "TemplateSeries"},
 )
+
+# Excel stores some validations (lists over 255 chars, cross-sheet refs) in an
+# extension block under a DIFFERENT namespace, invisible to a scan of the main
+# one. Not migrated — but never skipped silently either: a Status-covering
+# extension validation is refused so a human sees it.
+X14 = "{http://schemas.microsoft.com/office/spreadsheetml/2009/9/main}"
+XM = "{http://schemas.microsoft.com/office/excel/2006/main}"
 
 # How far down column A the dropdown is probed. The rule ships on roughly
 # A2:A1000; probing past it just reads empty rows.
@@ -115,10 +134,11 @@ def migrate_list(values):
 # column-A equality test and must not be touched.
 CF_TOKEN_OLD = '$A2="%s"' % OLD
 CF_TOKEN_NEW = '$A2="%s"' % NEW
-# A column-A test for "New" written some other way (spacing, EXACT(), $A$2).
+# A column-A test for "New" written some other way: extra spacing, an absolute
+# $A$2, a negated <> test ("highlight everything not yet triaged"), or EXACT().
 # Not migrated silently: reported, so a human fixes it rather than the rule
 # quietly going dead the way `=$A2="New"` just did.
-CF_SUSPECT = re.compile(r'\$A\$?\d+\s*=\s*"%s"|EXACT\s*\(\s*\$A' % OLD)
+CF_SUSPECT = re.compile(r'\$A\$?\d+\s*(?:=|<>)\s*"%s"|EXACT\s*\(\s*\$A' % OLD)
 
 
 def migrate_cf_formula(formula):
@@ -169,32 +189,62 @@ HOWTO_TEXTS = (
 
 
 def howto_new_text(old):
-    """The migrated text of one How-to-use sentence: the FIRST "New" only."""
+    """The migrated text of one How-to-use sentence: the FIRST "New" only.
+
+    Raises on a sentence that does not contain it: returning the text unchanged
+    would make plan_howto plan a self-write that can never converge, and the
+    post-write verify would report "not migrated" forever without saying why.
+    """
+    if OLD not in old:
+        raise ValueError("How-to-use sentence does not contain %r: %r"
+                         % (OLD, old[:60]))
     return old.replace(OLD, NEW, 1)
 
 
 def plan_howto(rows):
-    """([(a1, old, new)], [refusals]) for the How-to-use tab's status prose.
+    """([(a1, raw_old, new)], [refusals]) for the How-to-use tab's status prose.
 
     `rows` is the tab as returned by get_values (ragged rows of strings). Each
     sentence is located by its text, not by a fixed A1 — the tab gets rows
     inserted as it is edited, and a coordinate would silently rewrite the wrong
     cell after that.
+
+    Matching is on the STRIPPED text but the rewrite is applied to the cell's
+    RAW text, so a sentence carrying leading whitespace keeps it: one of these
+    lines is the head of an indented ASCII flow diagram, and writing back the
+    flush-left canonical form would silently misalign it.
+
+    A sentence found more than once is refused rather than half-migrated: the
+    write would fix one copy per run, and the run would report failure on a
+    tab that is arguably fine.
     """
     where = {}
     for i, row in enumerate(rows, start=1):
         for j, cell in enumerate(row):
-            where.setdefault((cell or "").strip(), cell_ref(j, i))
+            where.setdefault((cell or "").strip(), []).append(
+                (cell_ref(j, i), cell))
     plans, refusals = [], []
     for old in HOWTO_TEXTS:
         new = howto_new_text(old)
-        if old in where:
-            plans.append((where[old], old, new))
+        hits = where.get(old, [])
+        if len(hits) > 1:
+            refusals.append("the sentence %r appears %d times on the tab — "
+                            "migrate the duplicates by hand"
+                            % (_ellipsis(old), len(hits)))
+            continue
+        if hits:
+            a1, raw = hits[0]
+            plans.append((a1, raw, howto_new_text(raw)))
         elif new not in where:
             refusals.append("the sentence %r is on the tab in neither "
-                            "spelling \u2014 it was reworded; migrate it by hand"
-                            % (old[:48] + ("..." if len(old) > 48 else "")))
+                            "spelling — it was reworded; migrate it by hand"
+                            % _ellipsis(old))
     return plans, refusals
+
+
+def _ellipsis(text, width=48):
+    """Shorten a sentence for a refusal line."""
+    return text[:width] + ("..." if len(text) > width else "")
 
 
 def intake_status_guard(headers):
@@ -238,9 +288,15 @@ def runs_of(rownums):
 
 
 def sqref_cols(sqref):
-    """0-based column indices covered by an sqref like 'D2:D1000 F3'."""
+    """0-based column indices covered by an sqref like 'D2:D1000 F3'.
+
+    Absolute refs are normalised first: col_of stops at the first non-alpha
+    character, so a leading "$" made it return -1 and the Status validation
+    silently unmatchable — the workbook then reported "in sync" while keeping
+    the legacy value in its dropdown forever.
+    """
     cols = set()
-    for ref in (sqref or "").split():
+    for ref in (sqref or "").replace("$", "").split():
         parts = ref.split(":")
         a = col_of(parts[0])
         b = col_of(parts[-1])
@@ -303,6 +359,20 @@ class CrmStatusSheet:
                     break
         return hit
 
+    def signal_dv_text(self):
+        """The Signal column's validation list as raw text, or None.
+
+        Read before and after a write so "Signal's unrelated New survives" is
+        an assertion the production run makes, not just one the tests make.
+        """
+        if self.signal_col is None:
+            return None
+        for dv in self.root.iter(X + "dataValidation"):
+            if sqref_cols(dv.get("sqref")) == {self.signal_col}:
+                f1 = dv.find(X + "formula1")
+                return f1.text if f1 is not None else None
+        return None
+
     def plan_validations(self):
         """([(dv_element, old_list, new_list)], [refusal_reason]).
 
@@ -313,11 +383,12 @@ class CrmStatusSheet:
         Signal column's own validation is never matched at all: the match is
         the header-located column, not the list's contents.
         """
-        plans, refusals = [], []
+        plans, refusals, saw = [], [], False
         for dv in self.root.iter(X + "dataValidation"):
             cols = sqref_cols(dv.get("sqref"))
             if self.status_col not in cols:
                 continue
+            saw = True
             extra = cols - {self.status_col}
             if extra:
                 refusals.append(
@@ -325,16 +396,62 @@ class CrmStatusSheet:
                     "column(s) — refusing to edit it" % dv.get("sqref"))
                 continue
             f1 = dv.find(X + "formula1")
-            values = dv_list(f1.text if f1 is not None else None)
+            text = f1.text if f1 is not None else None
+            values = dv_list(text)
             if values is None:
+                # A list backed by a range or a defined name (=Lists!$A$1:$A$9),
+                # or no formula1 at all. Skipping it silently would report the
+                # workbook "in sync" while its dropdown still offers the legacy
+                # value — and the post-write verify, which re-runs THIS
+                # function, would agree. Reported, never guessed at.
+                refusals.append(
+                    "the Status validation (sqref %r) is not a literal list "
+                    "(formula1=%r) — migrate it by hand"
+                    % (dv.get("sqref"), text))
                 continue
             new = migrate_list(values)
             if new is not None:
                 plans.append((dv, values, new))
+        x14 = self.x14_refusals()
+        if not saw and not x14:
+            # sync_crm's Host patch reports this state as "absent" rather than
+            # guessing at it; the same discipline applies here, or a workbook
+            # with no Status list reads as a migrated one.
+            refusals.append("no data validation covers the Status column "
+                            "(header column %d) — reported, not guessed at"
+                            % self.status_col)
+        refusals.extend(x14)
         return plans, refusals
 
+    def x14_refusals(self):
+        """Refusals for Status validations hidden in the x14 extension block.
+
+        This script does not rewrite them — the point is that they are SEEN.
+        Matched by the same rule as the main-namespace ones: the sqref covers
+        the header-located Status column.
+        """
+        out = []
+        for dv in self.root.iter(X14 + "dataValidation"):
+            ref = dv.find(XM + "sqref")
+            text = ref.text if ref is not None else None
+            if self.status_col in sqref_cols(text):
+                out.append("an x14 extension validation covers the Status "
+                           "column (sqref %r) — this script does not rewrite "
+                           "those; migrate it by hand" % text)
+        return out
+
     def apply(self, cell_rows, dv_plans):
-        """Rewrite the planned cells and lists, re-serialize this ONE part."""
+        """Rewrite the planned cells and lists, re-serialize this ONE part.
+
+        The plan must have come from THIS instance: dv_plans hold live Element
+        handles into self.root, so a plan from another workbook would edit a
+        detached tree — no error, no effect, and the run would print "wrote".
+        """
+        unknown = [r for r in cell_rows if r not in self.rows]
+        if unknown:
+            raise ValueError("%s: plan names row(s) %s that are not in this "
+                             "sheet — plan/instance mismatch"
+                             % (self.part_name, unknown[:5]))
         for rownum in cell_rows:
             set_cell(self.rows[rownum], self.status_col, NEW)
         for dv, _old, new in dv_plans:
@@ -358,32 +475,115 @@ def assert_git_safe(path):
     """Refuse a backup/work path git would ever pick up (this repo is public).
 
     mkdtemp lands outside any checkout, so the common case is the cheap one; a
-    path inside a git work tree must be ignored there. Inlined (like
-    aaif-backup's copy) rather than imported from lib/, so this skill keeps
-    working without the library checkout.
+    path inside a git work tree must be ignored there AND untracked. Inlined
+    (like aaif-backup's assert_dest_git_safe, whose three checks this mirrors)
+    rather than imported from lib/, so this skill keeps working without the
+    library checkout.
+
+    Only git's own "not a git repository" answer means outside-a-repo. Any
+    other failure — dubious ownership (exit 128), a corrupt .git, git missing
+    from PATH — ABORTS: mapping it to "safe" would silently disengage the PII
+    guard on a directory about to hold ~84 workbooks of real names and emails.
     """
-    probe = subprocess.run(
-        ["git", "-C", path, "rev-parse", "--show-toplevel"],
-        capture_output=True, text=True)
+    try:
+        probe = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True,
+            env={**os.environ, "LC_ALL": "C", "LANG": "C"})
+    except FileNotFoundError:
+        sys.exit("ABORT: git is not installed, so this cannot verify that %s "
+                 "is outside the repo. The working copies hold every "
+                 "organizer's name and email." % path)
     if probe.returncode != 0:
-        return  # not inside any git work tree — safe
-    chk = subprocess.run(["git", "-C", path, "check-ignore", "-q", path],
-                         capture_output=True)
-    if chk.returncode != 0:
+        stderr = (probe.stderr or "").strip()
+        if "not a git repository" in stderr.lower():
+            return                       # outside any repo — nothing to leak into
+        sys.exit("ABORT: `git rev-parse` failed in %s (exit %d: %s), so this "
+                 "cannot verify the path is safe. The working copies hold "
+                 "every organizer's name and email."
+                 % (path, probe.returncode, stderr[:200]))
+    root = probe.stdout.strip()
+    # Probe through a CHILD: check-ignore answers differently for a bare
+    # directory name, and this works before the child exists.
+    ignored = subprocess.run(
+        ["git", "-C", root, "check-ignore", "-q", os.path.join(path, "probe")],
+        capture_output=True).returncode == 0
+    # .gitignore has no effect on already-tracked files, so a path committed
+    # before the rules landed still rides along on `git add -A` while
+    # check-ignore reports it ignored.
+    tracked = subprocess.run(
+        ["git", "-C", root, "ls-files", "--error-unmatch", path],
+        capture_output=True).returncode == 0
+    if tracked:
+        sys.exit("ABORT: %s already holds files TRACKED by the repo at %s — "
+                 "git rm --cached them first. The working copies hold every "
+                 "organizer's name and email." % (path, root))
+    if not ignored:
         sys.exit("ABORT: %s is inside the git work tree %s and not gitignored "
-                 "— refusing to write member data there."
-                 % (path, probe.stdout.strip()))
+                 "— refusing to write member data there." % (path, root))
 
 
 # ----------------------------------------------------------------------------
 # Phase A — the intake role tabs
 # ----------------------------------------------------------------------------
-def intake_grid_rule(tab):
-    """(sheetId, rule, start_row, end_row) for the Status dropdown on `tab`.
+def grid_rule_plan(rows, start, probe_rows):
+    """Pure planner for the Status dropdown: (rule, runs, refusals).
 
-    `rule` is the full dataValidation of the first covered cell; rows are
-    0-based [start_row, end_row). (None, None, 0, 0) when column A carries no
-    ONE_OF_LIST containing "New" — already migrated, or never had one.
+    `rows` is the probed rowData for column A (each entry a dict, possibly
+    empty). `runs` are 0-based [first, last+1] spans of the rows that actually
+    carry a ONE_OF_LIST offering the legacy value — CONTIGUOUS RUNS, never the
+    min..max hull: the rows between two covered blocks may carry a different
+    validation, or deliberately none, and blanketing the hull would overwrite
+    them with the Status rule.
+
+    Refusals cover the three ways this read can be lying:
+      * a covered row sits at the last probed row — the rule very likely runs
+        past the window, and every verify re-reads through the SAME window, so
+        the leftover would never be seen;
+      * the covered rows carry more than one distinct list — one of them would
+        silently win for all of them;
+      * column A carries no ONE_OF_LIST at all, which is NOT the same fact as
+        "already migrated": a deleted Status dropdown must not read as success.
+    """
+    covered, lists, rule = [], [], None
+    saw_list = False
+    for i, rd in enumerate(rows):
+        vals = rd.get("values") or [{}]
+        dv = vals[0].get("dataValidation") or {}
+        cond = dv.get("condition") or {}
+        if cond.get("type") != "ONE_OF_LIST":
+            continue
+        saw_list = True
+        listed = [v.get("userEnteredValue", "") for v in cond.get("values", [])]
+        if OLD in listed:
+            covered.append(start + i)
+            if listed not in lists:
+                lists.append(listed)
+            rule = rule or dv
+    refusals = []
+    if not saw_list:
+        refusals.append("column A carries no ONE_OF_LIST validation at all in "
+                        "the first %d rows — the Status dropdown is missing, "
+                        "not migrated" % probe_rows)
+    if len(lists) > 1:
+        refusals.append("the Status dropdown offers %d DIFFERENT lists across "
+                        "the covered rows — refusing to flatten them to one"
+                        % len(lists))
+    if covered and covered[-1] >= start + probe_rows - 1:
+        refusals.append("the Status dropdown still offers %r at the last "
+                        "probed row (%d) — it very likely runs past the probe "
+                        "window, which every verify also reads through"
+                        % (OLD, covered[-1] + 1))
+    return rule, runs_of(covered), refusals
+
+
+def intake_grid_rule(tab):
+    """(sheetId, rule, runs, refusals) for the Status dropdown on `tab`.
+
+    `rule` is the full dataValidation of the first covered cell; `runs` are
+    0-based contiguous [first, last] row spans. `rule` is None (and `runs`
+    empty) when no covered row was found — see grid_rule_plan for why that
+    alone is not proof of a migrated tab. The sheetId is ALWAYS returned.
     """
     res = gws_json("sheets", "spreadsheets", "get", params={
         "spreadsheetId": INTAKE_ID,
@@ -391,23 +591,10 @@ def intake_grid_rule(tab):
         "fields": "sheets(properties(sheetId,title),"
                   "data(startRow,rowData(values(dataValidation))))"})
     sheet = res["sheets"][0]
-    gid = sheet["properties"]["sheetId"]
     data = (sheet.get("data") or [{}])[0]
-    start = data.get("startRow", 0)
-    covered, rule = [], None
-    for i, rd in enumerate(data.get("rowData") or []):
-        vals = rd.get("values") or [{}]
-        dv = vals[0].get("dataValidation") or {}
-        cond = dv.get("condition") or {}
-        if cond.get("type") != "ONE_OF_LIST":
-            continue
-        listed = [v.get("userEnteredValue", "") for v in cond.get("values", [])]
-        if OLD in listed:
-            covered.append(start + i)
-            rule = rule or dv
-    if not covered:
-        return gid, None, 0, 0
-    return gid, rule, covered[0], covered[-1] + 1
+    rule, runs, refusals = grid_rule_plan(data.get("rowData") or [],
+                                          data.get("startRow", 0), PROBE_ROWS)
+    return sheet["properties"]["sheetId"], rule, runs, refusals
 
 
 def intake_cf_plans(tab):
@@ -429,7 +616,20 @@ def intake_cf_plans(tab):
     plans, refusals = [], []
     for i, cf in enumerate(sheet.get("conditionalFormats") or []):
         cond = (cf.get("booleanRule") or {}).get("condition") or {}
+        vals_any = [v.get("userEnteredValue", "") for v in
+                    (cond.get("values") or [])]
         if cond.get("type") != "CUSTOM_FORMULA":
+            # A TEXT_EQ "New" rule is the natural way to hand-make a status
+            # color in the Sheets UI and is indistinguishable from the
+            # custom-formula one on screen. This script only rewrites formulas,
+            # so such a rule is REPORTED rather than skipped: skipped, it would
+            # keep testing the retired value while verify (which re-runs this
+            # function) called the tab clean.
+            if OLD in vals_any:
+                refusals.append(
+                    "conditional-format rule %d is a %s condition on %r — this "
+                    "script only rewrites CUSTOM_FORMULA rules; migrate it by "
+                    "hand" % (i, cond.get("type"), OLD))
             continue
         vals = cond.get("values") or []
         old = vals[0].get("userEnteredValue", "") if vals else ""
@@ -475,36 +675,88 @@ def apply_howto(plans):
 
 
 def plan_intake_tab(tab):
-    """One tab's plan: {tab, guard, cell_rows, gid, rule, r0, r1, new_list,
-    cf_gid, cf_plans, cf_refusals}."""
+    """One tab's plan.
+
+    Keys: tab, guard, cell_rows, gid, rule, dv_runs, new_list, cf_gid,
+    cf_plans, cf_refusals, dv_refusals, col_a. `col_a` and the cf/dv plans are
+    the snapshot the drift gate re-compares against before any write.
+    Use tab_changes()/tab_actionable() rather than testing the keys by hand.
+    """
     col_a = [r[0] if r else "" for r in
              get_values(INTAKE_ID, "'%s'!A1:A" % tab)]
     headers = get_values(INTAKE_ID, "'%s'!1:1" % tab)
     guard = intake_status_guard(headers[0] if headers else [])
     plan = {"tab": tab, "guard": guard, "cell_rows": [], "gid": None,
-            "rule": None, "r0": 0, "r1": 0, "new_list": None,
-            "cf_gid": None, "cf_plans": [], "cf_refusals": []}
+            "rule": None, "dv_runs": [], "new_list": None, "cf_gid": None,
+            "cf_plans": [], "cf_refusals": [], "dv_refusals": [],
+            "col_a": col_a}
     if guard:
         return plan
     plan["cf_gid"], plan["cf_plans"], plan["cf_refusals"] = intake_cf_plans(tab)
     plan["cell_rows"] = plan_intake_cells(col_a)
-    gid, rule, r0, r1 = intake_grid_rule(tab)
+    gid, rule, runs, dv_refusals = intake_grid_rule(tab)
     plan["gid"] = gid
+    plan["dv_refusals"] = dv_refusals
     if rule is not None:
         listed = [v.get("userEnteredValue", "")
                   for v in rule["condition"].get("values", [])]
-        plan.update(rule=rule, r0=r0, r1=r1, new_list=migrate_list(listed))
+        plan.update(rule=rule, dv_runs=runs, new_list=migrate_list(listed))
     return plan
+
+
+def tab_changes(plan):
+    """How many changes this tab's plan would apply."""
+    return (len(plan["cell_rows"]) + (1 if plan["new_list"] else 0)
+            + len(plan["cf_plans"]))
+
+
+def tab_actionable(plan):
+    """Is there writable work here? ONE definition, used by the report count,
+    the apply gate and the re-verify gate alike — three hand-copied copies of
+    this expression would drift, and the one that drifts silently is the apply
+    gate: the change is reported, never written, and the run still says
+    "Verified"."""
+    return not plan["guard"] and tab_changes(plan) > 0
+
+
+def intake_tab_drifted(plan):
+    """Why this tab must not be written NOW, or None.
+
+    Phase A's plan is built before ~84 Drive round-trips, so minutes pass and a
+    human edit in that window is normal — the same reasoning that put
+    fresh_if_unchanged in front of every Phase B write. It matters more here,
+    not less: the cell writes address ABSOLUTE ROW NUMBERS on a tab whose B+
+    columns are ARRAYFORMULA mirrors, and the color rules address POSITIONAL
+    INDEXES. A row inserted meanwhile stamps Prospect over a human's Accepted,
+    and a rule added meanwhile makes updateConditionalFormatRule replace some
+    other rule wholesale — and verify, which only asks whether anything still
+    says "New", calls both clean.
+    """
+    tab = plan["tab"]
+    col_a = [r[0] if r else "" for r in
+             get_values(INTAKE_ID, "'%s'!A1:A" % tab)]
+    if col_a != plan["col_a"]:
+        return ("column A changed since the plan was built — NOT written, "
+                "re-run")
+    _gid, cf_now, _refusals = intake_cf_plans(tab)
+    if [(i, old) for i, old, _r in cf_now] != [(i, old) for i, old, _r
+                                               in plan["cf_plans"]]:
+        return ("the conditional-format rules changed since the plan was "
+                "built — NOT written, re-run")
+    return None
 
 
 def apply_intake_tab(plan):
     """Apply one tab's plan: the dropdown rule, the color rules, then the cell
-    rewrites."""
+    rewrites. Caller must have cleared intake_tab_drifted() first."""
     tab = plan["tab"]
     if plan["new_list"]:
-        # An EXPLICIT full rule over the rule's own observed row span. Never a
-        # partial/empty rule: gws drops empty request objects, so anything less
-        # than the complete replacement rule can silently no-op.
+        # An EXPLICIT full rule, over the CONTIGUOUS RUNS that actually carry
+        # the legacy list — never the min..max hull, which would blanket the
+        # Status rule over rows that deliberately carry a different validation
+        # or none. Never a partial/empty rule either: gws drops empty request
+        # objects, so anything less than the complete replacement can silently
+        # no-op.
         rule = dict(plan["rule"])
         rule["condition"] = {"type": "ONE_OF_LIST",
                              "values": [{"userEnteredValue": v}
@@ -514,10 +766,9 @@ def apply_intake_tab(plan):
                  params={"spreadsheetId": INTAKE_ID},
                  body={"requests": [{"setDataValidation": {
                      "range": {"sheetId": plan["gid"],
-                               "startRowIndex": plan["r0"],
-                               "endRowIndex": plan["r1"],
+                               "startRowIndex": r0, "endRowIndex": r1 + 1,
                                "startColumnIndex": 0, "endColumnIndex": 1},
-                     "rule": rule}}]})
+                     "rule": rule}} for r0, r1 in plan["dv_runs"]]})
     if plan["cf_plans"]:
         apply_intake_cf(plan["cf_gid"], plan["cf_plans"])
     if plan["cell_rows"]:
@@ -529,28 +780,73 @@ def apply_intake_tab(plan):
                  body={"valueInputOption": "RAW", "data": data})
 
 
-def verify_intake_tab(tab):
-    """Re-read; return a failure string or None."""
+def verify_intake_tab(plan):
+    """Re-read and prove the PLANNED work landed. Returns a failure or None.
+
+    Positive, not merely absence-of-OLD: every planned cell must now read
+    exactly NEW (a blanked or mis-addressed cell also stops saying "New"), and
+    the re-read dropdown must offer exactly new_list (a clobbered or vanished
+    validation also stops offering "New").
+
+    Refusals are deliberately NOT part of this verdict. A refusal is a
+    permanent won't-do — a rule shaped in a way this script never rewrites —
+    so counting it here would pin every future run to exit 1 with a message
+    claiming outstanding work that no run will ever do. They are reported at
+    plan time instead.
+    """
+    tab = plan["tab"]
     col_a = [r[0] if r else "" for r in
              get_values(INTAKE_ID, "'%s'!A1:A" % tab)]
+
+    def at(row):
+        return (col_a[row - 1] if row - 1 < len(col_a) else "").strip()
+
     left = plan_intake_cells(col_a)
     if left:
         return "%s: %d Status cell(s) still read %r" % (tab, len(left), OLD)
-    _gid, rule, _r0, _r1 = intake_grid_rule(tab)
+    missed = [r for r in plan["cell_rows"] if at(r) != NEW]
+    if missed:
+        return ("%s: %d planned cell(s) do not read %r after the write (rows "
+                "%s)" % (tab, len(missed), NEW, missed[:5]))
+    _gid, rule, _runs, _refusals = intake_grid_rule(tab)
     if rule is not None:
         return "%s: the Status dropdown still offers %r" % (tab, OLD)
-    _cfgid, cf_plans, cf_refusals = intake_cf_plans(tab)
-    if cf_plans or cf_refusals:
+    if plan["new_list"]:
+        got = intake_dropdown_values(tab)
+        if got != plan["new_list"]:
+            return ("%s: the Status dropdown reads %r after the write, not the "
+                    "migrated list" % (tab, got))
+    _cfgid, cf_plans, _cf_refusals = intake_cf_plans(tab)
+    if cf_plans:
         return ("%s: %d conditional-format rule(s) still test %r"
-                % (tab, len(cf_plans) + len(cf_refusals), OLD))
+                % (tab, len(cf_plans), OLD))
     return None
+
+
+def intake_dropdown_values(tab):
+    """The Status dropdown's list as it now reads, or None when it has none."""
+    res = gws_json("sheets", "spreadsheets", "get", params={
+        "spreadsheetId": INTAKE_ID,
+        "ranges": ["'%s'!A2:A2" % tab],
+        "fields": "sheets(data(rowData(values(dataValidation))))"})
+    rows = ((res["sheets"][0].get("data") or [{}])[0].get("rowData") or [{}])
+    dv = ((rows[0].get("values") or [{}])[0].get("dataValidation") or {})
+    cond = dv.get("condition") or {}
+    if cond.get("type") != "ONE_OF_LIST":
+        return None
+    return [v.get("userEnteredValue", "") for v in cond.get("values", [])]
 
 
 # ----------------------------------------------------------------------------
 # Phase B — the chapter CRMs
 # ----------------------------------------------------------------------------
 def crm_folders(city=None):
-    """Chapter folders plus the two template folders, deduped by id."""
+    """Chapter folders plus the two template folders, deduped by id.
+
+    `city` filters AFTER the templates are added, so --city drops TemplateCity
+    and TemplateSeries from the run too — scoping to one chapter means exactly
+    one workbook, templates included.
+    """
     folders = list(list_chapter_folders())
     seen = {f["id"] for f in folders}
     folders += [t for t in TEMPLATE_FOLDERS if t["id"] not in seen]
@@ -563,22 +859,36 @@ def crm_folders(city=None):
 
 
 def open_crm_sheet(folder, workdir):
-    """((crm_meta, names, parts, sheet, path), None) or (None, why)."""
+    """(book, None) or (None, why), where book is a dict with keys
+    crm/names/parts/sheet/path — named rather than a positional tuple, whose
+    members are only valid as a set and were being indexed as book[3] a hundred
+    lines from where they are built."""
     crm, why = find_crm(folder["id"])
     if crm is None:
         return None, why
-    path = os.path.join(workdir, "%s.xlsx"
-                        % "".join(ch if ch.isalnum() or ch in "._-" else "_"
-                                  for ch in folder["name"]))
+    # The Drive FILE ID is part of the basename: sanitizing the folder name
+    # alone collides ("Washington DC" and "Washington, DC" both fold to
+    # Washington_DC), and the second backup would overwrite the first
+    # workbook's only pre-edit copy — after that workbook had been mutated.
+    path = os.path.join(workdir, "%s-%s.xlsx"
+                        % ("".join(ch if ch.isalnum() or ch in "._-" else "_"
+                                   for ch in folder["name"]), crm["id"]))
     try:
         names, parts = load_parts(download(crm["id"], path))
         part = sheet_part(parts, CRM_SHEET)
         if part is None:
             return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
         sheet = CrmStatusSheet(parts, part)
-    except Exception as e:   # BadZipFile / KeyError / ParseError / ValueError
+    except (zipfile.BadZipFile, KeyError, ET.ParseError, ValueError) as e:
+        # STRUCTURAL failures only — a workbook this script cannot read. A
+        # transport failure (the RuntimeError gws raises once its five retries
+        # are spent, OSError, ...) must PROPAGATE: reported here it would be
+        # indistinguishable from a corrupt workbook, when the right answer is
+        # "the write may have landed, re-run to confirm" — this migration is
+        # idempotent, so a re-run is always the correct remedy.
         return None, "%s: %s: %s" % (crm["name"], type(e).__name__, e)
-    return (crm, names, parts, sheet, path), None
+    return {"crm": crm, "names": names, "parts": parts, "sheet": sheet,
+            "path": path}, None
 
 
 def plan_crm(sheet):
@@ -589,7 +899,7 @@ def plan_crm(sheet):
 
 def write_crm(folder, book, plan, workdir, backup_dir):
     """Apply + upload one workbook. Returns a failure string or None."""
-    crm, names, parts, sheet, path = book
+    crm, path = book["crm"], book["path"]
     with open(path, "rb") as fh:
         planned = fh.read()
     fresh, drifted = fresh_if_unchanged(
@@ -599,16 +909,28 @@ def write_crm(folder, book, plan, workdir, backup_dir):
     if drifted:
         return ("%s changed since the plan was built — NOT written, re-run"
                 % crm["name"])
-    sheet.apply(plan["cells"], plan["dvs"])
-    upload(crm["id"], path, save_parts(names, parts), XLSX)
-    # Verify: a fresh download must propose nothing.
+    signal_before = book["sheet"].signal_dv_text()
+    book["sheet"].apply(plan["cells"], plan["dvs"])
+    upload(crm["id"], path, save_parts(book["names"], book["parts"]), XLSX)
+    # Verify: a fresh download must show the PLANNED work done. Refusals are
+    # excluded on purpose — a refusal is a permanent won't-do (a validation
+    # spanning extra columns is refused by design and is still there after a
+    # perfectly successful write), so counting it here would fail every future
+    # run with a message claiming work no run will ever do.
     book2, why = open_crm_sheet(folder, os.path.join(workdir, "verify"))
     if book2 is None:
         return "%s: could not re-open after write: %s" % (crm["name"], why)
-    plan2, refusals2 = plan_crm(book2[3])
-    if plan2["cells"] or plan2["dvs"] or refusals2:
+    plan2, _refusals2 = plan_crm(book2["sheet"])
+    if plan2["cells"] or plan2["dvs"]:
         return ("%s: %d cell(s) / %d validation(s) still pending after write"
                 % (crm["name"], len(plan2["cells"]), len(plan2["dvs"])))
+    # The Signal column's own "New" is unrelated and must survive. The class
+    # locates that column precisely so this can be PROVEN in production, not
+    # only asserted in the tests.
+    signal_after = book2["sheet"].signal_dv_text()
+    if signal_after != signal_before:
+        return ("%s: the Signal validation changed during the write (%r -> %r)"
+                % (crm["name"], signal_before, signal_after))
     return None
 
 
@@ -621,12 +943,54 @@ def run(args):
     try:
         return _run(args, workdir)
     finally:
-        if not args.write:   # --write keeps its before/ backups for recovery
-            shutil.rmtree(workdir, ignore_errors=True)
+        cleanup_workdir(workdir, keep_backups=args.write)
+
+
+def cleanup_workdir(workdir, keep_backups):
+    """Delete the working copies; keep only the pre-edit backups on --write.
+
+    What lands in workdir is not just before/: a downloaded working copy per
+    chapter, reread.xlsx, and the whole verify/ subtree re-downloaded after
+    each upload — three to four full copies of every CRM, i.e. the names and
+    emails of the entire organizer base. Only before/ has recovery value, so
+    only before/ survives, and a failed delete is REPORTED rather than
+    swallowed: silence would leave member data on disk with nobody aware.
+    """
+    left = []
+    for name in sorted(os.listdir(workdir)):
+        if keep_backups and name == "before":
+            continue
+        target = os.path.join(workdir, name)
+        shutil.rmtree(target, ignore_errors=True) if os.path.isdir(target) \
+            else _unlink_quietly(target)
+        if os.path.exists(target):
+            left.append(target)
+    if not keep_backups and not left:
+        shutil.rmtree(workdir, ignore_errors=True)
+        if not os.path.exists(workdir):
+            return
+        left.append(workdir)
+    if left:
+        print("WARNING: could not delete %d path(s) holding member data — "
+              "remove by hand: %s" % (len(left), ", ".join(left[:5])),
+              file=sys.stderr)
+
+
+def _unlink_quietly(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _run(args, workdir):
-    proposed, failures = 0, []
+    proposed, failures, refused = 0, [], []
+
+    def refuse(where, why, width):
+        """A won't-do: reported once, here, and never folded into a verify
+        verdict — it is still true after a perfectly successful write."""
+        refused.append("%s: %s" % (where, why))
+        print("  %-*s REFUSED — %s" % (width, where, why))
 
     print("Phase A — Intake Ops role tabs (%s):" % ", ".join(ROLE_TABS))
     tab_plans = []
@@ -637,29 +1001,28 @@ def _run(args, workdir):
             failures.append("%s: %s" % (tab, plan["guard"]))
             print("  %-10s REFUSED — %s" % (tab, plan["guard"]))
             continue
-        for r in plan["cf_refusals"]:
-            failures.append("%s: %s" % (tab, r))
-            print("  %-10s REFUSED — %s" % (tab, r))
+        for r in plan["cf_refusals"] + plan["dv_refusals"]:
+            refuse(tab, r, 10)
         bits = []
         if plan["cell_rows"]:
             bits.append("%d Status cell(s) %r -> %r (column A only)"
                         % (len(plan["cell_rows"]), OLD, NEW))
         if plan["new_list"]:
-            bits.append("dropdown list %r -> %r" % (OLD, NEW))
-        if plan["cf_plans"]:
-            bits.append("%d conditional-format rule(s) %s -> %s"
-                        % (len(plan["cf_plans"]), CF_TOKEN_OLD, CF_TOKEN_NEW))
+            bits.append("dropdown list %r -> %r over row run(s) %s"
+                        % (OLD, NEW, [[a + 1, b + 1] for a, b
+                                      in plan["dv_runs"]]))
+        for _i, old, _rule in plan["cf_plans"]:
+            bits.append("color rule %s" % old)
         print("  %-10s %s" % (tab, "; ".join(bits) or "in sync"))
-        proposed += (len(plan["cell_rows"]) + (1 if plan["new_list"] else 0)
-                     + len(plan["cf_plans"]))
+        proposed += tab_changes(plan)
 
     howto_plans, howto_refusals = intake_howto_plans()
     for r in howto_refusals:
-        failures.append("%s: %s" % (HOWTO_TAB, r))
-        print("  %-10s REFUSED — %s" % (HOWTO_TAB, r))
+        refuse(HOWTO_TAB, r, 10)
     print("  %-10s %s" % (HOWTO_TAB,
-                          ("%d status sentence(s) %r -> %r"
-                           % (len(howto_plans), OLD, NEW))
+                          ("%d status sentence(s) %r -> %r at %s"
+                           % (len(howto_plans), OLD, NEW,
+                              ", ".join(a1 for a1, _o, _n in howto_plans)))
                           if howto_plans else "in sync"))
     proposed += len(howto_plans)
 
@@ -673,10 +1036,9 @@ def _run(args, workdir):
             failures.append("%s: %s" % (folder["name"], why))
             print("  %-20s SKIPPED — %s" % (folder["name"], why))
             continue
-        plan, refusals = plan_crm(book[3])
+        plan, refusals = plan_crm(book["sheet"])
         for r in refusals:
-            failures.append("%s: %s" % (book[0]["name"], r))
-            print("  %-20s REFUSED — %s" % (folder["name"], r))
+            refuse(folder["name"], r, 20)
         n_cells, n_dvs = len(plan["cells"]), len(plan["dvs"])
         if not n_cells and not n_dvs:
             print("  %-20s in sync" % folder["name"])
@@ -685,41 +1047,68 @@ def _run(args, workdir):
                 if n_cells else []) \
             + ([('Status dropdown -%r' % OLD)] if n_dvs else [])
         print("  %-20s %s (%s)" % (folder["name"], ", ".join(bits),
-                                   book[0]["name"]))
+                                   book["crm"]["name"]))
         proposed += n_cells + n_dvs
         crm_plans.append((folder, book, plan))
 
+    # Phase A is the WHOLE intake spreadsheet, so --city (whose entire purpose
+    # is limiting blast radius) must not drag it along silently: with --city,
+    # Phase A is reported but written only on an explicit --include-intake.
+    write_intake = args.write and (not args.city or args.include_intake)
+    if args.write and args.city and not args.include_intake and (
+            howto_plans or any(tab_actionable(p) for p in tab_plans)):
+        print("\nNOTE: --city scopes Phase B only. The intake-wide Phase A "
+              "changes above are REPORTED, not written — re-run with "
+              "--include-intake to apply them.")
+
     if not proposed:
+        print()
+        for r in refused:
+            print("  needs a human: %s" % r)
         if failures:
-            print("\n%d tab(s)/workbook(s) could not be planned:" % len(failures))
+            print("%d tab(s)/workbook(s) could not be planned:" % len(failures))
             for f in failures:
                 print("  %s" % f)
             return 1
-        print("\nNothing to do — %r is gone from every dropdown, cell, color "
-              "rule and How-to-use sentence." % OLD)
-        return 0
+        print("Nothing to do — %r is gone from every dropdown, cell, color "
+              "rule and How-to-use sentence this script can read%s."
+              % (OLD, " (see the refusals above)" if refused else ""))
+        return 0 if not refused else 1
 
     if not args.write:
         print("\n%d change(s) proposed across %d tab(s) and %d workbook(s). "
               "Re-run with --write to apply."
-              % (proposed, sum(1 for p in tab_plans
-                               if p["cell_rows"] or p["new_list"]
-                               or p["cf_plans"]) + (1 if howto_plans else 0),
+              % (proposed,
+                 sum(1 for p in tab_plans if tab_actionable(p))
+                 + (1 if howto_plans else 0),
                  len(crm_plans)))
+        for r in refused:
+            print("  needs a human: %s" % r)
         return 1 if failures else 2
 
     print("\nApplying...")
+    written_tabs = []
     for plan in tab_plans:
-        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]
-                                 or plan["cf_plans"]):
+        if not (write_intake and tab_actionable(plan)):
             continue
         try:
+            drift = intake_tab_drifted(plan)
+            if drift:
+                failures.append("%s: %s" % (plan["tab"], drift))
+                print("  SKIPPED %s — %s" % (plan["tab"], drift),
+                      file=sys.stderr)
+                continue
             apply_intake_tab(plan)
-            print("  wrote %s" % plan["tab"])
+            written_tabs.append(plan)
+            left = [r for r in plan["cf_refusals"] + plan["dv_refusals"]]
+            print("  %s %s%s"
+                  % ("PARTIAL" if left else "wrote", plan["tab"],
+                     " — applied %d change(s), %d item(s) still need a human"
+                     % (tab_changes(plan), len(left)) if left else ""))
         except Exception as e:
             failures.append("%s: %s" % (plan["tab"], e))
             print("  FAILED %s — %s" % (plan["tab"], e), file=sys.stderr)
-    if howto_plans:
+    if howto_plans and write_intake:
         try:
             apply_howto(howto_plans)
             print("  wrote %s (%d sentence(s))" % (HOWTO_TAB, len(howto_plans)))
@@ -739,26 +1128,25 @@ def _run(args, workdir):
     print("Pre-edit workbook copies kept in %s" % backup_dir)
 
     print("\nRe-verifying the intake tabs...")
-    for plan in tab_plans:
-        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]
-                                 or plan["cf_plans"]):
-            continue
-        bad = verify_intake_tab(plan["tab"])
+    for plan in written_tabs:
+        bad = verify_intake_tab(plan)
         if bad:
             failures.append(bad)
-    if howto_plans:
-        left, still_refused = intake_howto_plans()
-        if left or still_refused:
+    if howto_plans and write_intake:
+        left, _still_refused = intake_howto_plans()
+        if left:
             failures.append("%s: %d status sentence(s) not migrated"
-                            % (HOWTO_TAB, len(left) + len(still_refused)))
+                            % (HOWTO_TAB, len(left)))
 
+    for r in refused:
+        print("  needs a human: %s" % r)
     if failures:
         print("VERIFY FAILED / INCOMPLETE:")
         for f in failures:
             print("  %s" % f)
         return 1
-    print("Verified: fresh reads of every written tab and workbook propose "
-          "zero changes.")
+    print("Verified: every planned change landed — fresh reads of each written "
+          "tab and workbook propose zero further changes.")
     return 2   # changes were proposed AND applied — the shared 0/2/1 contract
 
 
@@ -768,8 +1156,11 @@ def main():
     ap.add_argument("--write", action="store_true",
                     help="apply the proposed changes (default: report only)")
     ap.add_argument("--city",
-                    help="limit Phase B to one chapter folder — Phase A (the "
-                         "intake tabs) always runs in full")
+                    help="limit Phase B to one chapter folder; Phase A is then "
+                         "reported but not written (see --include-intake)")
+    ap.add_argument("--include-intake", action="store_true",
+                    help="with --city --write, also apply the intake-wide "
+                         "Phase A changes")
     sys.exit(run(ap.parse_args()))
 
 

--- a/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""One-shot: rename the intake/CRM status "New" to "Prospect".
+
+"New" misread as *new organizer*; "Prospect" is the term sync_crm.py already
+writes for a pipeline candidate, so the rename unifies the vocabulary. Code
+accepts BOTH values during the transition (sync_crm.PIPELINE_STATUSES,
+intake.normalize_status); this script is what retires "New" from the sheets:
+
+Phase A — the Intake Ops role tabs (Organizers / Speakers / Hosts):
+  * the Status dropdown (ONE_OF_LIST dataValidation on column A) has its "New"
+    entry replaced by "Prospect" — reapplied as an EXPLICIT full rule, never a
+    partial one: gws drops empty request objects, so a partial rule hoping to
+    "clear and keep the rest" would silently no-op;
+  * every Status cell literally holding "New" is rewritten to "Prospect" via a
+    RAW values write to the exact A-column cells. Status is the ONE hand-edited
+    literal column on those tabs; columns B+ are ARRAYFORMULA mirrors and a
+    literal written into them #REF!s the whole tab, so this script refuses to
+    run against a tab whose Status column is not column A.
+
+Phase B — every chapter CRM workbook (the ~80 "<City> CRM.xlsx" under the
+Chapters Drive folder, plus the TemplateCity and TemplateSeries templates):
+  * the Status column is located BY HEADER NAME on the Attendees sheet (column
+    positions vary per CRM — never assume D);
+  * the Status column's dataValidation list loses its leading "New" ("Prospect"
+    is already on the list). The Signal column's list also contains a "New" —
+    an UNRELATED value that must survive, which is why validations are matched
+    to the header-located Status column, never by list content alone;
+  * Status data cells holding "New" (the sheet default for hand-added rows) are
+    rewritten to "Prospect".
+  Edits are zip-part surgery in create_chapter._rewrite_zip's style: only the
+  Attendees sheet part is re-serialized; every other part is repacked
+  byte-identically. Pre-edit bytes are kept in a mkdtemp backup dir.
+
+House rules: report is the default and writes nothing; --write applies, then
+re-downloads / re-reads and verifies, printing a Verified line. No member names
+or emails on stdout — counts, tab names and file names only.
+
+Exit codes: 0 everything already in sync; 2 changes proposed (or applied);
+1 failure (including a failed verify or a skipped workbook).
+
+Usage:
+  python3 migrate_status_prospect.py            # report only, zero writes
+  python3 migrate_status_prospect.py --city Boston   # scope Phase B to one CRM
+  python3 migrate_status_prospect.py --write    # apply, then verify
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sync_chapters import (INTAKE_ID, download, fold_city, fresh_if_unchanged,  # noqa: E402
+                           get_values, gws_json, upload)
+from sync_crm import (CRM_SHEET, X, XLSX, cell_text, col_of, find_crm,  # noqa: E402
+                      list_chapter_folders, load_parts, register_namespaces,
+                      save_parts, set_cell, shared_strings, sheet_part,
+                      _XML_DECL)
+
+OLD, NEW = "New", "Prospect"
+ROLE_TABS = ("Organizers", "Speakers", "Hosts")
+
+# The template workbooks must migrate too, or every future chapter/series is
+# born with the legacy dropdown. Ids as declared by their own creation scripts
+# (create_chapter.TEMPLATE_FOLDER / create_series.TEMPLATE_FOLDER — different
+# skills, so the ids are restated rather than imported across skill folders).
+# TemplateCity is itself a child of the Chapters parent and is deduped by id.
+TEMPLATE_FOLDERS = (
+    {"id": "1PHvEgqnHo0RrsFyA47O9iRJGaKehC8Eg", "name": "TemplateCity"},
+    {"id": "1M15wzKvQqd_jQz5cG16NO_YcbWU3EH1j", "name": "TemplateSeries"},
+)
+
+# How far down column A the dropdown is probed. The rule ships on roughly
+# A2:A1000; probing past it just reads empty rows.
+PROBE_ROWS = 2000
+
+
+# ----------------------------------------------------------------------------
+# Pure plan logic (offline-testable)
+# ----------------------------------------------------------------------------
+def migrate_list(values):
+    """New dropdown list with "New" retired, or None when already in sync.
+
+    "New" becomes "Prospect" in place when Prospect is not on the list (the
+    intake dropdown); when Prospect is already offered (the CRM list), "New" is
+    simply dropped. Order is otherwise preserved — the dropdown is a workflow,
+    and reshuffling it would reorder every status menu an operator uses.
+    """
+    if OLD not in values:
+        return None
+    if NEW in values:
+        return [v for v in values if v != OLD]
+    return [NEW if v == OLD else v for v in values]
+
+
+def intake_status_guard(headers):
+    """Why a role tab must NOT be written, or None when it is safe.
+
+    Status is resolved by header name AND required to be column A: columns B+
+    are ARRAYFORMULA mirrors, and one literal written into them #REF!s the
+    whole tab. A layout where Status moved is a migration this script does not
+    know how to do safely, so it refuses rather than guesses.
+    """
+    heads = [h.strip() for h in headers]
+    if "Status" not in heads:
+        return "no 'Status' column — headers: %s" % heads[:8]
+    if heads.index("Status") != 0:
+        return ("'Status' is not column A (found at index %d) — columns B+ are "
+                "ARRAYFORMULA mirrors and must never be written; refusing"
+                % heads.index("Status"))
+    return None
+
+
+def plan_intake_cells(col_a_values):
+    """Sheet row numbers (1-based) of data cells literally holding "New".
+
+    `col_a_values` is column A top to bottom, header included. Only the exact
+    legacy value is rewritten — blanks stay blank (code already reads a blank
+    as Prospect) and every other status is someone else's decision.
+    """
+    return [i for i, v in enumerate(col_a_values, start=1)
+            if i > 1 and (v or "").strip() == OLD]
+
+
+def runs_of(rownums):
+    """Contiguous [start, end] row runs, for compact range writes."""
+    out = []
+    for r in sorted(rownums):
+        if out and r == out[-1][1] + 1:
+            out[-1][1] = r
+        else:
+            out.append([r, r])
+    return out
+
+
+def sqref_cols(sqref):
+    """0-based column indices covered by an sqref like 'D2:D1000 F3'."""
+    cols = set()
+    for ref in (sqref or "").split():
+        parts = ref.split(":")
+        a = col_of(parts[0])
+        b = col_of(parts[-1])
+        cols.update(range(min(a, b), max(a, b) + 1))
+    return cols
+
+
+def dv_list(formula_text):
+    """The list a <formula1> literal holds, or None when it isn't a literal."""
+    t = (formula_text or "").strip()
+    if len(t) >= 2 and t[0] == '"' and t[-1] == '"':
+        return t[1:-1].split(",")
+    return None
+
+
+class CrmStatusSheet:
+    """The Attendees sheet of one CRM, opened just far enough to migrate Status.
+
+    Deliberately NOT sync_crm.Attendees: that class requires all eleven CRM
+    headers, and this migration must also reach the TemplateSeries CRM, whose
+    layout it does not otherwise care about. Only 'Status' is required;
+    'Signal' is located when present so its unrelated "New" can be proven
+    untouched.
+    """
+
+    def __init__(self, parts, part_name):
+        raw = parts[part_name]
+        register_namespaces(raw)
+        self.parts, self.part_name, self.raw = parts, part_name, raw
+        self.root = ET.fromstring(raw)
+        self.sst = shared_strings(parts)
+        self.data = self.root.find(X + "sheetData")
+        if self.data is None:
+            raise ValueError("no <sheetData> in %s" % part_name)
+        self.rows = {int(r.get("r")): r for r in self.data.findall(X + "row")}
+        head = self.rows.get(1)
+        if head is None:
+            raise ValueError("no header row")
+        self.headers = {}
+        for c in head.findall(X + "c"):
+            txt = cell_text(c, self.sst).strip()
+            if txt and txt not in self.headers:
+                self.headers[txt] = col_of(c.get("r"))
+        if "Status" not in self.headers:
+            raise ValueError("no 'Status' header on row 1 — headers: %s"
+                             % sorted(self.headers))
+        self.status_col = self.headers["Status"]
+        self.signal_col = self.headers.get("Signal")
+
+    def status_cells_holding_old(self):
+        """Row numbers whose Status cell literally reads "New"."""
+        hit = []
+        for rownum in sorted(self.rows):
+            if rownum == 1:
+                continue
+            for c in self.rows[rownum].findall(X + "c"):
+                if col_of(c.get("r") or "") == self.status_col:
+                    if cell_text(c, self.sst).strip() == OLD:
+                        hit.append(rownum)
+                    break
+        return hit
+
+    def plan_validations(self):
+        """([(dv_element, old_list, new_list)], [refusal_reason]).
+
+        Only a validation whose sqref covers EXACTLY the Status column is
+        edited. One that also spans the Signal column (whose list legitimately
+        contains "New") or any other column is refused loudly — editing it
+        would rewrite a list this migration has no business touching. The
+        Signal column's own validation is never matched at all: the match is
+        the header-located column, not the list's contents.
+        """
+        plans, refusals = [], []
+        for dv in self.root.iter(X + "dataValidation"):
+            cols = sqref_cols(dv.get("sqref"))
+            if self.status_col not in cols:
+                continue
+            extra = cols - {self.status_col}
+            if extra:
+                refusals.append(
+                    "the Status validation (sqref %r) also covers other "
+                    "column(s) — refusing to edit it" % dv.get("sqref"))
+                continue
+            f1 = dv.find(X + "formula1")
+            values = dv_list(f1.text if f1 is not None else None)
+            if values is None:
+                continue
+            new = migrate_list(values)
+            if new is not None:
+                plans.append((dv, values, new))
+        return plans, refusals
+
+    def apply(self, cell_rows, dv_plans):
+        """Rewrite the planned cells and lists, re-serialize this ONE part."""
+        for rownum in cell_rows:
+            set_cell(self.rows[rownum], self.status_col, NEW)
+        for dv, _old, new in dv_plans:
+            dv.find(X + "formula1").text = '"' + ",".join(new) + '"'
+        # Same serialization discipline as sync_crm.Attendees.serialize():
+        # re-register this workbook's own prefixes (the ET registry is global)
+        # and refuse a root that did not serialize as <worksheet>.
+        register_namespaces(self.raw)
+        body = ET.tostring(self.root, encoding="UTF-8")
+        at = body.find(b"<worksheet")
+        if at < 0:
+            raise ValueError("%s: serialized root is not <worksheet> (got %r) "
+                             "— refusing to write" % (self.part_name, body[:80]))
+        self.parts[self.part_name] = _XML_DECL + body[at:]
+
+
+# ----------------------------------------------------------------------------
+# Local-output safety
+# ----------------------------------------------------------------------------
+def assert_git_safe(path):
+    """Refuse a backup/work path git would ever pick up (this repo is public).
+
+    mkdtemp lands outside any checkout, so the common case is the cheap one; a
+    path inside a git work tree must be ignored there. Inlined (like
+    aaif-backup's copy) rather than imported from lib/, so this skill keeps
+    working without the library checkout.
+    """
+    probe = subprocess.run(
+        ["git", "-C", path, "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True)
+    if probe.returncode != 0:
+        return  # not inside any git work tree — safe
+    chk = subprocess.run(["git", "-C", path, "check-ignore", "-q", path],
+                         capture_output=True)
+    if chk.returncode != 0:
+        sys.exit("ABORT: %s is inside the git work tree %s and not gitignored "
+                 "— refusing to write member data there."
+                 % (path, probe.stdout.strip()))
+
+
+# ----------------------------------------------------------------------------
+# Phase A — the intake role tabs
+# ----------------------------------------------------------------------------
+def intake_grid_rule(tab):
+    """(sheetId, rule, start_row, end_row) for the Status dropdown on `tab`.
+
+    `rule` is the full dataValidation of the first covered cell; rows are
+    0-based [start_row, end_row). (None, None, 0, 0) when column A carries no
+    ONE_OF_LIST containing "New" — already migrated, or never had one.
+    """
+    res = gws_json("sheets", "spreadsheets", "get", params={
+        "spreadsheetId": INTAKE_ID,
+        "ranges": ["'%s'!A1:A%d" % (tab, PROBE_ROWS)],
+        "fields": "sheets(properties(sheetId,title),"
+                  "data(startRow,rowData(values(dataValidation))))"})
+    sheet = res["sheets"][0]
+    gid = sheet["properties"]["sheetId"]
+    data = (sheet.get("data") or [{}])[0]
+    start = data.get("startRow", 0)
+    covered, rule = [], None
+    for i, rd in enumerate(data.get("rowData") or []):
+        vals = rd.get("values") or [{}]
+        dv = vals[0].get("dataValidation") or {}
+        cond = dv.get("condition") or {}
+        if cond.get("type") != "ONE_OF_LIST":
+            continue
+        listed = [v.get("userEnteredValue", "") for v in cond.get("values", [])]
+        if OLD in listed:
+            covered.append(start + i)
+            rule = rule or dv
+    if not covered:
+        return gid, None, 0, 0
+    return gid, rule, covered[0], covered[-1] + 1
+
+
+def plan_intake_tab(tab):
+    """One tab's plan: {tab, guard, cell_rows, gid, rule, r0, r1, new_list}."""
+    col_a = [r[0] if r else "" for r in
+             get_values(INTAKE_ID, "'%s'!A1:A" % tab)]
+    headers = get_values(INTAKE_ID, "'%s'!1:1" % tab)
+    guard = intake_status_guard(headers[0] if headers else [])
+    plan = {"tab": tab, "guard": guard, "cell_rows": [], "gid": None,
+            "rule": None, "r0": 0, "r1": 0, "new_list": None}
+    if guard:
+        return plan
+    plan["cell_rows"] = plan_intake_cells(col_a)
+    gid, rule, r0, r1 = intake_grid_rule(tab)
+    plan["gid"] = gid
+    if rule is not None:
+        listed = [v.get("userEnteredValue", "")
+                  for v in rule["condition"].get("values", [])]
+        plan.update(rule=rule, r0=r0, r1=r1, new_list=migrate_list(listed))
+    return plan
+
+
+def apply_intake_tab(plan):
+    """Apply one tab's plan: the dropdown rule, then the cell rewrites."""
+    tab = plan["tab"]
+    if plan["new_list"]:
+        # An EXPLICIT full rule over the rule's own observed row span. Never a
+        # partial/empty rule: gws drops empty request objects, so anything less
+        # than the complete replacement rule can silently no-op.
+        rule = dict(plan["rule"])
+        rule["condition"] = {"type": "ONE_OF_LIST",
+                             "values": [{"userEnteredValue": v}
+                                        for v in plan["new_list"]]}
+        rule.setdefault("showCustomUi", True)
+        gws_json("sheets", "spreadsheets", "batchUpdate",
+                 params={"spreadsheetId": INTAKE_ID},
+                 body={"requests": [{"setDataValidation": {
+                     "range": {"sheetId": plan["gid"],
+                               "startRowIndex": plan["r0"],
+                               "endRowIndex": plan["r1"],
+                               "startColumnIndex": 0, "endColumnIndex": 1},
+                     "rule": rule}}]})
+    if plan["cell_rows"]:
+        data = [{"range": "'%s'!A%d:A%d" % (tab, a, b),
+                 "values": [[NEW]] * (b - a + 1)}
+                for a, b in runs_of(plan["cell_rows"])]
+        gws_json("sheets", "spreadsheets", "values", "batchUpdate",
+                 params={"spreadsheetId": INTAKE_ID},
+                 body={"valueInputOption": "RAW", "data": data})
+
+
+def verify_intake_tab(tab):
+    """Re-read; return a failure string or None."""
+    col_a = [r[0] if r else "" for r in
+             get_values(INTAKE_ID, "'%s'!A1:A" % tab)]
+    left = plan_intake_cells(col_a)
+    if left:
+        return "%s: %d Status cell(s) still read %r" % (tab, len(left), OLD)
+    _gid, rule, _r0, _r1 = intake_grid_rule(tab)
+    if rule is not None:
+        return "%s: the Status dropdown still offers %r" % (tab, OLD)
+    return None
+
+
+# ----------------------------------------------------------------------------
+# Phase B — the chapter CRMs
+# ----------------------------------------------------------------------------
+def crm_folders(city=None):
+    """Chapter folders plus the two template folders, deduped by id."""
+    folders = list(list_chapter_folders())
+    seen = {f["id"] for f in folders}
+    folders += [t for t in TEMPLATE_FOLDERS if t["id"] not in seen]
+    if city:
+        want = fold_city(city)
+        folders = [f for f in folders if fold_city(f["name"]) == want]
+        if not folders:
+            sys.exit("ABORT: no chapter folder matches %r." % city)
+    return sorted(folders, key=lambda f: f["name"])
+
+
+def open_crm_sheet(folder, workdir):
+    """((crm_meta, names, parts, sheet, path), None) or (None, why)."""
+    crm, why = find_crm(folder["id"])
+    if crm is None:
+        return None, why
+    path = os.path.join(workdir, "%s.xlsx"
+                        % "".join(ch if ch.isalnum() or ch in "._-" else "_"
+                                  for ch in folder["name"]))
+    try:
+        names, parts = load_parts(download(crm["id"], path))
+        part = sheet_part(parts, CRM_SHEET)
+        if part is None:
+            return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
+        sheet = CrmStatusSheet(parts, part)
+    except Exception as e:   # BadZipFile / KeyError / ParseError / ValueError
+        return None, "%s: %s: %s" % (crm["name"], type(e).__name__, e)
+    return (crm, names, parts, sheet, path), None
+
+
+def plan_crm(sheet):
+    """({cells, dvs}, [refusals]) for one opened workbook."""
+    dvs, refusals = sheet.plan_validations()
+    return {"cells": sheet.status_cells_holding_old(), "dvs": dvs}, refusals
+
+
+def write_crm(folder, book, plan, workdir, backup_dir):
+    """Apply + upload one workbook. Returns a failure string or None."""
+    crm, names, parts, sheet, path = book
+    with open(path, "rb") as fh:
+        planned = fh.read()
+    fresh, drifted = fresh_if_unchanged(
+        crm["id"], os.path.join(workdir, "reread.xlsx"), planned)
+    with open(os.path.join(backup_dir, os.path.basename(path)), "wb") as fh:
+        fh.write(fresh)
+    if drifted:
+        return ("%s changed since the plan was built — NOT written, re-run"
+                % crm["name"])
+    sheet.apply(plan["cells"], plan["dvs"])
+    upload(crm["id"], path, save_parts(names, parts), XLSX)
+    # Verify: a fresh download must propose nothing.
+    book2, why = open_crm_sheet(folder, os.path.join(workdir, "verify"))
+    if book2 is None:
+        return "%s: could not re-open after write: %s" % (crm["name"], why)
+    plan2, refusals2 = plan_crm(book2[3])
+    if plan2["cells"] or plan2["dvs"] or refusals2:
+        return ("%s: %d cell(s) / %d validation(s) still pending after write"
+                % (crm["name"], len(plan2["cells"]), len(plan2["dvs"])))
+    return None
+
+
+# ----------------------------------------------------------------------------
+# Run
+# ----------------------------------------------------------------------------
+def run(args):
+    workdir = tempfile.mkdtemp(prefix="aaif-status-migrate-")
+    assert_git_safe(workdir)
+    try:
+        return _run(args, workdir)
+    finally:
+        if not args.write:   # --write keeps its before/ backups for recovery
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _run(args, workdir):
+    proposed, failures = 0, []
+
+    print("Phase A — Intake Ops role tabs (%s):" % ", ".join(ROLE_TABS))
+    tab_plans = []
+    for tab in ROLE_TABS:
+        plan = plan_intake_tab(tab)
+        tab_plans.append(plan)
+        if plan["guard"]:
+            failures.append("%s: %s" % (tab, plan["guard"]))
+            print("  %-10s REFUSED — %s" % (tab, plan["guard"]))
+            continue
+        bits = []
+        if plan["cell_rows"]:
+            bits.append("%d Status cell(s) %r -> %r (column A only)"
+                        % (len(plan["cell_rows"]), OLD, NEW))
+        if plan["new_list"]:
+            bits.append("dropdown list %r -> %r" % (OLD, NEW))
+        print("  %-10s %s" % (tab, "; ".join(bits) or "in sync"))
+        proposed += len(plan["cell_rows"]) + (1 if plan["new_list"] else 0)
+
+    print("\nPhase B — chapter CRMs:")
+    backup_dir = os.path.join(workdir, "before")
+    os.makedirs(backup_dir, exist_ok=True)
+    crm_plans = []
+    for folder in crm_folders(args.city):
+        book, why = open_crm_sheet(folder, workdir)
+        if book is None:
+            failures.append("%s: %s" % (folder["name"], why))
+            print("  %-20s SKIPPED — %s" % (folder["name"], why))
+            continue
+        plan, refusals = plan_crm(book[3])
+        for r in refusals:
+            failures.append("%s: %s" % (book[0]["name"], r))
+            print("  %-20s REFUSED — %s" % (folder["name"], r))
+        n_cells, n_dvs = len(plan["cells"]), len(plan["dvs"])
+        if not n_cells and not n_dvs:
+            print("  %-20s in sync" % folder["name"])
+            continue
+        bits = ([("%d Status cell(s) %r -> %r" % (n_cells, OLD, NEW))]
+                if n_cells else []) \
+            + ([('Status dropdown -%r' % OLD)] if n_dvs else [])
+        print("  %-20s %s (%s)" % (folder["name"], ", ".join(bits),
+                                   book[0]["name"]))
+        proposed += n_cells + n_dvs
+        crm_plans.append((folder, book, plan))
+
+    if not proposed:
+        if failures:
+            print("\n%d tab(s)/workbook(s) could not be planned:" % len(failures))
+            for f in failures:
+                print("  %s" % f)
+            return 1
+        print("\nNothing to do — %r is gone from every dropdown and cell." % OLD)
+        return 0
+
+    if not args.write:
+        print("\n%d change(s) proposed across %d tab(s) and %d workbook(s). "
+              "Re-run with --write to apply."
+              % (proposed, sum(1 for p in tab_plans
+                               if p["cell_rows"] or p["new_list"]),
+                 len(crm_plans)))
+        return 1 if failures else 2
+
+    print("\nApplying...")
+    for plan in tab_plans:
+        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]):
+            continue
+        try:
+            apply_intake_tab(plan)
+            print("  wrote %s" % plan["tab"])
+        except Exception as e:
+            failures.append("%s: %s" % (plan["tab"], e))
+            print("  FAILED %s — %s" % (plan["tab"], e), file=sys.stderr)
+    for folder, book, plan in crm_plans:
+        try:
+            why = write_crm(folder, book, plan, workdir, backup_dir)
+        except Exception as e:   # one bad workbook must not abandon the rest
+            why = "%s: %s" % (type(e).__name__, e)
+        if why:
+            failures.append(why)
+            print("  FAILED %s — %s" % (folder["name"], why), file=sys.stderr)
+        else:
+            print("  wrote %s" % folder["name"])
+    print("Pre-edit workbook copies kept in %s" % backup_dir)
+
+    print("\nRe-verifying the intake tabs...")
+    for plan in tab_plans:
+        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]):
+            continue
+        bad = verify_intake_tab(plan["tab"])
+        if bad:
+            failures.append(bad)
+
+    if failures:
+        print("VERIFY FAILED / INCOMPLETE:")
+        for f in failures:
+            print("  %s" % f)
+        return 1
+    print("Verified: fresh reads of every written tab and workbook propose "
+          "zero changes.")
+    return 2   # changes were proposed AND applied — the shared 0/2/1 contract
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Retire the legacy intake status "New" in favor of "Prospect".')
+    ap.add_argument("--write", action="store_true",
+                    help="apply the proposed changes (default: report only)")
+    ap.add_argument("--city", help="limit Phase B to one chapter folder")
+    sys.exit(run(ap.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
@@ -15,7 +15,14 @@ Phase A — the Intake Ops role tabs (Organizers / Speakers / Hosts):
     RAW values write to the exact A-column cells. Status is the ONE hand-edited
     literal column on those tabs; columns B+ are ARRAYFORMULA mirrors and a
     literal written into them #REF!s the whole tab, so this script refuses to
-    run against a tab whose Status column is not column A.
+    run against a tab whose Status column is not column A;
+  * the hand-made conditional-format rules that TEST the Status literal are
+    renamed with it: the blue whole-row color (`=$A2="New"`) and the arm of the
+    pink SLA-breach rule (`OR($A2="",$A2="New")`). Renaming only the cells
+    unpaints every Prospect row and — the real damage — stops the 1-week SLA
+    breach from ever firing again. These rules are hand-made on the sheet;
+    clean.py owns only the red error rule and the city/violet rules, so nothing
+    else would ever repair them.
 
 Phase B — every chapter CRM workbook (the ~80 "<City> CRM.xlsx" under the
 Chapters Drive folder, plus the TemplateCity and TemplateSeries templates):
@@ -44,7 +51,9 @@ Usage:
   python3 migrate_status_prospect.py --write    # apply, then verify
 """
 import argparse
+import copy
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -93,6 +102,40 @@ def migrate_list(values):
     if NEW in values:
         return [v for v in values if v != OLD]
     return [NEW if v == OLD else v for v in values]
+
+
+# The Status-literal test inside a conditional-format formula. Column A is the
+# Status column (intake_status_guard requires it), so the exact `$A2="New"`
+# token is the whole match surface: every other mention of the word on these
+# tabs — the `City (New)` header, the CRMs' unrelated Signal list — is not a
+# column-A equality test and must not be touched.
+CF_TOKEN_OLD = '$A2="%s"' % OLD
+CF_TOKEN_NEW = '$A2="%s"' % NEW
+# A column-A test for "New" written some other way (spacing, EXACT(), $A$2).
+# Not migrated silently: reported, so a human fixes it rather than the rule
+# quietly going dead the way `=$A2="New"` just did.
+CF_SUSPECT = re.compile(r'\$A\$?\d+\s*=\s*"%s"|EXACT\s*\(\s*\$A' % OLD)
+
+
+def migrate_cf_formula(formula):
+    """The rule formula with its Status test renamed, or None when it has none.
+
+    A plain textual swap of the exact token — the rest of the formula (the SLA
+    rule's date arithmetic, its blank-status arm) is someone else's logic and
+    is preserved verbatim.
+    """
+    f = formula or ""
+    return f.replace(CF_TOKEN_OLD, CF_TOKEN_NEW) if CF_TOKEN_OLD in f else None
+
+
+def cf_refusal(formula):
+    """Why a rule this script did not migrate still looks like it tests the old
+    Status, or None. Catches the near-misses of `migrate_cf_formula`."""
+    f = formula or ""
+    if CF_TOKEN_OLD in f or not CF_SUSPECT.search(f):
+        return None
+    return ("tests the Status column for %r in a shape this script does not "
+            "rewrite (%s) — migrate it by hand" % (OLD, f))
 
 
 def intake_status_guard(headers):
@@ -308,6 +351,51 @@ def intake_grid_rule(tab):
     return gid, rule, covered[0], covered[-1] + 1
 
 
+def intake_cf_plans(tab):
+    """(sheetId, [(index, old_formula, new_rule)], [refusals]) for one tab.
+
+    Rules are addressed by their INDEX within the tab — what
+    updateConditionalFormatRule takes — and each is re-sent WHOLE (ranges,
+    colors, the untouched parts of the formula). A partial rule would drop the
+    format it paints: gws drops empty request objects, and the API replaces the
+    rule outright rather than merging it.
+    """
+    res = gws_json("sheets", "spreadsheets", "get", params={
+        "spreadsheetId": INTAKE_ID,
+        "fields": "sheets(properties(sheetId,title),conditionalFormats)"})
+    sheet = next((sh for sh in res["sheets"]
+                  if sh["properties"]["title"] == tab), None)
+    if sheet is None:
+        return None, [], ["no %r tab on the intake" % tab]
+    plans, refusals = [], []
+    for i, cf in enumerate(sheet.get("conditionalFormats") or []):
+        cond = (cf.get("booleanRule") or {}).get("condition") or {}
+        if cond.get("type") != "CUSTOM_FORMULA":
+            continue
+        vals = cond.get("values") or []
+        old = vals[0].get("userEnteredValue", "") if vals else ""
+        new = migrate_cf_formula(old)
+        if new is None:
+            why = cf_refusal(old)
+            if why:
+                refusals.append("conditional-format rule %d %s" % (i, why))
+            continue
+        rule = copy.deepcopy(cf)
+        rule["booleanRule"]["condition"]["values"][0]["userEnteredValue"] = new
+        plans.append((i, old, rule))
+    return sheet["properties"]["sheetId"], plans, refusals
+
+
+def apply_intake_cf(gid, plans):
+    """Replace each planned rule in place, in ONE batch (indices are positional,
+    and a rule replaced in place never shifts the ones after it)."""
+    gws_json("sheets", "spreadsheets", "batchUpdate",
+             params={"spreadsheetId": INTAKE_ID},
+             body={"requests": [{"updateConditionalFormatRule": {
+                 "sheetId": gid, "index": i, "rule": rule}}
+                 for i, _old, rule in plans]})
+
+
 def plan_intake_tab(tab):
     """One tab's plan: {tab, guard, cell_rows, gid, rule, r0, r1, new_list}."""
     col_a = [r[0] if r else "" for r in
@@ -315,9 +403,11 @@ def plan_intake_tab(tab):
     headers = get_values(INTAKE_ID, "'%s'!1:1" % tab)
     guard = intake_status_guard(headers[0] if headers else [])
     plan = {"tab": tab, "guard": guard, "cell_rows": [], "gid": None,
-            "rule": None, "r0": 0, "r1": 0, "new_list": None}
+            "rule": None, "r0": 0, "r1": 0, "new_list": None,
+            "cf_gid": None, "cf_plans": [], "cf_refusals": []}
     if guard:
         return plan
+    plan["cf_gid"], plan["cf_plans"], plan["cf_refusals"] = intake_cf_plans(tab)
     plan["cell_rows"] = plan_intake_cells(col_a)
     gid, rule, r0, r1 = intake_grid_rule(tab)
     plan["gid"] = gid
@@ -348,6 +438,8 @@ def apply_intake_tab(plan):
                                "endRowIndex": plan["r1"],
                                "startColumnIndex": 0, "endColumnIndex": 1},
                      "rule": rule}}]})
+    if plan["cf_plans"]:
+        apply_intake_cf(plan["cf_gid"], plan["cf_plans"])
     if plan["cell_rows"]:
         data = [{"range": "'%s'!A%d:A%d" % (tab, a, b),
                  "values": [[NEW]] * (b - a + 1)}
@@ -367,6 +459,10 @@ def verify_intake_tab(tab):
     _gid, rule, _r0, _r1 = intake_grid_rule(tab)
     if rule is not None:
         return "%s: the Status dropdown still offers %r" % (tab, OLD)
+    _cfgid, cf_plans, cf_refusals = intake_cf_plans(tab)
+    if cf_plans or cf_refusals:
+        return ("%s: %d conditional-format rule(s) still test %r"
+                % (tab, len(cf_plans) + len(cf_refusals), OLD))
     return None
 
 
@@ -461,14 +557,21 @@ def _run(args, workdir):
             failures.append("%s: %s" % (tab, plan["guard"]))
             print("  %-10s REFUSED — %s" % (tab, plan["guard"]))
             continue
+        for r in plan["cf_refusals"]:
+            failures.append("%s: %s" % (tab, r))
+            print("  %-10s REFUSED — %s" % (tab, r))
         bits = []
         if plan["cell_rows"]:
             bits.append("%d Status cell(s) %r -> %r (column A only)"
                         % (len(plan["cell_rows"]), OLD, NEW))
         if plan["new_list"]:
             bits.append("dropdown list %r -> %r" % (OLD, NEW))
+        if plan["cf_plans"]:
+            bits.append("%d conditional-format rule(s) %s -> %s"
+                        % (len(plan["cf_plans"]), CF_TOKEN_OLD, CF_TOKEN_NEW))
         print("  %-10s %s" % (tab, "; ".join(bits) or "in sync"))
-        proposed += len(plan["cell_rows"]) + (1 if plan["new_list"] else 0)
+        proposed += (len(plan["cell_rows"]) + (1 if plan["new_list"] else 0)
+                     + len(plan["cf_plans"]))
 
     print("\nPhase B — chapter CRMs:")
     backup_dir = os.path.join(workdir, "before")
@@ -502,20 +605,23 @@ def _run(args, workdir):
             for f in failures:
                 print("  %s" % f)
             return 1
-        print("\nNothing to do — %r is gone from every dropdown and cell." % OLD)
+        print("\nNothing to do — %r is gone from every dropdown, cell and "
+              "color rule." % OLD)
         return 0
 
     if not args.write:
         print("\n%d change(s) proposed across %d tab(s) and %d workbook(s). "
               "Re-run with --write to apply."
               % (proposed, sum(1 for p in tab_plans
-                               if p["cell_rows"] or p["new_list"]),
+                               if p["cell_rows"] or p["new_list"]
+                               or p["cf_plans"]),
                  len(crm_plans)))
         return 1 if failures else 2
 
     print("\nApplying...")
     for plan in tab_plans:
-        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]):
+        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]
+                                 or plan["cf_plans"]):
             continue
         try:
             apply_intake_tab(plan)
@@ -537,7 +643,8 @@ def _run(args, workdir):
 
     print("\nRe-verifying the intake tabs...")
     for plan in tab_plans:
-        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]):
+        if plan["guard"] or not (plan["cell_rows"] or plan["new_list"]
+                                 or plan["cf_plans"]):
             continue
         bad = verify_intake_tab(plan["tab"])
         if bad:

--- a/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_status_prospect.py
@@ -50,6 +50,7 @@ Exit codes: 0 everything already in sync; 2 changes proposed (or applied);
 Usage:
   python3 migrate_status_prospect.py            # report only, zero writes
   python3 migrate_status_prospect.py --city Boston   # scope Phase B to one CRM
+                                                    # (Phase A still runs whole)
   python3 migrate_status_prospect.py --write    # apply, then verify
 """
 import argparse
@@ -766,7 +767,9 @@ def main():
         description='Retire the legacy intake status "New" in favor of "Prospect".')
     ap.add_argument("--write", action="store_true",
                     help="apply the proposed changes (default: report only)")
-    ap.add_argument("--city", help="limit Phase B to one chapter folder")
+    ap.add_argument("--city",
+                    help="limit Phase B to one chapter folder — Phase A (the "
+                         "intake tabs) always runs in full")
     sys.exit(run(ap.parse_args()))
 
 

--- a/skills/aaif-sync-chapters/scripts/sync_chapters.py
+++ b/skills/aaif-sync-chapters/scripts/sync_chapters.py
@@ -161,13 +161,14 @@ def upload(file_id, path, raw, content_type):
 def fresh_if_unchanged(file_id, tmp_path, planned_bytes):
     """Re-download a Drive file and say whether it drifted from a plan's bytes.
 
-    Returns (fresh_bytes, changed). Shared by sync_crm.write_workbooks and
-    sync_about.apply_writes — the one compare both engines' write gates hang
-    on: planning spans minutes plus the approval pause, so a human edit in
-    that window is NORMAL, and uploading over it would silently revert it.
-    Each caller keeps its own backup and skip-reporting behaviour; only the
-    "did the remote move under the plan" question lives here, so the two
-    twins cannot drift apart in what "unchanged" means.
+    Returns (fresh_bytes, changed). Shared by sync_crm.write_workbooks,
+    sync_about.apply_writes and migrate_status_prospect.write_crm — the one
+    compare every write gate hangs on: planning spans minutes plus the approval
+    pause, so a human edit in that window is NORMAL, and uploading over it
+    would silently revert it. Each caller keeps its own backup and
+    skip-reporting behaviour; only the "did the remote move under the plan"
+    question lives here, so the callers cannot drift apart in what "unchanged"
+    means.
     """
     fresh = download(file_id, tmp_path)
     return fresh, fresh != planned_bytes

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -123,9 +123,12 @@ ROLE_TABS = ("Organizers", "Speakers", "Hosts")   # also the merge priority orde
 CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
 
 # Status values this script is allowed to overwrite — everything the automation
-# itself writes, plus the sheet's own defaults: "Prospect", and its legacy
-# spelling "New" (pre-2026-08-22 rows and un-migrated dropdowns still hold it,
-# and it must keep upgrading identically). A human who moved someone to
+# itself writes, plus the sheet's own defaults: a BLANK cell (""), "Prospect",
+# and its legacy spelling "New" (pre-2026-08-22 rows and un-migrated dropdowns
+# still hold it, and it must keep upgrading identically). The "" is load-
+# bearing for the same reason it is in PIPELINE_STATUSES above: a hand-added
+# CRM row starts blank, and dropping the "redundant" empty string would freeze
+# every such row out of its role upgrade. A human who moved someone to
 # "Attended", "Regular", "Volunteer" or "Declined" has said something the intake
 # does not know; a later triage decision must not silently undo it.
 AUTO_STATUS = frozenset(("", "New", "Prospect", "Organizer", "Speaker", "Host"))
@@ -145,14 +148,33 @@ DUMMY_DOMAINS = ("example.com", "example.org", "example.net", "example.edu")
 
 # The Status dropdown shipped without a value for a venue host, so hosts had
 # nowhere honest to land. Patched in place on every workbook we open.
-DV_STATUS_OLD = "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined"
-DV_STATUS_NEW = "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
-# The same two lists after migrate_status_prospect.py has removed the legacy
-# "New" (Prospect is the surviving spelling). The Host patch must recognise a
-# migrated workbook, or every migrated CRM would be reported as having no
+#
+# ONE source of truth for what the dropdown holds — the four literals below are
+# derived, never typed twice. Hand-maintained copies would drift the day a
+# value is added: all four would miss, every workbook would report "absent",
+# and the Host patch would quietly stop working across the whole fleet.
+# LEGACY carries "New"; the MIGRATED pair is the same list after
+# migrate_status_prospect.py retired it (Prospect is the surviving spelling) —
+# the patch must recognise both, or every migrated CRM reads as having no
 # Status list at all.
-DV_STATUS_OLD_MIGRATED = DV_STATUS_OLD.replace("New,", "", 1)
-DV_STATUS_NEW_MIGRATED = DV_STATUS_NEW.replace("New,", "", 1)
+DV_STATUS_VALUES = ("New", "Prospect", "Attended", "Regular", "Speaker",
+                    "Organizer", "Volunteer", "Declined")
+_DV_HOST_AFTER = "Volunteer"          # Host slots in just before Declined
+
+
+def dv_status_list(values, with_host):
+    """The comma-joined dropdown list, optionally with "Host" inserted."""
+    out = list(values)
+    if with_host:
+        out.insert(out.index(_DV_HOST_AFTER) + 1, "Host")
+    return ",".join(out)
+
+
+DV_STATUS_OLD = dv_status_list(DV_STATUS_VALUES, False)
+DV_STATUS_NEW = dv_status_list(DV_STATUS_VALUES, True)
+_DV_MIGRATED = tuple(v for v in DV_STATUS_VALUES if v != "New")
+DV_STATUS_OLD_MIGRATED = dv_status_list(_DV_MIGRATED, False)
+DV_STATUS_NEW_MIGRATED = dv_status_list(_DV_MIGRATED, True)
 
 # Per-role source columns on the intake role tabs, resolved by header name and
 # taken in order (first non-empty wins). Organizers have no company or title
@@ -1029,22 +1051,41 @@ def finalize(book, ops, expected_dv=None):
 # ----------------------------------------------------------------------------
 # Drive
 # ----------------------------------------------------------------------------
+def drive_list(q, fields):
+    """Every file matching `q`, following nextPageToken to the end.
+
+    Drive may return fewer items than pageSize AND still hand back a token, so
+    a single call is not proof of a complete listing. Stopping at page one
+    would silently drop chapters from every sweep that walks this list — and a
+    one-shot migration would then report "nothing to do" for a chapter it never
+    saw.
+    """
+    out, token = [], None
+    while True:
+        params = {"q": q, "fields": "nextPageToken,files(%s)" % fields,
+                  "pageSize": 1000, "supportsAllDrives": True,
+                  "includeItemsFromAllDrives": True}
+        if token:
+            params["pageToken"] = token
+        res = gws_json("drive", "files", "list", params=params)
+        out.extend(res.get("files", []))
+        token = res.get("nextPageToken")
+        if not token:
+            return out
+
+
 def list_chapter_folders():
-    res = gws_json("drive", "files", "list", params={
-        "q": "'%s' in parents and mimeType='application/vnd.google-apps.folder' "
-             "and trashed=false" % CHAPTERS_PARENT,
-        "fields": "files(id,name)", "pageSize": 1000,
-        "supportsAllDrives": True, "includeItemsFromAllDrives": True})
-    return sorted(res.get("files", []), key=lambda f: f["name"])
+    files = drive_list(
+        "'%s' in parents and mimeType='application/vnd.google-apps.folder' "
+        "and trashed=false" % CHAPTERS_PARENT, "id,name")
+    return sorted(files, key=lambda f: f["name"])
 
 
 def find_crm(folder_id):
     """The one "* CRM.xlsx" in a chapter folder, or (None, why)."""
-    res = gws_json("drive", "files", "list", params={
-        "q": "'%s' in parents and trashed=false" % folder_id,
-        "fields": "files(id,name,mimeType)", "pageSize": 1000,
-        "supportsAllDrives": True, "includeItemsFromAllDrives": True})
-    crms = [f for f in res.get("files", [])
+    files = drive_list("'%s' in parents and trashed=false" % folder_id,
+                       "id,name,mimeType")
+    crms = [f for f in files
             if f["name"].lower().endswith("crm.xlsx") and f["mimeType"] == XLSX]
     if not crms:
         return None, "no '<City> CRM.xlsx' in the folder"

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -85,16 +85,22 @@ CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)"
 SYNC_STATUSES = ("Accepted", "Existing (from MLOps)")
 
 # The "still in flight" statuses ("" is a blank cell, which triage treats as
-# New — and the "" entry must STAY: read_role_tab checks membership on the RAW
-# cell value, before the `status or "New"` normalization, so removing the
-# "redundant" empty string would reject every untriaged row).
+# Prospect — and the "" entry must STAY: read_role_tab checks membership on the
+# RAW cell value, before the `status or "Prospect"` normalization, so removing
+# the "redundant" empty string would reject every untriaged row).
+# "New" is the LEGACY spelling of "Prospect" (renamed 2026-08-22: "New" misread
+# as new-organizer, and "Prospect" is the term this engine already writes into
+# the CRMs). migrate_status_prospect.py rewrites the intake dropdown and cells;
+# keep "New" here until that migration has run everywhere and the dropdowns no
+# longer offer it — then it can be dropped.
 # Pipeline hosts/speakers sync unconditionally; pipeline organizers sync
 # only into a self-serve chapter (see gate_pipeline_organizers). Both lists are
 # ALLOWLISTS on purpose: a status added to the intake dropdown tomorrow —
 # including a new rejected-ish one — syncs nobody until it is placed here, which
 # is the fail-closed direction. Denied / Inactive / Duplicate are excluded by
 # not appearing. See aaif-triage-intake/SKILL.md for the current dropdown.
-PIPELINE_STATUSES = ("", "New", "In progress", "Tentative", "Interviewing")
+PIPELINE_STATUSES = ("", "New", "Prospect", "In progress", "Tentative",
+                     "Interviewing")
 
 # A chapter with this many accepted organizers (SYNC_STATUSES, minus AAIF ops
 # people) runs its own organizer interviews: its pipeline organizers sync into
@@ -117,8 +123,9 @@ ROLE_TABS = ("Organizers", "Speakers", "Hosts")   # also the merge priority orde
 CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
 
 # Status values this script is allowed to overwrite — everything the automation
-# itself writes, plus the sheet's own default and the "Prospect" an earlier,
-# wider-scoped run could have left behind. A human who moved someone to
+# itself writes, plus the sheet's own defaults: "Prospect", and its legacy
+# spelling "New" (pre-2026-08-22 rows and un-migrated dropdowns still hold it,
+# and it must keep upgrading identically). A human who moved someone to
 # "Attended", "Regular", "Volunteer" or "Declined" has said something the intake
 # does not know; a later triage decision must not silently undo it.
 AUTO_STATUS = frozenset(("", "New", "Prospect", "Organizer", "Speaker", "Host"))
@@ -140,6 +147,12 @@ DUMMY_DOMAINS = ("example.com", "example.org", "example.net", "example.edu")
 # nowhere honest to land. Patched in place on every workbook we open.
 DV_STATUS_OLD = "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined"
 DV_STATUS_NEW = "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
+# The same two lists after migrate_status_prospect.py has removed the legacy
+# "New" (Prospect is the surviving spelling). The Host patch must recognise a
+# migrated workbook, or every migrated CRM would be reported as having no
+# Status list at all.
+DV_STATUS_OLD_MIGRATED = DV_STATUS_OLD.replace("New,", "", 1)
+DV_STATUS_NEW_MIGRATED = DV_STATUS_NEW.replace("New,", "", 1)
 
 # Per-role source columns on the intake role tabs, resolved by header name and
 # taken in order (first non-empty wins). Organizers have no company or title
@@ -543,7 +556,7 @@ def patch_status_dropdown(parts, part_name):
     """Add "Host" to the Status column's data-validation list.
 
     Returns "patched" (the part changed), "already" (Host is offered), or
-    "absent" (no list matching either spelling — reported, never guessed at).
+    "absent" (no list matching any known spelling — reported, never guessed at).
 
     A bytes-level swap of the one formula string: the validation lives outside
     <sheetData>, nothing else in the file mentions it, and re-serializing the
@@ -551,16 +564,24 @@ def patch_status_dropdown(parts, part_name):
     unrelated markup. Both quote encodings are handled — the template writes
     `"…"` and the older workbooks write `&quot;…&quot;`, and matching only the
     first silently left every legacy CRM un-patched while reporting success.
+    Both the legacy list (leading "New") and the migrated list (Prospect only,
+    after migrate_status_prospect.py) are recognised — every "already" check
+    runs before any patch, so the pass a workbook actually matches decides.
     """
     raw = parts[part_name]
+    variants = ((DV_STATUS_OLD, DV_STATUS_NEW),
+                (DV_STATUS_OLD_MIGRATED, DV_STATUS_NEW_MIGRATED))
     for q in (b'"', b"&quot;"):
-        new = b"<formula1>" + q + DV_STATUS_NEW.encode() + q + b"</formula1>"
-        if new in raw:
-            return "already"
-        old = b"<formula1>" + q + DV_STATUS_OLD.encode() + q + b"</formula1>"
-        if old in raw:
-            parts[part_name] = raw.replace(old, new)
-            return "patched"
+        for _old, new in variants:
+            if b"<formula1>" + q + new.encode() + q + b"</formula1>" in raw:
+                return "already"
+    for q in (b'"', b"&quot;"):
+        for old, new in variants:
+            old_b = b"<formula1>" + q + old.encode() + q + b"</formula1>"
+            if old_b in raw:
+                parts[part_name] = raw.replace(
+                    old_b, b"<formula1>" + q + new.encode() + q + b"</formula1>")
+                return "patched"
     return "absent"
 
 
@@ -653,7 +674,8 @@ def read_role_tab(tab, interests, include_pipeline=False):
         if not accepted:
             if not include_pipeline:
                 rejected.append({"row": rownum, "tab": tab, "name": name,
-                                 "why": "status %r — not accepted yet" % (status or "New")})
+                                 "why": "status %r — not accepted yet"
+                                        % (status or "Prospect")})
                 continue
             if status not in PIPELINE_STATUSES:
                 # Denied / Inactive / Duplicate, or a dropdown value this script
@@ -699,7 +721,7 @@ def read_role_tab(tab, interests, include_pipeline=False):
             fallbacks.append(rownum)
         interest = joined or DEFAULT_INTEREST[tab]
         people.append({
-            "row": rownum, "tab": tab, "status": status or "New",
+            "row": rownum, "tab": tab, "status": status or "Prospect",
             "name": clean_text(name) or clean_text(email),
             "email": clean_text(email), "city": clean_text(city),
             "linkedin": clean_text(first_of(row, headers, ("LinkedIn",))),

--- a/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
@@ -24,10 +24,12 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import migrate_status_prospect as mig
 from migrate_status_prospect import (CF_TOKEN_NEW, CF_TOKEN_OLD, HOWTO_TEXTS,
                                      CrmStatusSheet, cf_refusal, dv_list,
-                                     howto_new_text, intake_status_guard,
-                                     migrate_cf_formula, migrate_list, plan_crm,
-                                     plan_howto, plan_intake_cells, runs_of,
-                                     sqref_cols)
+                                     grid_rule_plan, howto_new_text,
+                                     intake_status_guard, migrate_cf_formula,
+                                     migrate_list, plan_crm, plan_howto,
+                                     plan_intake_cells, runs_of, sqref_cols,
+                                     tab_actionable, tab_changes)
+import sync_crm
 from sync_crm import cell_ref, load_parts, save_parts, sheet_part
 
 fails = 0
@@ -48,6 +50,12 @@ INTAKE_LIST = ["New", "In progress", "Tentative", "Interviewing", "Accepted",
 CRM_LIST = ["New", "Prospect", "Attended", "Regular", "Speaker", "Organizer",
             "Volunteer", "Host", "Declined"]
 SIGNAL_LIST = ["High", "Low", "Non-grata", "New"]
+
+check("the CRM fixture list IS sync_crm's dropdown (drift here breaks the "
+      "Host patch fleet-wide)",
+      ",".join(CRM_LIST), sync_crm.DV_STATUS_NEW)
+check("and migrating it yields exactly sync_crm's migrated list",
+      ",".join(migrate_list(CRM_LIST)), sync_crm.DV_STATUS_NEW_MIGRATED)
 
 check("intake list: New is replaced in place (Prospect not yet offered)",
       migrate_list(INTAKE_LIST),
@@ -77,6 +85,9 @@ check("runs_of groups contiguous rows",
       runs_of([2, 3, 4, 7, 9, 10]), [[2, 4], [7, 7], [9, 10]])
 
 check("sqref_cols reads a plain range", sqref_cols("D2:D1000"), {3})
+check("sqref_cols reads an ABSOLUTE range ($ broke col_of and made the "
+      "Status validation unmatchable)", sqref_cols("$D$2:$D$1000"), {3})
+check("sqref_cols reads a mixed-absolute span", sqref_cols("$B2:C$10"), {1, 2})
 check("sqref_cols reads multiple refs and spans",
       sqref_cols("B2:C10 F3"), {1, 2, 5})
 check("dv_list strips the quotes", dv_list('"A,B,C"'), ["A", "B", "C"])
@@ -104,6 +115,10 @@ check("an unrecognised column-A test for New is reported, never guessed at",
       "migrate it by hand" in (cf_refusal('=$A$2 = "New"') or ""), True)
 check("EXACT() against column A is reported too",
       "migrate it by hand" in (cf_refusal('=EXACT($A2,"New")') or ""), True)
+check("a NEGATED column-A test is reported too (highlight-the-untriaged)",
+      "migrate it by hand" in (cf_refusal('=$A2<>"New"') or ""), True)
+check("...with spaces around the <> as well",
+      "migrate it by hand" in (cf_refusal('=$A2 <> "New"') or ""), True)
 check("a rule with no Status test is not a refusal",
       cf_refusal('=$K2<>""'), None)
 
@@ -136,12 +151,21 @@ HOWTO_ROWS = [
     ["        \u2514 New city / new chapter  \u2192  City (New)"],
 ]
 _plans, _refusals = plan_howto(HOWTO_ROWS)
+# Expectations are spelled out as LITERALS, not computed with the function
+# under test: howto_new_text(HOWTO_TEXTS[1]) as an expectation would still pass
+# if the swap ate "new submission" instead of the status.
 check("every status sentence is located, and nothing else is",
       [(a1, new) for a1, _o, new in _plans],
       [("A4", "Prospect \u2192 In progress \u2192 Accepted / Denied"),
-       ("B4", howto_new_text(HOWTO_TEXTS[1])),
+       ("B4", "Every new submission defaults to Prospect. Pick from the "
+              "dropdown as you work each person: Tentative once their LinkedIn "
+              "checks out, Interviewing while the interview is scheduled or "
+              "under way, then Accepted / Denied. Use Inactive to park one "
+              "without deciding, and Duplicate for a repeat submission from "
+              "someone already in the queue."),
        ("B5", "Prospect \u2014 untriaged."),
-       ("B6", howto_new_text(HOWTO_TEXTS[3])),
+       ("B6", "Overdue \u2014 still Prospect after 1 week (of a 2-week response "
+              "SLA). Act on it to clear."),
        ("A8", "Form submission  \u2192  \U0001f7e6 Prospect")])
 check("a clean tab raises no refusals", _refusals, [])
 
@@ -158,7 +182,89 @@ check("...and the other four are still planned", len(_p2), 4)
 
 check("sentences are located by TEXT, not by a fixed A1 (rows can shift)",
       [a1 for a1, _o, _n in plan_howto([[], []] + HOWTO_ROWS)[0]][:1], ["A6"])
+
+# The flow-diagram head is indented on the live tab; matching strips, but the
+# REWRITE must keep the indent or the diagram silently misaligns.
+_indented = [["   " + HOWTO_TEXTS[4] + " "] if row and row[0] == HOWTO_TEXTS[4]
+             else row for row in HOWTO_ROWS]
+check("an indented sentence keeps its own whitespace",
+      [new for _a1, _o, new in plan_howto(_indented)[0] if "Form" in new],
+      ["   Form submission  \u2192  \U0001f7e6 Prospect "])
+
+_dup = HOWTO_ROWS + [[HOWTO_TEXTS[2]]]
+_p3, _r3 = plan_howto(_dup)
+check("a duplicated sentence is REFUSED, not half-migrated", len(_r3), 1)
+check("the duplicate refusal says how many copies", "appears 2 times" in _r3[0], True)
+check("...and the duplicated one is not planned", len(_p3), 4)
+
+try:
+    howto_new_text("a sentence with no status in it")
+    _raised = None
+except ValueError as e:
+    _raised = str(e)
+check("howto_new_text refuses a sentence with no New (never a self-write)",
+      _raised is not None, True)
 check("dv_list refuses a non-literal formula", dv_list("=Lists!A1:A9"), None)
+
+
+# ---------------------------------------------------------------------------
+# The one definition of "does this tab have work"
+# ---------------------------------------------------------------------------
+def _tp(**kw):
+    base = {"guard": None, "cell_rows": [], "new_list": None, "cf_plans": []}
+    base.update(kw)
+    return base
+
+check("tab_changes counts cells + the dropdown + each color rule",
+      tab_changes(_tp(cell_rows=[2, 3], new_list=["Prospect"],
+                      cf_plans=[("x",), ("y",)])), 5)
+check("a guarded tab is never actionable, however much it 'plans'",
+      tab_actionable(_tp(guard="Status is not column A", cell_rows=[2])), False)
+check("a tab with only color rules IS actionable (the apply gate must not "
+      "drop them)", tab_actionable(_tp(cf_plans=[("x",)])), True)
+check("an in-sync tab is not actionable", tab_actionable(_tp()), False)
+
+
+# ---------------------------------------------------------------------------
+# The Status dropdown's grid rule: runs, and the three ways the read can lie
+# ---------------------------------------------------------------------------
+def _dv_row(values):
+    if values is None:
+        return {}
+    return {"values": [{"dataValidation": {
+        "condition": {"type": "ONE_OF_LIST",
+                      "values": [{"userEnteredValue": v} for v in values]}}}]}
+
+_LEGACY, _DONE = ["New", "Accepted"], ["Prospect", "Accepted"]
+
+_rule, _runs, _ref = grid_rule_plan(
+    [_dv_row(None)] + [_dv_row(_LEGACY)] * 4, 0, 100)
+check("covered rows become one contiguous run", _runs, [[1, 4]])
+check("a clean read raises no refusal", _ref, [])
+
+_rule, _runs, _ref = grid_rule_plan(
+    [_dv_row(_LEGACY)] * 2 + [_dv_row(None)] * 3 + [_dv_row(_LEGACY)] * 2, 0, 100)
+check("a gap is TWO runs, never the min..max hull (the gap rows carry no "
+      "validation and must keep none)", _runs, [[0, 1], [5, 6]])
+
+_rule, _runs, _ref = grid_rule_plan([_dv_row(_DONE)] * 3, 0, 100)
+check("an already-migrated tab plans no runs", _runs, [])
+check("...and raises no refusal", _ref, [])
+
+_rule, _runs, _ref = grid_rule_plan([{}] * 5, 0, 100)
+check("NO dropdown at all is refused — not the same fact as 'already "
+      "migrated'", len(_ref), 1)
+check("the refusal says the dropdown is missing", "missing" in _ref[0], True)
+
+_rule, _runs, _ref = grid_rule_plan(
+    [_dv_row(_LEGACY), _dv_row(["New", "Denied"])], 0, 100)
+check("two DIFFERENT lists across covered rows are refused, not flattened",
+      any("DIFFERENT lists" in r for r in _ref), True)
+
+_rule, _runs, _ref = grid_rule_plan([_dv_row(_LEGACY)] * 3, 0, 3)
+check("a hit at the last probed row is refused (the rule likely runs past "
+      "the window every verify also reads through)",
+      any("probed row" in r for r in _ref), True)
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +280,8 @@ def _c(ref, text, shared_idx=None):
 
 def make_crm(status_col, signal_col, status_vals, signal_vals,
              status_dv=CRM_LIST, signal_dv=SIGNAL_LIST, dv_sqref=None,
-             shared_status_rows=()):
+             shared_status_rows=(), shared_signal_rows=(), status_dv_xml=None,
+             x14_sqref=None):
     """Build an .xlsx whose Attendees sheet has Status/Signal at the given
     0-based columns. `shared_status_rows` store their Status value through
     sharedStrings — the legacy storage form, and the reason a bytes-level
@@ -193,13 +300,20 @@ def make_crm(status_col, signal_col, status_vals, signal_vals,
             else:
                 cells += _c(cell_ref(status_col, n), sv)
         if gv is not None:
-            cells += _c(cell_ref(signal_col, n), gv)
+            if n in shared_signal_rows and gv == "New":
+                # ALIASES the same sst entry as the Status cells: any "fix"
+                # that rewrote the shared string in place would corrupt Signal
+                # too, and this is what proves the migration does not.
+                cells += _c(cell_ref(signal_col, n), gv, shared_idx=0)
+            else:
+                cells += _c(cell_ref(signal_col, n), gv)
         rows.append('<row r="%d">%s</row>' % (n, cells))
     s_let = cell_ref(status_col, 2)[:-1]
     g_let = cell_ref(signal_col, 2)[:-1]
-    dvs = ('<dataValidation type="list" sqref="%s">'
-           '<formula1>"%s"</formula1></dataValidation>'
-           % (dv_sqref or "%s2:%s1000" % (s_let, s_let), ",".join(status_dv)))
+    dvs = status_dv_xml if status_dv_xml is not None else (
+        '<dataValidation type="list" sqref="%s">'
+        '<formula1>"%s"</formula1></dataValidation>'
+        % (dv_sqref or "%s2:%s1000" % (s_let, s_let), ",".join(status_dv)))
     dvs += ('<dataValidation type="list" sqref="%s2:%s1000">'
             '<formula1>"%s"</formula1></dataValidation>'
             % (g_let, g_let, ",".join(signal_dv)))
@@ -207,8 +321,8 @@ def make_crm(status_col, signal_col, status_vals, signal_vals,
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
         '<dimension ref="A1:K12" /><sheetData>%s</sheetData>'
-        '<dataValidations count="2">%s</dataValidations></worksheet>'
-        % ("".join(rows), dvs))
+        '<dataValidations count="2">%s</dataValidations>%s</worksheet>'
+        % ("".join(rows), dvs, _x14(x14_sqref)))
     parts = {
         "[Content_Types].xml": "<Types />",
         "_rels/.rels": "<Relationships />",
@@ -231,6 +345,19 @@ def make_crm(status_col, signal_col, status_vals, signal_vals,
     return load_parts(buf.getvalue())
 
 
+def _x14(sqref):
+    """An extension-namespace validation block, as Excel writes for lists it
+    cannot store inline. Invisible to a scan of the main namespace."""
+    if not sqref:
+        return ""
+    return ('<extLst><ext xmlns:x14="http://schemas.microsoft.com/office/'
+            'spreadsheetml/2009/9/main"><x14:dataValidations count="1">'
+            '<x14:dataValidation type="list"><xm:sqref xmlns:xm='
+            '"http://schemas.microsoft.com/office/excel/2006/main">%s'
+            '</xm:sqref></x14:dataValidation></x14:dataValidations>'
+            '</ext></extLst>' % sqref)
+
+
 def open_sheet(parts):
     return CrmStatusSheet(parts, sheet_part(parts, "Attendees"))
 
@@ -248,7 +375,7 @@ def migrate_and_reload(names, parts):
 names, parts = make_crm(status_col=3, signal_col=1,
                         status_vals=["New", "Prospect", "New", "Organizer"],
                         signal_vals=["New", "High", None, "New"],
-                        shared_status_rows={4})
+                        shared_status_rows={4}, shared_signal_rows={2})
 sheet = open_sheet(parts)
 check("Status is located by header name", sheet.status_col, 3)
 check("Signal is located by header name", sheet.signal_col, 1)
@@ -259,12 +386,15 @@ check("exactly one validation (Status's) is planned",
       [(CRM_LIST, CRM_LIST[1:])])
 check("no refusals on a healthy workbook", refusals, [])
 
-_before_wb = parts["xl/workbook.xml"]
+_before_all = {n: v for n, v in parts.items()}
 plan, refusals, (rt_names, rt_parts) = migrate_and_reload(names, parts)
 rt = open_sheet(rt_parts)
 check("every zip part survives the round-trip", rt_names, names)
-check("untouched parts are byte-identical",
-      rt_parts["xl/workbook.xml"] == _before_wb, True)
+_sheet_part_name = sheet_part(rt_parts, "Attendees")
+check("EVERY untouched part is byte-identical, sharedStrings included "
+      "(the part a bytes-level 'fix' would corrupt)",
+      [n for n, v in rt_parts.items()
+       if n != _sheet_part_name and v != _before_all[n]], [])
 check("Status cells now read Prospect (incl. the shared-string one)",
       rt.status_cells_holding_old(), [])
 raw = rt_parts[sheet_part(rt_parts, "Attendees")].decode()
@@ -342,6 +472,123 @@ except ValueError as e:
 
 
 # ---------------------------------------------------------------------------
+# The shapes this script must REFUSE rather than silently skip
+# ---------------------------------------------------------------------------
+_n, _p = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                  signal_vals=["New"], dv_sqref="$D$2:$D$1000")
+_plan, _ref = plan_crm(open_sheet(_p))
+check("an ABSOLUTE sqref still matches the Status column (it used to miss, "
+      "leaving the legacy value in that CRM's dropdown forever)",
+      [(old, new) for _dv, old, new in _plan["dvs"]], [(CRM_LIST, CRM_LIST[1:])])
+check("...and raises no refusal", _ref, [])
+
+_n, _p = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                  signal_vals=["High"],
+                  status_dv_xml='<dataValidation type="list" sqref="D2:D1000">'
+                                '<formula1>Lists!$A$1:$A$9</formula1>'
+                                '</dataValidation>')
+_plan, _ref = plan_crm(open_sheet(_p))
+check("a RANGE-BACKED Status list is refused, not skipped (skipped, the "
+      "workbook reports in sync and verify agrees)", len(_ref), 1)
+check("the refusal shows the formula it could not read",
+      "Lists!$A$1:$A$9" in _ref[0], True)
+check("...and the cell rewrites are still planned", _plan["cells"], [2])
+
+_n, _p = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                  signal_vals=["High"], status_dv_xml="")
+_plan, _ref = plan_crm(open_sheet(_p))
+check("a workbook with NO Status validation at all is reported, not read as "
+      "already migrated", any("no data validation" in r for r in _ref), True)
+
+_n, _p = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                  signal_vals=["High"], x14_sqref="D2:D1000")
+_plan, _ref = plan_crm(open_sheet(_p))
+check("a Status validation hidden in the x14 extension block is refused "
+      "(a scan of the main namespace cannot see it)",
+      any("x14 extension" in r for r in _ref), True)
+
+_n, _p = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                  signal_vals=["High"], x14_sqref="F2:F1000")
+_plan, _ref = plan_crm(open_sheet(_p))
+check("an x14 validation on an UNRELATED column is not refused", _ref, [])
+
+# Signal's own list must be provably untouched in production, not just in tests.
+_n, _p = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                  signal_vals=["New"])
+_sh = open_sheet(_p)
+_sig_before = _sh.signal_dv_text()
+check("signal_dv_text reads the Signal list", _sig_before, '"%s"' % ",".join(SIGNAL_LIST))
+_pl, _rf = plan_crm(_sh)
+_sh.apply(_pl["cells"], _pl["dvs"])
+check("...and the migration leaves it byte-identical",
+      open_sheet(load_parts(save_parts(_n, _p))[1]).signal_dv_text(), _sig_before)
+
+# A plan from another workbook holds Element handles into a DIFFERENT tree.
+_na, _pa = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                    signal_vals=["High"])
+_nb, _pb = make_crm(status_col=3, signal_col=1,
+                    status_vals=["New", "New", "New"],
+                    signal_vals=["High", "High", "High"])
+_sheet_a = open_sheet(_pa)
+try:
+    _sheet_a.apply([2, 3, 4], [])
+    _mismatch = None
+except ValueError as e:
+    _mismatch = str(e)
+check("apply refuses a plan naming rows this sheet does not have "
+      "(plan/instance mismatch would edit a detached tree, silently)",
+      "plan/instance mismatch" in (_mismatch or ""), True)
+
+# The ET prefix registry is process-global and Phase B opens ~84 workbooks in
+# a row, so a workbook that declares an ALIASED spreadsheetml prefix must
+# neither be written mis-rooted nor poison the next workbook. This is the bug
+# sync_crm.Attendees.serialize() carries its own regression test for.
+def make_aliased_crm():
+    sheet = ('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+             '<x:worksheet xmlns:x="http://schemas.openxmlformats.org/'
+             'spreadsheetml/2006/main"><x:sheetData>'
+             '<x:row r="1"><x:c r="A1" t="inlineStr"><x:is><x:t>Status</x:t>'
+             '</x:is></x:c></x:row>'
+             '<x:row r="2"><x:c r="A2" t="inlineStr"><x:is><x:t>New</x:t>'
+             '</x:is></x:c></x:row></x:sheetData>'
+             '<x:dataValidations><x:dataValidation type="list" sqref="A2:A100">'
+             '<x:formula1>"New,Prospect"</x:formula1></x:dataValidation>'
+             '</x:dataValidations></x:worksheet>')
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", "<Types />")
+        z.writestr("xl/workbook.xml",
+                   '<workbook xmlns="http://schemas.openxmlformats.org/'
+                   'spreadsheetml/2006/main" xmlns:r="http://schemas.'
+                   'openxmlformats.org/officeDocument/2006/relationships">'
+                   '<sheets><sheet name="Attendees" sheetId="1" r:id="rId1" />'
+                   '</sheets></workbook>')
+        z.writestr("xl/_rels/workbook.xml.rels",
+                   '<Relationships xmlns="http://schemas.openxmlformats.org/'
+                   'package/2006/relationships"><Relationship Id="rId1" '
+                   'Target="worksheets/sheet1.xml" /></Relationships>')
+        z.writestr("xl/worksheets/sheet1.xml", sheet)
+    return load_parts(buf.getvalue())
+
+_na, _pa = make_aliased_crm()
+_sa = open_sheet(_pa)
+_pla, _rfa = plan_crm(_sa)
+check("an aliased workbook is still read by header name", _pla["cells"], [2])
+_sa.apply(_pla["cells"], _pla["dvs"])
+check("an aliased workbook serializes back as <worksheet>, not <x:worksheet>",
+      b"<worksheet" in _pa[sheet_part(_pa, "Attendees")], True)
+
+# ...and the NEXT workbook, opened after it, must be unaffected.
+_nb, _pb = make_crm(status_col=3, signal_col=1, status_vals=["New"],
+                    signal_vals=["High"])
+_sb = open_sheet(_pb)
+_plb, _rfb = plan_crm(_sb)
+_sb.apply(_plb["cells"], _plb["dvs"])
+check("the workbook opened AFTER it is not poisoned by the global ET registry",
+      b"<worksheet" in _pb[sheet_part(_pb, "Attendees")], True)
+
+
+# ---------------------------------------------------------------------------
 # Intake apply: column A and nothing else, explicit full rule
 # ---------------------------------------------------------------------------
 _calls = []
@@ -359,8 +606,9 @@ try:
                     "format": {"backgroundColor": {"blue": 1}}}}
     mig.apply_intake_tab({
         "tab": "Organizers", "guard": None, "cell_rows": [5, 6, 7, 12],
-        "gid": 99, "r0": 1, "r1": 1000, "cf_gid": 99,
+        "gid": 99, "cf_gid": 99, "dv_runs": [[1, 499], [899, 999]],
         "cf_plans": [(4, '=$A2="New"', _cf_rule)], "cf_refusals": [],
+        "dv_refusals": [],
         "rule": {"condition": {"type": "ONE_OF_LIST",
                                "values": [{"userEnteredValue": v}
                                           for v in INTAKE_LIST]},
@@ -374,22 +622,23 @@ check("apply issues the dropdown, then the color rules, then the cell writes",
       [("sheets", "spreadsheets", "batchUpdate"),
        ("sheets", "spreadsheets", "batchUpdate"),
        ("sheets", "spreadsheets", "values", "batchUpdate")])
+_dv_reqs = [r["setDataValidation"] for r in _calls[0][2]["requests"]]
+check("the dropdown is written per contiguous RUN, never over the hull "
+      "(the gap rows carry a different validation, or none)",
+      [(r["range"]["startRowIndex"], r["range"]["endRowIndex"]) for r in _dv_reqs],
+      [(1, 500), (899, 1000)])
+check("every dropdown write targets column A only",
+      {(r["range"]["startColumnIndex"], r["range"]["endColumnIndex"])
+       for r in _dv_reqs}, {(0, 1)})
+check("the rule is EXPLICIT and full (gws drops empty request objects)",
+      [v["userEnteredValue"] for v in _dv_reqs[0]["rule"]["condition"]["values"]],
+      migrate_list(INTAKE_LIST))
 _cf_req = _calls[1][2]["requests"][0]["updateConditionalFormatRule"]
 check("the color rule is replaced at its own index",
       (_cf_req["sheetId"], _cf_req["index"]), (99, 4))
 check("the rule is re-sent WHOLE — its ranges and color survive",
       (_cf_req["rule"]["ranges"], _cf_req["rule"]["booleanRule"]["format"]),
-      ([{"sheetId": 99, "startRowIndex": 1}],
-       {"backgroundColor": {"blue": 1}}))
-_dv_req = _calls[0][2]["requests"][0]["setDataValidation"]
-check("the dropdown rule targets column A only",
-      (_dv_req["range"]["startColumnIndex"], _dv_req["range"]["endColumnIndex"]),
-      (0, 1))
-check("the rule is EXPLICIT and full (gws drops empty request objects)",
-      [v["userEnteredValue"] for v in _dv_req["rule"]["condition"]["values"]],
-      migrate_list(INTAKE_LIST))
-check("showCustomUi is restated explicitly",
-      _dv_req["rule"]["showCustomUi"], True)
+      ([{"sheetId": 99, "startRowIndex": 1}], {"backgroundColor": {"blue": 1}}))
 _cell_body = _calls[2][2]
 check("cell writes are RAW", _cell_body["valueInputOption"], "RAW")
 check("every cell write targets column A, never B+",
@@ -402,6 +651,114 @@ check("run lengths match their value payloads",
       [len(d["values"]) for d in _cell_body["data"]], [3, 1])
 check("the written literal is Prospect",
       {v[0] for d in _cell_body["data"] for v in d["values"]}, {"Prospect"})
+
+# showCustomUi: the fixture above already carries it, so asserting on that run
+# proves nothing. Sheets OMITS the key when the chip is off — pin what the
+# setdefault actually does to a rule that lacks it.
+_calls.clear()
+mig.gws_json = _fake_gws_json
+try:
+    mig.apply_intake_tab({
+        "tab": "Organizers", "guard": None, "cell_rows": [], "gid": 7,
+        "cf_gid": 7, "dv_runs": [[1, 99]], "cf_plans": [], "cf_refusals": [],
+        "dv_refusals": [],
+        "rule": {"condition": {"type": "ONE_OF_LIST", "values": []}},
+        "new_list": ["Prospect"]})
+finally:
+    mig.gws_json = _saved
+check("a rule with NO showCustomUi gets it restated as True",
+      _calls[0][2]["requests"][0]["setDataValidation"]["rule"]["showCustomUi"],
+      True)
+
+
+# ---------------------------------------------------------------------------
+# intake_cf_plans: what it migrates, and what it refuses rather than skips
+# ---------------------------------------------------------------------------
+def _cf(kind, values, extra=None):
+    rule = {"ranges": [{"sheetId": 1}],
+            "booleanRule": {"condition": {
+                "type": kind,
+                "values": [{"userEnteredValue": v} for v in values]}}}
+    if extra:
+        rule["booleanRule"].update(extra)
+    return rule
+
+def _fake_cf_get(formats):
+    def _fake(*args, params=None, body=None):
+        return {"sheets": [{"properties": {"sheetId": 42, "title": "Organizers"},
+                            "conditionalFormats": formats}]}
+    return _fake
+
+def _cf_plans(formats):
+    mig.gws_json = _fake_cf_get(formats)
+    try:
+        return mig.intake_cf_plans("Organizers")
+    finally:
+        mig.gws_json = _saved
+
+_gid, _plans4, _ref4 = _cf_plans([
+    _cf("CUSTOM_FORMULA", ['=$A2="New"']),
+    _cf("CUSTOM_FORMULA", ['=$A2="Existing (from MLOps)"']),
+    _cf("TEXT_EQ", ["New"]),
+    _cf("TEXT_EQ", ["Accepted"]),
+    {"ranges": [{"sheetId": 1}], "gradientRule": {"minpoint": {}}},
+])
+check("the sheetId is returned for the named tab", _gid, 42)
+check("only the CUSTOM_FORMULA Status rule is planned",
+      [(i, old) for i, old, _r in _plans4], [(0, '=$A2="New"')])
+check("a TEXT_EQ 'New' rule is REFUSED, not silently skipped (it is how the "
+      "Sheets UI makes a status color, and verify re-runs this function)",
+      len(_ref4), 1)
+check("the refusal names the condition type", "TEXT_EQ" in _ref4[0], True)
+check("a TEXT_EQ on another status, and a gradient rule, are neither planned "
+      "nor refused", [r for r in _ref4 if "Accepted" in r], [])
+
+_gid, _plans5, _ref5 = _cf_plans([_cf("CUSTOM_FORMULA", ['=$A2="Prospect"'])])
+check("an already-migrated tab plans and refuses nothing",
+      (_plans5, _ref5), ([], []))
+
+_gid, _plans6, _ref6 = _cf_plans(
+    [_cf("CUSTOM_FORMULA", ['=OR($A2="New",EXACT($A2,"New"))'])])
+check("a rule that is BOTH migrated and partly unrecognised is planned AND "
+      "reported", (len(_plans6), len(_ref6)), (1, 1))
+
+
+# ---------------------------------------------------------------------------
+# assert_git_safe — the PII guard (ported from test_backup.py's cases)
+# ---------------------------------------------------------------------------
+def _git_safe_with(results):
+    """Run assert_git_safe with subprocess.run stubbed; return SystemExit msg."""
+    calls = iter(results)
+    class _P:
+        def __init__(self, rc, out="", err=""):
+            self.returncode, self.stdout, self.stderr = rc, out, err
+    def _fake_run(argv, **kw):
+        return _P(*next(calls))
+    saved = mig.subprocess.run
+    mig.subprocess.run = _fake_run
+    try:
+        mig.assert_git_safe("/tmp/whatever")
+        return None
+    except SystemExit as e:
+        return str(e)
+    finally:
+        mig.subprocess.run = saved
+
+check("outside any repo is safe",
+      _git_safe_with([(128, "", "fatal: not a git repository (or any of the "
+                              "parent directories): .git")]), None)
+check("a git failure that is NOT 'outside a repo' ABORTS — mapping it to safe "
+      "silently disengages the PII guard",
+      "cannot verify" in (_git_safe_with(
+          [(128, "", "fatal: detected dubious ownership in repository at '/x'")])
+          or ""), True)
+check("inside a repo, ignored and untracked is safe",
+      _git_safe_with([(0, "/repo", ""), (0,), (1,)]), None)
+check("inside a repo but NOT ignored aborts",
+      "not gitignored" in (_git_safe_with([(0, "/repo", ""), (1,), (1,)]) or ""),
+      True)
+check("an ignored-but-TRACKED path aborts (.gitignore does not un-track)",
+      "TRACKED" in (_git_safe_with([(0, "/repo", ""), (0,), (0,)]) or ""), True)
 
 print()
 print("FAILED %d check(s)" % fails if fails else "All checks passed.")

--- a/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Unit tests for migrate_status_prospect.py — plan logic and zip surgery only,
+no network/gws. Follows the plain-script test convention (exit 1 on failure).
+
+The .xlsx fixtures are built with zipfile from the same shape the chapter CRMs
+have — a Status list validation AND a Signal list validation that legitimately
+contains "New". The load-bearing cases:
+
+  * columns are located by HEADER NAME: a workbook whose Status/Signal columns
+    are swapped migrates identically, and Signal's unrelated "New" survives in
+    both its dropdown and its data cells;
+  * only the sheet part being edited changes — every other zip part is repacked
+    byte-identically;
+  * the intake plan touches column A and nothing else (columns B+ are
+    ARRAYFORMULA mirrors), and refuses a tab whose Status column moved.
+"""
+import io
+import os
+import re
+import sys
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import migrate_status_prospect as mig
+from migrate_status_prospect import (CrmStatusSheet, dv_list,
+                                     intake_status_guard, migrate_list,
+                                     plan_crm, plan_intake_cells, runs_of,
+                                     sqref_cols)
+from sync_crm import cell_ref, load_parts, save_parts, sheet_part
+
+fails = 0
+def check(label, got, want):
+    global fails
+    ok = got == want
+    fails += 0 if ok else 1
+    print("%s %s" % ("ok  " if ok else "FAIL", label))
+    if not ok:
+        print("      got : %r\n      want: %r" % (got, want))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+INTAKE_LIST = ["New", "In progress", "Tentative", "Interviewing", "Accepted",
+               "Denied", "Inactive", "Duplicate", "Existing (from MLOps)"]
+CRM_LIST = ["New", "Prospect", "Attended", "Regular", "Speaker", "Organizer",
+            "Volunteer", "Host", "Declined"]
+SIGNAL_LIST = ["High", "Low", "Non-grata", "New"]
+
+check("intake list: New is replaced in place (Prospect not yet offered)",
+      migrate_list(INTAKE_LIST),
+      ["Prospect", "In progress", "Tentative", "Interviewing", "Accepted",
+       "Denied", "Inactive", "Duplicate", "Existing (from MLOps)"])
+check("CRM list: the leading New is dropped (Prospect already offered)",
+      migrate_list(CRM_LIST), CRM_LIST[1:])
+check("a list without New is already in sync", migrate_list(CRM_LIST[1:]), None)
+check("order is preserved either way",
+      migrate_list(["A", "New", "B"]), ["A", "Prospect", "B"])
+
+check("guard passes when Status is column A",
+      intake_status_guard(["Status", "Full name", "Email"]), None)
+check("guard strips header whitespace",
+      intake_status_guard([" Status ", "Full name"]), None)
+check("guard refuses a tab with no Status column",
+      "no 'Status' column" in (intake_status_guard(["Full name"]) or ""), True)
+check("guard refuses Status anywhere but column A (B+ are ARRAYFORMULAs)",
+      "not column A" in (intake_status_guard(["Full name", "Status"]) or ""), True)
+
+check("plan_intake_cells takes only literal New data cells",
+      plan_intake_cells(["Status", "New", "", "In progress", "New ", "Accepted"]),
+      [2, 5])
+check("a header cell is never planned even if it said New",
+      plan_intake_cells(["New", "Accepted"]), [])
+check("runs_of groups contiguous rows",
+      runs_of([2, 3, 4, 7, 9, 10]), [[2, 4], [7, 7], [9, 10]])
+
+check("sqref_cols reads a plain range", sqref_cols("D2:D1000"), {3})
+check("sqref_cols reads multiple refs and spans",
+      sqref_cols("B2:C10 F3"), {1, 2, 5})
+check("dv_list strips the quotes", dv_list('"A,B,C"'), ["A", "B", "C"])
+check("dv_list refuses a non-literal formula", dv_list("=Lists!A1:A9"), None)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a CRM-shaped workbook with Status and Signal validations
+# ---------------------------------------------------------------------------
+def _c(ref, text, shared_idx=None):
+    if text is None:
+        return ""
+    if shared_idx is not None:
+        return '<c r="%s" t="s"><v>%d</v></c>' % (ref, shared_idx)
+    return '<c r="%s" t="inlineStr"><is><t>%s</t></is></c>' % (ref, text)
+
+
+def make_crm(status_col, signal_col, status_vals, signal_vals,
+             status_dv=CRM_LIST, signal_dv=SIGNAL_LIST, dv_sqref=None,
+             shared_status_rows=()):
+    """Build an .xlsx whose Attendees sheet has Status/Signal at the given
+    0-based columns. `shared_status_rows` store their Status value through
+    sharedStrings — the legacy storage form, and the reason a bytes-level
+    replace of "New" could never be safe (Signal shares the same string)."""
+    headers = ["Full name"] + [""] * (max(status_col, signal_col) + 1)
+    headers[status_col] = "Status"
+    headers[signal_col] = "Signal"
+    sst = ["New"]
+    rows = ['<row r="1">%s</row>'
+            % "".join(_c(cell_ref(i, 1), h) for i, h in enumerate(headers) if h)]
+    for n, (sv, gv) in enumerate(zip(status_vals, signal_vals), start=2):
+        cells = _c(cell_ref(0, n), "Person %d" % n)
+        if sv is not None:
+            if n in shared_status_rows and sv == "New":
+                cells += _c(cell_ref(status_col, n), sv, shared_idx=0)
+            else:
+                cells += _c(cell_ref(status_col, n), sv)
+        if gv is not None:
+            cells += _c(cell_ref(signal_col, n), gv)
+        rows.append('<row r="%d">%s</row>' % (n, cells))
+    s_let = cell_ref(status_col, 2)[:-1]
+    g_let = cell_ref(signal_col, 2)[:-1]
+    dvs = ('<dataValidation type="list" sqref="%s">'
+           '<formula1>"%s"</formula1></dataValidation>'
+           % (dv_sqref or "%s2:%s1000" % (s_let, s_let), ",".join(status_dv)))
+    dvs += ('<dataValidation type="list" sqref="%s2:%s1000">'
+            '<formula1>"%s"</formula1></dataValidation>'
+            % (g_let, g_let, ",".join(signal_dv)))
+    sheet = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        '<dimension ref="A1:K12" /><sheetData>%s</sheetData>'
+        '<dataValidations count="2">%s</dataValidations></worksheet>'
+        % ("".join(rows), dvs))
+    parts = {
+        "[Content_Types].xml": "<Types />",
+        "_rels/.rels": "<Relationships />",
+        "xl/workbook.xml":
+            '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+            ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+            '<sheets><sheet name="Attendees" sheetId="1" r:id="rId1" /></sheets></workbook>',
+        "xl/_rels/workbook.xml.rels":
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            '<Relationship Id="rId1" Target="worksheets/sheet1.xml" /></Relationships>',
+        "xl/sharedStrings.xml":
+            '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            + "".join("<si><t>%s</t></si>" % s for s in sst) + "</sst>",
+        "xl/worksheets/sheet1.xml": sheet,
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for n, v in parts.items():
+            z.writestr(n, v.encode())
+    return load_parts(buf.getvalue())
+
+
+def open_sheet(parts):
+    return CrmStatusSheet(parts, sheet_part(parts, "Attendees"))
+
+
+def migrate_and_reload(names, parts):
+    sheet = open_sheet(parts)
+    plan, refusals = plan_crm(sheet)
+    sheet.apply(plan["cells"], plan["dvs"])
+    return plan, refusals, load_parts(save_parts(names, parts))
+
+
+# ---------------------------------------------------------------------------
+# The canonical shape: Signal at B, Status at D; one legacy shared-string cell
+# ---------------------------------------------------------------------------
+names, parts = make_crm(status_col=3, signal_col=1,
+                        status_vals=["New", "Prospect", "New", "Organizer"],
+                        signal_vals=["New", "High", None, "New"],
+                        shared_status_rows={4})
+sheet = open_sheet(parts)
+check("Status is located by header name", sheet.status_col, 3)
+check("Signal is located by header name", sheet.signal_col, 1)
+plan, refusals = plan_crm(sheet)
+check("only Status cells holding New are planned", plan["cells"], [2, 4])
+check("exactly one validation (Status's) is planned",
+      [(old, new) for _dv, old, new in plan["dvs"]],
+      [(CRM_LIST, CRM_LIST[1:])])
+check("no refusals on a healthy workbook", refusals, [])
+
+_before_wb = parts["xl/workbook.xml"]
+plan, refusals, (rt_names, rt_parts) = migrate_and_reload(names, parts)
+rt = open_sheet(rt_parts)
+check("every zip part survives the round-trip", rt_names, names)
+check("untouched parts are byte-identical",
+      rt_parts["xl/workbook.xml"] == _before_wb, True)
+check("Status cells now read Prospect (incl. the shared-string one)",
+      rt.status_cells_holding_old(), [])
+raw = rt_parts[sheet_part(rt_parts, "Attendees")].decode()
+check("the rewritten Status cells read back as Prospect",
+      [mig.cell_text(c, rt.sst)
+       for r in rt.rows.values() if int(r.get("r")) > 1
+       for c in r.findall(mig.X + "c")
+       if mig.col_of(c.get("r")) == rt.status_col],
+      ["Prospect", "Prospect", "Prospect", "Organizer"])
+check("the Status dropdown lost New",
+      '"%s"' % ",".join(CRM_LIST[1:]) in raw, True)
+check("Signal's dropdown STILL offers its unrelated New",
+      '"%s"' % ",".join(SIGNAL_LIST) in raw, True)
+# Signal data cells: row 2 and row 5 held "New" — prove they survived.
+sig_cells = [c for r in rt.rows.values() if int(r.get("r")) > 1
+             for c in r.findall(mig.X + "c")
+             if mig.col_of(c.get("r")) == rt.signal_col]
+from sync_crm import cell_text  # noqa: E402
+check("Signal data cells still hold their New values",
+      sorted(cell_text(c, rt.sst) for c in sig_cells if cell_text(c, rt.sst)),
+      ["High", "New", "New"])
+plan2, refusals2 = plan_crm(rt)
+check("a migrated workbook plans nothing (idempotent / verify contract)",
+      (plan2["cells"], plan2["dvs"], refusals2), ([], [], []))
+
+
+# ---------------------------------------------------------------------------
+# Swapped columns: Status at B, Signal at D — header location, not position
+# ---------------------------------------------------------------------------
+names_s, parts_s = make_crm(status_col=1, signal_col=3,
+                            status_vals=["New", "Declined"],
+                            signal_vals=["New", "New"])
+sheet_s = open_sheet(parts_s)
+check("swapped: Status found at column B", sheet_s.status_col, 1)
+plan_s, refusals_s, (_n, rt_parts_s) = migrate_and_reload(names_s, parts_s)
+rt_s = open_sheet(rt_parts_s)
+raw_s = rt_parts_s[sheet_part(rt_parts_s, "Attendees")].decode()
+check("swapped: the one New status cell was planned", plan_s["cells"], [2])
+check("swapped: Status dropdown (on B) lost New",
+      '"%s"' % ",".join(CRM_LIST[1:]) in raw_s, True)
+check("swapped: Signal dropdown (on D) keeps New",
+      '"%s"' % ",".join(SIGNAL_LIST) in raw_s, True)
+check("swapped: both Signal data cells still say New",
+      sorted(cell_text(c, rt_s.sst)
+             for r in rt_s.rows.values() if int(r.get("r")) > 1
+             for c in r.findall(mig.X + "c")
+             if mig.col_of(c.get("r")) == rt_s.signal_col),
+      ["New", "New"])
+check("swapped: a human's Declined is untouched",
+      "Declined" in raw_s, True)
+
+
+# ---------------------------------------------------------------------------
+# Refusals: a validation spanning Status AND another column is never edited
+# ---------------------------------------------------------------------------
+names_r, parts_r = make_crm(status_col=3, signal_col=1,
+                            status_vals=["New"], signal_vals=["New"],
+                            dv_sqref="B2:D1000")
+plan_r, refusals_r = plan_crm(open_sheet(parts_r))
+check("a multi-column Status validation is refused, not edited",
+      (len(plan_r["dvs"]), len(refusals_r)), (0, 1))
+check("the refusal names the sqref", "B2:D1000" in refusals_r[0], True)
+check("...but the cell rewrites are still planned", plan_r["cells"], [2])
+
+try:
+    make_no_status = make_crm(status_col=3, signal_col=1,
+                              status_vals=["New"], signal_vals=["New"])
+    make_no_status[1]["xl/worksheets/sheet1.xml"] = \
+        make_no_status[1]["xl/worksheets/sheet1.xml"].replace(b"Status", b"Stage")
+    open_sheet(make_no_status[1])
+    check("a workbook without a Status header is refused", "no error", "ValueError")
+except ValueError as e:
+    check("a workbook without a Status header is refused",
+          "no 'Status' header" in str(e), True)
+
+
+# ---------------------------------------------------------------------------
+# Intake apply: column A and nothing else, explicit full rule
+# ---------------------------------------------------------------------------
+_calls = []
+def _fake_gws_json(*args, params=None, body=None):
+    _calls.append((args, params, body))
+    return {}
+
+_saved = mig.gws_json
+mig.gws_json = _fake_gws_json
+try:
+    mig.apply_intake_tab({
+        "tab": "Organizers", "guard": None, "cell_rows": [5, 6, 7, 12],
+        "gid": 99, "r0": 1, "r1": 1000,
+        "rule": {"condition": {"type": "ONE_OF_LIST",
+                               "values": [{"userEnteredValue": v}
+                                          for v in INTAKE_LIST]},
+                 "showCustomUi": True},
+        "new_list": migrate_list(INTAKE_LIST)})
+finally:
+    mig.gws_json = _saved
+
+check("apply issues the dropdown batchUpdate then the cell writes",
+      [a[:4] for a, _p, _b in _calls],
+      [("sheets", "spreadsheets", "batchUpdate"),
+       ("sheets", "spreadsheets", "values", "batchUpdate")])
+_dv_req = _calls[0][2]["requests"][0]["setDataValidation"]
+check("the dropdown rule targets column A only",
+      (_dv_req["range"]["startColumnIndex"], _dv_req["range"]["endColumnIndex"]),
+      (0, 1))
+check("the rule is EXPLICIT and full (gws drops empty request objects)",
+      [v["userEnteredValue"] for v in _dv_req["rule"]["condition"]["values"]],
+      migrate_list(INTAKE_LIST))
+check("showCustomUi is restated explicitly",
+      _dv_req["rule"]["showCustomUi"], True)
+_cell_body = _calls[1][2]
+check("cell writes are RAW", _cell_body["valueInputOption"], "RAW")
+check("every cell write targets column A, never B+",
+      all(re.fullmatch(r"'Organizers'!A\d+:A\d+", d["range"])
+          for d in _cell_body["data"]), True)
+check("contiguous rows are grouped into runs",
+      [d["range"] for d in _cell_body["data"]],
+      ["'Organizers'!A5:A7", "'Organizers'!A12:A12"])
+check("run lengths match their value payloads",
+      [len(d["values"]) for d in _cell_body["data"]], [3, 1])
+check("the written literal is Prospect",
+      {v[0] for d in _cell_body["data"] for v in d["values"]}, {"Prospect"})
+
+print()
+print("FAILED %d check(s)" % fails if fails else "All checks passed.")
+sys.exit(1 if fails else 0)

--- a/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
@@ -22,10 +22,12 @@ import zipfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import migrate_status_prospect as mig
-from migrate_status_prospect import (CF_TOKEN_NEW, CF_TOKEN_OLD, CrmStatusSheet,
-                                     cf_refusal, dv_list, intake_status_guard,
+from migrate_status_prospect import (CF_TOKEN_NEW, CF_TOKEN_OLD, HOWTO_TEXTS,
+                                     CrmStatusSheet, cf_refusal, dv_list,
+                                     howto_new_text, intake_status_guard,
                                      migrate_cf_formula, migrate_list, plan_crm,
-                                     plan_intake_cells, runs_of, sqref_cols)
+                                     plan_howto, plan_intake_cells, runs_of,
+                                     sqref_cols)
 from sync_crm import cell_ref, load_parts, save_parts, sheet_part
 
 fails = 0
@@ -104,6 +106,58 @@ check("EXACT() against column A is reported too",
       "migrate it by hand" in (cf_refusal('=EXACT($A2,"New")') or ""), True)
 check("a rule with no Status test is not a refusal",
       cf_refusal('=$K2<>""'), None)
+
+# ---------------------------------------------------------------------------
+# The "How to use" tab's status prose
+# ---------------------------------------------------------------------------
+check("every curated sentence still says the old status",
+      [t for t in HOWTO_TEXTS if "New" not in t], [])
+check("the swap takes the FIRST New, which is the status one",
+      howto_new_text("Every new submission defaults to New. Then Tentative."),
+      "Every new submission defaults to Prospect. Then Tentative.")
+check("no curated sentence also mentions the City (New) header "
+      "(which the first-occurrence swap would eat)",
+      [t for t in HOWTO_TEXTS if "City (New)" in t], [])
+check("no curated sentence carries a second status New",
+      [t for t in HOWTO_TEXTS if t.count("New") != 1], [])
+
+# The tab as get_values returns it: ragged rows, prose in mixed columns, and
+# the mentions that must SURVIVE (a form note, the City (New) header, a flow
+# line about a new city).
+HOWTO_ROWS = [
+    ["STATUS"],
+    [],
+    ["Tab", "New submissions append here automatically."],
+    [HOWTO_TEXTS[0], HOWTO_TEXTS[1]],
+    ["\U0001f7e6  Blue", HOWTO_TEXTS[2]],
+    ["\U0001fa77  Pink", HOWTO_TEXTS[3]],
+    ["CITY COLORS  (on the City (Existing) / City (New) columns)"],
+    [HOWTO_TEXTS[4]],
+    ["        \u2514 New city / new chapter  \u2192  City (New)"],
+]
+_plans, _refusals = plan_howto(HOWTO_ROWS)
+check("every status sentence is located, and nothing else is",
+      [(a1, new) for a1, _o, new in _plans],
+      [("A4", "Prospect \u2192 In progress \u2192 Accepted / Denied"),
+       ("B4", howto_new_text(HOWTO_TEXTS[1])),
+       ("B5", "Prospect \u2014 untriaged."),
+       ("B6", howto_new_text(HOWTO_TEXTS[3])),
+       ("A8", "Form submission  \u2192  \U0001f7e6 Prospect")])
+check("a clean tab raises no refusals", _refusals, [])
+
+_migrated = [[howto_new_text(c) if c in HOWTO_TEXTS else c for c in row]
+             for row in HOWTO_ROWS]
+check("an already-migrated tab plans nothing (idempotent)",
+      plan_howto(_migrated), ([], []))
+
+_reworded = [[c for c in row if c not in (HOWTO_TEXTS[2],)] for row in HOWTO_ROWS]
+_p2, _r2 = plan_howto(_reworded)
+check("a reworded sentence is REFUSED, not guessed at", len(_r2), 1)
+check("the refusal names the sentence", "untriaged" in _r2[0], True)
+check("...and the other four are still planned", len(_p2), 4)
+
+check("sentences are located by TEXT, not by a fixed A1 (rows can shift)",
+      [a1 for a1, _o, _n in plan_howto([[], []] + HOWTO_ROWS)[0]][:1], ["A6"])
 check("dv_list refuses a non-literal formula", dv_list("=Lists!A1:A9"), None)
 
 

--- a/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
@@ -22,10 +22,10 @@ import zipfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import migrate_status_prospect as mig
-from migrate_status_prospect import (CrmStatusSheet, dv_list,
-                                     intake_status_guard, migrate_list,
-                                     plan_crm, plan_intake_cells, runs_of,
-                                     sqref_cols)
+from migrate_status_prospect import (CF_TOKEN_NEW, CF_TOKEN_OLD, CrmStatusSheet,
+                                     cf_refusal, dv_list, intake_status_guard,
+                                     migrate_cf_formula, migrate_list, plan_crm,
+                                     plan_intake_cells, runs_of, sqref_cols)
 from sync_crm import cell_ref, load_parts, save_parts, sheet_part
 
 fails = 0
@@ -78,6 +78,32 @@ check("sqref_cols reads a plain range", sqref_cols("D2:D1000"), {3})
 check("sqref_cols reads multiple refs and spans",
       sqref_cols("B2:C10 F3"), {1, 2, 5})
 check("dv_list strips the quotes", dv_list('"A,B,C"'), ["A", "B", "C"])
+
+# The two live rule shapes on the intake role tabs: the whole-row status color
+# and the pink 1-week SLA breach (which ORs blank with the old literal).
+SLA = '=AND($C2<>"",OR($A2="",$A2="New"),TODAY()-INT($C2)>=7)'
+check("the status color rule is renamed",
+      migrate_cf_formula('=$A2="New"'), '=$A2="Prospect"')
+check("the SLA rule keeps its date logic and its blank arm",
+      migrate_cf_formula(SLA),
+      '=AND($C2<>"",OR($A2="",$A2="Prospect"),TODAY()-INT($C2)>=7)')
+check("a rule testing another status is left alone",
+      migrate_cf_formula('=$A2="Existing (from MLOps)"'), None)
+check("the City (New) header is not a Status test",
+      migrate_cf_formula('=$J2="City (New)"'), None)
+check("an already-migrated rule is in sync (idempotent)",
+      migrate_cf_formula('=$A2="Prospect"'), None)
+check("the tokens are the column-A Status test",
+      (CF_TOKEN_OLD, CF_TOKEN_NEW), ('$A2="New"', '$A2="Prospect"'))
+
+check("a migrated rule is not also reported as a refusal",
+      cf_refusal('=$A2="New"'), None)
+check("an unrecognised column-A test for New is reported, never guessed at",
+      "migrate it by hand" in (cf_refusal('=$A$2 = "New"') or ""), True)
+check("EXACT() against column A is reported too",
+      "migrate it by hand" in (cf_refusal('=EXACT($A2,"New")') or ""), True)
+check("a rule with no Status test is not a refusal",
+      cf_refusal('=$K2<>""'), None)
 check("dv_list refuses a non-literal formula", dv_list("=Lists!A1:A9"), None)
 
 
@@ -272,9 +298,15 @@ def _fake_gws_json(*args, params=None, body=None):
 _saved = mig.gws_json
 mig.gws_json = _fake_gws_json
 try:
+    _cf_rule = {"ranges": [{"sheetId": 99, "startRowIndex": 1}],
+                "booleanRule": {"condition": {
+                    "type": "CUSTOM_FORMULA",
+                    "values": [{"userEnteredValue": '=$A2="Prospect"'}]},
+                    "format": {"backgroundColor": {"blue": 1}}}}
     mig.apply_intake_tab({
         "tab": "Organizers", "guard": None, "cell_rows": [5, 6, 7, 12],
-        "gid": 99, "r0": 1, "r1": 1000,
+        "gid": 99, "r0": 1, "r1": 1000, "cf_gid": 99,
+        "cf_plans": [(4, '=$A2="New"', _cf_rule)], "cf_refusals": [],
         "rule": {"condition": {"type": "ONE_OF_LIST",
                                "values": [{"userEnteredValue": v}
                                           for v in INTAKE_LIST]},
@@ -283,10 +315,18 @@ try:
 finally:
     mig.gws_json = _saved
 
-check("apply issues the dropdown batchUpdate then the cell writes",
+check("apply issues the dropdown, then the color rules, then the cell writes",
       [a[:4] for a, _p, _b in _calls],
       [("sheets", "spreadsheets", "batchUpdate"),
+       ("sheets", "spreadsheets", "batchUpdate"),
        ("sheets", "spreadsheets", "values", "batchUpdate")])
+_cf_req = _calls[1][2]["requests"][0]["updateConditionalFormatRule"]
+check("the color rule is replaced at its own index",
+      (_cf_req["sheetId"], _cf_req["index"]), (99, 4))
+check("the rule is re-sent WHOLE — its ranges and color survive",
+      (_cf_req["rule"]["ranges"], _cf_req["rule"]["booleanRule"]["format"]),
+      ([{"sheetId": 99, "startRowIndex": 1}],
+       {"backgroundColor": {"blue": 1}}))
 _dv_req = _calls[0][2]["requests"][0]["setDataValidation"]
 check("the dropdown rule targets column A only",
       (_dv_req["range"]["startColumnIndex"], _dv_req["range"]["endColumnIndex"]),
@@ -296,7 +336,7 @@ check("the rule is EXPLICIT and full (gws drops empty request objects)",
       migrate_list(INTAKE_LIST))
 check("showCustomUi is restated explicitly",
       _dv_req["rule"]["showCustomUi"], True)
-_cell_body = _calls[1][2]
+_cell_body = _calls[2][2]
 check("cell writes are RAW", _cell_body["valueInputOption"], "RAW")
 check("every cell write targets column A, never B+",
       all(re.fullmatch(r"'Organizers'!A\d+:A\d+", d["range"])

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -194,6 +194,17 @@ check("pipeline note carries the intake status",
 f_pspk = crm_fields(merge_people([person("Dee", "dee@x.io", "B", "Speakers", "New")])[0], TODAY)
 check("pipeline speaker -> Speaker (not Prospect)", f_pspk["Status"], "Speaker")
 check("pipeline speaker is not Trusted", f_pspk["Trusted/Regular"], "")
+# The 2026-08-22 rename transition: an intake row still saying the legacy "New"
+# behaves identically to one saying "Prospect".
+check("both the legacy and current spellings are pipeline statuses",
+      [s for s in ("New", "Prospect") if s in sync_crm.PIPELINE_STATUSES],
+      ["New", "Prospect"])
+f_leg = crm_fields(merge_people([person("Lee", "lee@x.io", "B", "Organizers", "New")])[0], TODAY)
+f_cur = crm_fields(merge_people([person("Lee", "lee@x.io", "B", "Organizers", "Prospect")])[0], TODAY)
+check("a legacy-New organizer lands as Prospect, exactly like a Prospect one",
+      (f_leg["Status"], f_leg["Trusted/Regular"]),
+      (f_cur["Status"], f_cur["Trusted/Regular"]))
+check("...and that Status is Prospect", f_cur["Status"], "Prospect")
 # Accepted in one role while still in the pipeline for another: the accepted
 # role wins the Status, and the organizer application alone earns no trust.
 f_mix = crm_fields(merge_people([
@@ -277,6 +288,8 @@ _GRID = [
     ["Tentative", "Tess", "tess@x.io", "Boston", "", ""],
     ["Denied", "Dan", "dan@x.io", "Boston", "", ""],
     ["Zebra", "Zed", "zed@x.io", "Boston", "", ""],
+    ["New", "Newt", "newt@x.io", "Boston", "", ""],       # legacy spelling
+    ["Prospect", "Pia", "pia@x.io", "Boston", "", ""],    # current spelling
     ["", "Bea", "bea@x.io", "Boston", "", ""],
 ]
 _saved_gv = sync_crm.get_values
@@ -287,12 +300,14 @@ try:
           [p["name"] for p in pp], ["Ada"])
     check("everyone else is rejected as not-accepted by default",
           [r["name"] for r in rr if "not accepted yet" in r["why"]],
-          ["Tess", "Dan", "Zed", "Bea"])
+          ["Tess", "Dan", "Zed", "Newt", "Pia", "Bea"])
     pp, rr, _fb = sync_crm.read_role_tab("Organizers", {}, include_pipeline=True)
-    check("pipeline mode admits in-flight statuses",
-          sorted(p["name"] for p in pp), ["Ada", "Bea", "Tess"])
-    check("a blank status is normalized to New on the person",
-          [p["status"] for p in pp if p["name"] == "Bea"], ["New"])
+    check("pipeline mode admits in-flight statuses — legacy New included",
+          sorted(p["name"] for p in pp), ["Ada", "Bea", "Newt", "Pia", "Tess"])
+    check("a blank status is normalized to Prospect on the person",
+          [p["status"] for p in pp if p["name"] == "Bea"], ["Prospect"])
+    check("a raw legacy New survives on the person (the note shows the truth)",
+          [p["status"] for p in pp if p["name"] == "Newt"], ["New"])
     check("Denied and unknown statuses fail closed even in pipeline mode",
           sorted(r["name"] for r in rr
                  if "declined, parked, or not a recognised" in r["why"]),
@@ -567,6 +582,25 @@ check("legacy patch is idempotent", patch_status_dropdown(parts, part), "already
 names, parts, _ = book(sample_row=SAMPLE, dv="Yes,No")
 check("a workbook with no Status list is reported, not guessed at",
       patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "absent")
+
+# The status-rename migration (migrate_status_prospect.py) removes the legacy
+# "New" from a workbook's Status list; the Host patch must still recognise the
+# migrated spellings rather than reporting the list absent.
+check("the migrated lists differ from the shipped ones only by the leading New",
+      (sync_crm.DV_STATUS_OLD_MIGRATED, sync_crm.DV_STATUS_NEW_MIGRATED),
+      (DV_STATUS_OLD.replace("New,", "", 1), DV_STATUS_NEW.replace("New,", "", 1)))
+names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_OLD_MIGRATED)
+part = sheet_part(parts, "Attendees")
+check("a migrated Host-less workbook is still patched",
+      patch_status_dropdown(parts, part), "patched")
+check('...gaining "Host" in the migrated spelling',
+      sync_crm.DV_STATUS_NEW_MIGRATED.encode() in parts[part], True)
+check("...and never re-gaining the legacy New",
+      DV_STATUS_NEW.encode() in parts[part], False)
+check("the migrated patch is idempotent", patch_status_dropdown(parts, part), "already")
+names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_NEW_MIGRATED)
+check("a migrated, already-Host workbook is left alone",
+      patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "already")
 
 # Regression: serialize() rewrites the sheet part from the element tree, so a
 # dropdown patch applied BEFORE it is silently discarded — the run reports the

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -602,6 +602,32 @@ names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_NEW_MIGRATED)
 check("a migrated, already-Host workbook is left alone",
       patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "already")
 
+# The real post-migration fleet shape: a LEGACY workbook (&quot;-escaped) whose
+# Status list has been migrated. Every migrated-list case above uses the `"`
+# encoding, so this combination — the likeliest one in the estate — is the one
+# the restructured two-pass loop never exercised.
+names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_OLD_MIGRATED)
+part = sheet_part(parts, "Attendees")
+parts[part] = parts[part].replace(
+    ('"%s"' % sync_crm.DV_STATUS_OLD_MIGRATED).encode(),
+    ("&quot;%s&quot;" % sync_crm.DV_STATUS_OLD_MIGRATED).encode())
+check("a &quot;-escaped MIGRATED workbook is patched, not reported absent",
+      patch_status_dropdown(parts, part), "patched")
+check("...keeping the escaping and the migrated spelling",
+      ("&quot;%s&quot;" % sync_crm.DV_STATUS_NEW_MIGRATED).encode() in parts[part],
+      True)
+check("...and it stays idempotent", patch_status_dropdown(parts, part), "already")
+
+# The four dropdown literals are DERIVED from one tuple; pin what they derive to
+# so a future edit to DV_STATUS_VALUES cannot silently change the wire format.
+check("the derived literals are exactly the four the patcher matches",
+      (sync_crm.DV_STATUS_OLD, sync_crm.DV_STATUS_NEW,
+       sync_crm.DV_STATUS_OLD_MIGRATED, sync_crm.DV_STATUS_NEW_MIGRATED),
+      ("New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined",
+       "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined",
+       "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined",
+       "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"))
+
 # Regression: serialize() rewrites the sheet part from the element tree, so a
 # dropdown patch applied BEFORE it is silently discarded — the run reports the
 # patch as applied and the uploaded workbook still has the eight-value list.

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -37,9 +37,12 @@ know it has seen someone before, so no automation sets this value. A
 **blank** Status cell is treated as `Prospect`, and so is the **legacy value `New`** —
 the pre-2026-08-22 name for the same state, renamed because `New` misread as
 "new organizer" while `Prospect` matches the term the CRM sync already writes.
-`migrate_status_prospect.py` (in `aaif-sync-chapters`) rewrites the dropdowns and
-cells; until it has run everywhere, tooling treats `New` and `Prospect` as one
-status. Two overrides beat the status color: a **data error** (missing/invalid email
+`migrate_status_prospect.py` (in `aaif-sync-chapters`) rewrites the dropdowns,
+the cells **and the conditional-format rules that test the Status literal**
+(the blue row color and the pink SLA rule below both key on `=$A2="…"`, are
+hand-made on the sheet, and are repaired by nothing else — renaming only the
+cells leaves every row unpainted and the SLA breach permanently un-fired);
+until it has run everywhere, tooling treats `New` and `Prospect` as one status. Two overrides beat the status color: a **data error** (missing/invalid email
 or broken LinkedIn) paints the row bright red, and an **SLA breach** — a `Prospect`/blank
 row older than 1 week (of a 2-week response SLA) — paints it pink. Acting on a row
 (moving it off `Prospect`) clears the pink. Each role tab also has `Reviewed by`,

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -19,7 +19,7 @@ sheet's structure.
 ## Status model (drives the queue and the sheet's cell colors)
 
 The Status values (dropdown on column A, matched exactly by the sheet's
-whole-row colors): `New` (blue) → `In progress` (orange) → `Tentative` (teal) →
+whole-row colors): `Prospect` (blue) → `In progress` (orange) → `Tentative` (teal) →
 `Interviewing` (indigo) → `Accepted` (green) / `Denied` (maroon); `Inactive` (gray);
 `Duplicate` (brown); and `Existing (from MLOps)`
 (**violet**) for a prior organizer imported from the MLOps community. `Tentative` is a
@@ -34,10 +34,15 @@ rather than denied (a `Denied` row reads as a decision about the person, which t
 is not). It is not a sync status: nothing carries a `Duplicate` row to the chapters
 feed, a CRM or a Drive grant. Rows are only ever marked by hand — the form can't
 know it has seen someone before, so no automation sets this value. A
-**blank** Status cell is treated as `New`. Two overrides beat the status color: a **data error** (missing/invalid email
-or broken LinkedIn) paints the row bright red, and an **SLA breach** — a `New`/blank
+**blank** Status cell is treated as `Prospect`, and so is the **legacy value `New`** —
+the pre-2026-08-22 name for the same state, renamed because `New` misread as
+"new organizer" while `Prospect` matches the term the CRM sync already writes.
+`migrate_status_prospect.py` (in `aaif-sync-chapters`) rewrites the dropdowns and
+cells; until it has run everywhere, tooling treats `New` and `Prospect` as one
+status. Two overrides beat the status color: a **data error** (missing/invalid email
+or broken LinkedIn) paints the row bright red, and an **SLA breach** — a `Prospect`/blank
 row older than 1 week (of a 2-week response SLA) — paints it pink. Acting on a row
-(moving it off `New`) clears the pink. Each role tab also has `Reviewed by`,
+(moving it off `Prospect`) clears the pink. Each role tab also has `Reviewed by`,
 `Reviewed at`, `Decision notes`, and a `Chapter` assignment.
 
 **City provenance colors** (on the two city columns, below the error rule; installed by
@@ -56,7 +61,7 @@ MLOps veterans convert straight through; everyone else is accepted only **after 
 interview** (existing-city candidates also get an intro to the chapter champs):
 
 ```
-Form submission ─→ New
+Form submission ─→ Prospect
    └ Review LinkedIn: credible organizer?  ── no ─→ Denied
         │ yes
         ▼  Tentative (vetted, not yet accepted)
@@ -71,7 +76,8 @@ The same flow (and colors) is documented on the sheet's **"How to use"** tab.
 
 ## Procedure
 
-1. **Pull the queue.** Rows needing attention = Status blank / `New` / `In progress`:
+1. **Pull the queue.** Rows needing attention = Status blank / `Prospect`
+   (incl. legacy `New`) / `In progress`:
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/intake.py
    ```

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -19,7 +19,8 @@ sheet's structure.
 ## Status model (drives the queue and the sheet's cell colors)
 
 The Status values (dropdown on column A, matched exactly by the sheet's
-whole-row colors): `Prospect` (blue) → `In progress` (orange) → `Tentative` (teal) →
+whole-row colors): `Prospect` (blue) → `In progress` (orange) →
+`Tentative` (teal) →
 `Interviewing` (indigo) → `Accepted` (green) / `Denied` (maroon); `Inactive` (gray);
 `Duplicate` (brown); and `Existing (from MLOps)`
 (**violet**) for a prior organizer imported from the MLOps community. `Tentative` is a
@@ -41,8 +42,9 @@ the pre-2026-08-22 name for the same state, renamed because `New` misread as
 the cells **and the conditional-format rules that test the Status literal**
 (the blue row color and the pink SLA rule below both key on `=$A2="…"`, are
 hand-made on the sheet, and are repaired by nothing else — renaming only the
-cells leaves every row unpainted and the SLA breach permanently un-fired);
-until it has run everywhere, tooling treats `New` and `Prospect` as one status. Two overrides beat the status color: a **data error** (missing/invalid email
+cells leaves every row unpainted and the SLA breach permanently un-fired) **and
+the "How to use" tab's own status prose**; until it has run everywhere, tooling
+treats `New` and `Prospect` as one status. Two overrides beat the status color: a **data error** (missing/invalid email
 or broken LinkedIn) paints the row bright red, and an **SLA breach** — a `Prospect`/blank
 row older than 1 week (of a 2-week response SLA) — paints it pink. Acting on a row
 (moving it off `Prospect`) clears the pink. Each role tab also has `Reviewed by`,

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -9,7 +9,7 @@ Usage:
     intake.py                 # text digest of rows needing attention
     intake.py --json          # same selection as JSON (for the digest routine)
     intake.py --all           # every row, regardless of status
-    intake.py --status New "In progress"   # custom status filter
+    intake.py --status Prospect "In progress"   # custom status filter
 """
 import argparse, json, subprocess, sys
 
@@ -28,18 +28,30 @@ TABS = {
                    "Talk title", "Ships in production?", "Past talks / portfolio"],
 }
 
-# Rows in these Status states are "awaiting review". A blank Status IS "New"
-# (the form writes none) and is normalized to it in collect(), so filters match
-# on "New" alone — a custom --status list never needs to know about blanks.
-DEFAULT_NEEDS_REVIEW = {"New", "In progress"}
+# Rows in these Status states are "awaiting review". A blank Status IS
+# "Prospect" (the form writes none), and so is the legacy value "New" — the
+# pre-2026-08-22 name for the same state ("New" misread as new-organizer;
+# "Prospect" matches what sync_crm already writes). Both are normalized in
+# collect() via normalize_status(), so filters match on "Prospect" alone — a
+# custom --status list never needs to know about blanks or legacy cells.
+DEFAULT_NEEDS_REVIEW = {"Prospect", "In progress"}
+
+
+def normalize_status(value):
+    """One normalization for Status cells AND --status filter values: blank and
+    the legacy "New" are both "Prospect". Cells still saying "New" exist until
+    migrate_status_prospect.py has rewritten every sheet; a row holding it must
+    behave identically to one holding "Prospect"."""
+    v = (value or "").strip()
+    return "Prospect" if v in ("", "New") else v
 
 
 def normalize_filter(values):
     """Normalize a --status list the same way collect() normalizes cells: a
-    requested blank means the blank-status rows — which the rows themselves
-    report as "New" by then, so an un-normalized --status "" would silently
-    select zero rows."""
-    return {(v.strip() or "New") for v in values}
+    requested blank (or legacy "New") means the blank/"New"-status rows — which
+    the rows themselves report as "Prospect" by then, so an un-normalized
+    --status "" or --status New would silently select zero rows."""
+    return {normalize_status(v) for v in values}
 
 # The City columns were renamed to City (Existing)/City (New). They only carry
 # those headers after `aaif-clean-data install-colors` has run; until then the
@@ -104,9 +116,10 @@ def collect(status_filter, show_all):
         for rn, row in enumerate(rows, start=2):  # row 2 = first data row
             if not (row[ti] or "").strip():
                 continue  # skip empty trailing rows (no Timestamp)
-            # Blank IS "New" — normalized once here, so the filter below and the
-            # reported status can never disagree about what a blank cell means.
-            status = (row[si].strip() if si is not None else "") or "New"
+            # Blank IS "Prospect" (and legacy "New" is too) — normalized once
+            # here, so the filter below and the reported status can never
+            # disagree about what a blank or legacy cell means.
+            status = normalize_status(row[si] if si is not None else "")
             if not show_all and status not in status_filter:
                 continue
             rec = {"row": rn, "status": status}
@@ -153,8 +166,8 @@ def main():
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--all", action="store_true")
     ap.add_argument("--status", nargs="*", default=None,
-                    help="Status values to include (default: New/In progress; "
-                         "blank counts as New)")
+                    help="Status values to include (default: Prospect/In progress; "
+                         "blank counts as Prospect)")
     args = ap.parse_args()
     sf = normalize_filter(args.status) if args.status is not None else DEFAULT_NEEDS_REVIEW
     data = collect(sf, args.all)

--- a/skills/aaif-triage-intake/scripts/intake.py
+++ b/skills/aaif-triage-intake/scripts/intake.py
@@ -36,14 +36,22 @@ TABS = {
 # custom --status list never needs to know about blanks or legacy cells.
 DEFAULT_NEEDS_REVIEW = {"Prospect", "In progress"}
 
+# What a row reports when the tab has no Status column at all — see collect().
+UNKNOWN_STATUS = "?"
+
 
 def normalize_status(value):
     """One normalization for Status cells AND --status filter values: blank and
     the legacy "New" are both "Prospect". Cells still saying "New" exist until
     migrate_status_prospect.py has rewritten every sheet; a row holding it must
-    behave identically to one holding "Prospect"."""
+    behave identically to one holding "Prospect".
+
+    The legacy alias is matched case-INSENSITIVELY. Now that the dropdown no
+    longer offers "New", the only way it can reach a cell is by hand or paste —
+    exactly the route that produces "new" or "NEW", and a row spelled that way
+    would silently drop out of the triage queue."""
     v = (value or "").strip()
-    return "Prospect" if v in ("", "New") else v
+    return "Prospect" if v == "" or v.lower() == "new" else v
 
 
 def normalize_filter(values):
@@ -118,8 +126,12 @@ def collect(status_filter, show_all):
                 continue  # skip empty trailing rows (no Timestamp)
             # Blank IS "Prospect" (and legacy "New" is too) — normalized once
             # here, so the filter below and the reported status can never
-            # disagree about what a blank or legacy cell means.
-            status = normalize_status(row[si] if si is not None else "")
+            # disagree about what a blank or legacy cell means. With no Status
+            # column at all (--all reaches here; the filtered path aborts
+            # above) the honest answer is "unknown" — reporting a confident
+            # "Prospect" read from nothing is worse than saying so.
+            status = (normalize_status(row[si]) if si is not None
+                      else UNKNOWN_STATUS)
             if not show_all and status not in status_filter:
                 continue
             rec = {"row": rn, "status": status}

--- a/skills/aaif-triage-intake/scripts/test_intake.py
+++ b/skills/aaif-triage-intake/scripts/test_intake.py
@@ -16,7 +16,7 @@ def _digest_of(rec):
     return buf.getvalue()
 
 
-BASE = {"row": 2, "status": "New", "Full name": "Ada", "Email": "ada@x.com"}
+BASE = {"row": 2, "status": "Prospect", "Full name": "Ada", "Email": "ada@x.com"}
 
 
 class TestDigestCity(unittest.TestCase):
@@ -78,51 +78,67 @@ class CollectBase(unittest.TestCase):
 
 
 class TestCollectStatusFilter(CollectBase):
-    ROWS = [["t1", "", "Ada", "a@x.com"],            # blank status = New
-            ["t2", "New", "Grace", "g@x.com"],
+    ROWS = [["t1", "", "Ada", "a@x.com"],            # blank status = Prospect
+            ["t2", "New", "Grace", "g@x.com"],       # legacy spelling = Prospect
+            ["t2b", "Prospect", "Hedy", "h@x.com"],
             ["t3", "In progress", "Joan", "j@x.com"],
             ["t4", "Accepted", "Mary", "m@x.com"],
             ["", "New", "ghost", ""]]                # no Timestamp -> not a row
 
-    def test_default_filter_takes_blank_new_and_in_progress(self):
+    def test_default_filter_takes_blank_legacy_prospect_and_in_progress(self):
         got = self._collect(self._org(self.ROWS))["Organizers"]
-        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace", "Joan"])
+        self.assertEqual([r["Full name"] for r in got],
+                         ["Ada", "Grace", "Hedy", "Joan"])
 
-    def test_blank_status_is_normalized_to_new(self):
+    def test_blank_status_is_normalized_to_prospect(self):
         got = self._collect(self._org(self.ROWS))["Organizers"]
-        self.assertEqual(got[0]["status"], "New")
+        self.assertEqual(got[0]["status"], "Prospect")
 
-    def test_a_custom_new_filter_still_includes_blank_status_rows(self):
-        # The regression: filtering on "New" alone used to drop blank-status
-        # rows, even though a blank Status IS New per the skill's status model.
-        got = self._collect(self._org(self.ROWS), status_filter={"New"})["Organizers"]
-        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace"])
+    def test_legacy_new_behaves_identically_to_prospect(self):
+        # The 2026-08-22 rename transition: a row still saying "New" (not yet
+        # rewritten by migrate_status_prospect.py) reports as, and filters
+        # like, "Prospect".
+        got = self._collect(self._org(self.ROWS))["Organizers"]
+        self.assertEqual(got[1]["Full name"], "Grace")
+        self.assertEqual(got[1]["status"], "Prospect")
 
-    def test_a_custom_filter_without_new_excludes_blank_rows(self):
+    def test_a_custom_prospect_filter_includes_blank_and_legacy_rows(self):
+        got = self._collect(self._org(self.ROWS),
+                            status_filter={"Prospect"})["Organizers"]
+        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace", "Hedy"])
+
+    def test_a_status_new_filter_still_works_via_normalization(self):
+        # --status New keeps working: normalize_filter folds it to "Prospect",
+        # the same normalization the cells get.
+        got = self._collect(self._org(self.ROWS),
+                            status_filter=intake.normalize_filter(["New"]))["Organizers"]
+        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace", "Hedy"])
+
+    def test_a_custom_filter_without_prospect_excludes_blank_rows(self):
         got = self._collect(self._org(self.ROWS),
                             status_filter={"In progress"})["Organizers"]
         self.assertEqual([r["Full name"] for r in got], ["Joan"])
 
     def test_show_all_ignores_the_filter_but_not_the_timestamp_marker(self):
         got = self._collect(self._org(self.ROWS), show_all=True)["Organizers"]
-        self.assertEqual(len(got), 4)                  # ghost row still skipped
-        self.assertEqual(got[3]["status"], "Accepted")
+        self.assertEqual(len(got), 5)                  # ghost row still skipped
+        self.assertEqual(got[4]["status"], "Accepted")
 
     def test_explicit_blank_status_selects_blank_rows(self):
         # The regression: --status "" used to silently select zero rows, because
-        # blank cells normalize to "New" before the filter ever sees them. The
-        # filter must be normalized the same way.
+        # blank cells normalize to "Prospect" before the filter ever sees them.
+        # The filter must be normalized the same way.
         got = self._collect(self._org(self.ROWS),
                             status_filter=intake.normalize_filter([""]))["Organizers"]
-        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace"])
+        self.assertEqual([r["Full name"] for r in got], ["Ada", "Grace", "Hedy"])
 
-    def test_normalize_filter_maps_blank_to_new_and_keeps_the_rest(self):
-        self.assertEqual(intake.normalize_filter(["", "  ", "Accepted"]),
-                         {"New", "Accepted"})
+    def test_normalize_filter_maps_blank_and_legacy_new_to_prospect(self):
+        self.assertEqual(intake.normalize_filter(["", "  ", "New", "Accepted"]),
+                         {"Prospect", "Accepted"})
 
     def test_row_numbers_are_sheet_rows(self):
         got = self._collect(self._org(self.ROWS), status_filter={"Accepted"})["Organizers"]
-        self.assertEqual([r["row"] for r in got], [5])  # row 2 = first data row
+        self.assertEqual([r["row"] for r in got], [6])  # row 2 = first data row
 
 
 class TestCollectLegacyAliases(CollectBase):
@@ -156,7 +172,7 @@ class TestCollectAborts(CollectBase):
             self._collect(sheets)
         self.assertIn("Status", str(e.exception))
         got = self._collect(sheets, show_all=True)["Organizers"]
-        self.assertEqual(got[0]["status"], "New")      # no column reads as New
+        self.assertEqual(got[0]["status"], "Prospect")  # no column reads as Prospect
 
     def test_an_empty_tab_is_an_empty_queue_not_an_abort(self):
         self.assertEqual(self._collect({})["Organizers"], [])

--- a/skills/aaif-triage-intake/scripts/test_intake.py
+++ b/skills/aaif-triage-intake/scripts/test_intake.py
@@ -172,7 +172,10 @@ class TestCollectAborts(CollectBase):
             self._collect(sheets)
         self.assertIn("Status", str(e.exception))
         got = self._collect(sheets, show_all=True)["Organizers"]
-        self.assertEqual(got[0]["status"], "Prospect")  # no column reads as Prospect
+        # --all still reports the rows, but a row whose tab has NO Status
+        # column reports "unknown" — a confident "Prospect" there would be read
+        # from nothing at all, and the digest would look authoritative.
+        self.assertEqual(got[0]["status"], intake.UNKNOWN_STATUS)
 
     def test_an_empty_tab_is_an_empty_queue_not_an_abort(self):
         self.assertEqual(self._collect({})["Organizers"], [])


### PR DESCRIPTION
## Summary
Renames the intake status `New` → `Prospect` end to end. "New" misread as *new organizer* when it meant *unreviewed application*; "Prospect" unifies the funnel with the term `sync_crm` already writes to chapter CRMs. Decided 2026-08-22; the live migration has already run and verified.

## Changesets

### 1. `feat(status): rename the intake status "New" to "Prospect"`
**Files:** sync_crm.py, intake.py, migrate_status_prospect.py (new) + tests + SKILL.mds
- **Code transition**: both spellings accepted everywhere (`PIPELINE_STATUSES`, `AUTO_STATUS`, dropdown patcher); blank and legacy `New` normalize to `Prospect` via one shared rule in intake (cells and `--status` filters alike); `DEFAULT_NEEDS_REVIEW` is now `{Prospect, In progress}`.
- **Migration script** (report-first, `--write`, verify-after-write, exit 0/2/1): intake role tabs — Status is located by header and must be column A (the B+ mirrors are ARRAYFORMULAs); CRMs — Status/Signal columns located by header name so the Signal dropdown's unrelated `New` survives; zip surgery keeps untouched parts byte-identical; pre-edit backups kept.
- **Applied 2026-08-22**: 265 changes — 178 intake cells (81 organizers, 69 speakers, 28 hosts), 3 intake dropdowns, 84 CRM Status dropdowns (all 82 chapters + TemplateCity + TemplateSeries). Verified: fresh reads propose zero changes.
- **Untouched by design**: `City (New)` column header; Signal's `New`; clean.py color rules (they key on `Existing (from MLOps)`).

### 2. `fix(status): migrate the color rules that test the Status literal`
**Files:** migrate_status_prospect.py, its test, aaif-triage-intake/SKILL.md
Changeset 1 renamed the cells and dropdowns but not the intake tabs' **hand-made
conditional formats**, which key on the Status literal — so after it ran, the blue
whole-row color matched nothing and the pink **1-week SLA-breach rule**
(`OR($A2="",$A2="New")`) had stopped firing for every Prospect row. `clean.py` owns
only the red error rule and the city/violet rules, so nothing else would have
repaired them.
- Phase A now plans/applies/verifies those rules with the cells: the exact
  `$A2="New"` token is swapped, each rule re-sent **whole** so its ranges and color
  survive, and a column-A test for `New` written any other way (`$A$2 = "New"`,
  `EXACT($A2,"New")`) is reported rather than guessed at. Idempotent.
- **Applied 2026-08-21**: 6 rules (status color + SLA arm × 3 role tabs). Verified —
  fresh read proposes zero, both colors intact on all three tabs.

### 3. `fix(status): migrate the sheet's own How-to-use status prose`
**Files:** migrate_status_prospect.py, its test, both SKILL.mds
The **"How to use" tab** — what an organizer reads before picking from the Status
dropdown — still taught `New` in five sentences, including the SLA rule it
documents ("still New after 1 week"), for a value the dropdown no longer offers.
- Migrated by **exact whole-sentence match**, never a word swap: the same tab
  legitimately says "New submissions", "New city" and "City (New)" (a column
  header), and pinning the whole sentence is what makes the single
  first-occurrence swap unambiguous. Sentences are located by text, not by a fixed
  A1 (rows shift as the tab is edited); one present in neither spelling is reported,
  never guessed at.
- Also: a color rule holding **both** the exact token and an unrecognised shape is
  now migrated **and** reported, instead of being half-done silently — the refusal
  is judged on what the rule will say after the swap.
- **Applied 2026-08-21**: 5 sentences. Verified — the five legitimate `New`
  mentions on the tab are untouched.

### 4. `fix: address self-review findings across all six review streams`
**Files:** migrate_status_prospect.py + test, sync_crm.py + test, sync_chapters.py, intake.py + test, SKILL.md
A six-agent review (code-review, silent-failure, tests, comments, type-design, security) surfaced 35 findings; all are fixed here. The theme of the critical set: **every verify path re-used the same read as the plan**, so anything the script could not see, it also could not see it had missed — on a one-shot migration.
- **Now refused instead of silently skipped**: a range-backed `formula1`, an `x14`-namespace validation, a Status column with no validation at all, and a `TEXT_EQ "New"` color rule. `sqref_cols` also stripped `$`, so an absolute sqref never matched the Status column.
- **Phase A gets Phase B's drift gate** — cell writes address absolute rows on a tab whose B+ columns are ARRAYFORMULA mirrors, and color rules address positional indices; the plan is now re-compared against a fresh read immediately before writing. The dropdown is written per contiguous run, not over the `min..max` hull.
- **Verification is positive**: planned cells must read `Prospect` and the re-read dropdown must equal the migrated list. **Refusals are separated from pending work**, so a permanent won't-do cannot pin later runs to exit 1.
- **Security**: `assert_git_safe` no longer fails open on a non-"not a git repository" git error (it mirrors `backup.py` in full); `--write` retains only `before/`; backups are keyed by Drive file id.
- **Blast radius**: `--city --write` no longer writes the intake-wide Phase A without `--include-intake`.
- Design/doc cleanups, and **+59 test checks** covering every new refusal path plus three weak assertions the analyzer caught.

## Test Plan
- [x] New `test_migrate_status_prospect.py` — 47 checks incl. swapped-columns CRM (header-name location), byte-identical untouched parts, idempotence, column-A-only intake writes
- [x] Transition tests: a row still saying `New` behaves identically to `Prospect` in sync_crm and the digest
- [x] Post-review live re-verification: full-estate report exits **0** — 3 role tabs + How-to-use + 84 workbooks in sync, **zero refusals**, so none of the newly-detectable shapes exist in the real data
- [x] Full suites: 154 lib + all skill scripts + pre-commit + `claude plugin validate` green
- [x] 11 new checks for the How-to-use prose (survival of the 3 legitimate `New` mentions, idempotence, reword-refusal, location-by-text)
- [x] 11 new checks for the color-rule rename (both live rule shapes, refusal shapes, whole-rule replacement, apply ordering)
- [x] Live re-verified after the fix: `migrate_status_prospect.py` report proposes **zero** across all 3 tabs + 84 workbooks; `sync_crm.py --city Boston` in sync (migrated Status lists still recognised by the Host patch); digest shows 178 awaiting review with `[Prospect]` labels; sync_crm report run clean; migration re-verify proposes zero

_Generated using hero-skills._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


