### PR TITLE
feat(create-chapter): backfill map dots in existing chapter decks

### DIFF
--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -94,21 +94,29 @@ Two consequences of dropping the override table:
 - **Decks placed under the old projection sit a few px off the fitted position**
   (the template's own hand-placed SF dot, ~9 px). A small dot delta against an old
   deck is the fit being *right*, not a regression — see the validate note below.
+  For chapter decks, `backfill_map_dots.py` below reports and repairs this.
 
 ## Backfilling existing decks
 
-`scripts/backfill_map_dots.py` re-places the dot in chapter decks that already
-exist. Every chapter created before 2026-08-12 carried a dot from the old
-projection (mean 31 px out, worst 60 px — Shanghai on Japan, Tokyo in the
-Pacific); **all 80 were corrected on 2026-08-25**, so this is now a maintenance
-tool rather than a one-off — reach for it after a refit, or to check the estate.
+`scripts/backfill_map_dots.py` re-places the markers in chapter decks that
+already exist. Decks created before the Gall Stereographic fit shipped (PR #20)
+carry their dot from the old placement, which was wrong in two distinct ways:
+the **projection** was ~9% too wide with a ~20 px offset (Tokyo landed in the
+Pacific), and the four `PIXEL_OVERRIDES` cities bypassed the projection entirely
+(Shanghai landed on Honshu because that hand-tuned **override** was wrong — not
+evidence about the formula).
+
+Run the plan (the default) to find out where the estate actually stands: an
+already-corrected estate reports every chapter as `already correct`, and that
+report — not a number written down here — is the authoritative answer. Reach for
+this after a refit, or to check the estate.
 
 Coordinates come from the **Chapters & Teams** sheet's `Generated Geolocation`
 column, joined to Drive by the folder URL in `Chapter Folder` — not from the
 folder name. That is what the website feed already draws, so the deck and the
-site agree; it is also the only source that knows the folder still called
-"Scotland" is the Edinburgh chapter. A Drive folder with no sheet row is reported
-and skipped, never guessed at.
+site agree; it is also the only source that maps a folder to its real city, and
+a folder's name can lag that city (they have been renamed before). A Drive
+folder with no sheet row is reported and skipped, never guessed at.
 
 ```bash
 # Plan (default) — per-chapter drift in pixels, writes nothing:
@@ -122,12 +130,22 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_map_dots.py \
     --city Shanghai --lat 31.2304 --lon 121.4737 --write
 ```
 
-A deck already within `--tolerance` (default 1 px — sub-pixel is invisible and is
-just rounding) is left untouched, so a re-run is a cheap no-op and the run is
-safe to interrupt and repeat. A deck whose slide 5 does not hold exactly one
-green dot and one green label is reported and skipped, never rewritten on a
-guess. The script imports the projection and the OOXML surgery from
-`create_chapter.py` — do not reimplement either there.
+`--city` takes the Drive folder's **name** or the city the sheet gives that
+folder, so both `--city Scotland` and `--city Edinburgh` reach the same chapter.
+
+A deck already within `--tolerance` (default 1 px — a pixel or less is rounding,
+not misplacement) is left untouched, so **re-running is a no-op on decks that are
+already correct**. Drift is the worse of the dot and its label, so a refit that
+moves only the label is still caught. A deck whose slide 5 does not hold exactly
+one green dot and one green label is reported with a reason and skipped, never
+rewritten on a guess — and a run that could not evaluate part of the estate exits
+non-zero rather than reading as a finished backfill.
+
+There is **no undo** beyond Drive's revision history: `--write` replaces up to 80
+production decks in place. Read a plan run first.
+
+The script imports the projection and the OOXML surgery from `create_chapter.py`
+— do not reimplement either of those inside the backfill script.
 
 ## Procedure
 

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -92,9 +92,42 @@ Two consequences of dropping the override table:
   placeable with no network at all; now they hit the geocoder like everyone
   else, and if it is down the fallback above applies to them too.
 - **Decks placed under the old projection sit a few px off the fitted position**
-  (the pre-Stuttgart chapters, and the template's own hand-placed SF dot, ~9 px).
-  A small dot delta against an old deck is the fit being *right*, not a
-  regression — see the validate note below.
+  (the template's own hand-placed SF dot, ~9 px). A small dot delta against an old
+  deck is the fit being *right*, not a regression — see the validate note below.
+
+## Backfilling existing decks
+
+`scripts/backfill_map_dots.py` re-places the dot in chapter decks that already
+exist. Every chapter created before 2026-08-12 carried a dot from the old
+projection (mean 31 px out, worst 60 px — Shanghai on Japan, Tokyo in the
+Pacific); **all 80 were corrected on 2026-08-25**, so this is now a maintenance
+tool rather than a one-off — reach for it after a refit, or to check the estate.
+
+Coordinates come from the **Chapters & Teams** sheet's `Generated Geolocation`
+column, joined to Drive by the folder URL in `Chapter Folder` — not from the
+folder name. That is what the website feed already draws, so the deck and the
+site agree; it is also the only source that knows the folder still called
+"Scotland" is the Edinburgh chapter. A Drive folder with no sheet row is reported
+and skipped, never guessed at.
+
+```bash
+# Plan (default) — per-chapter drift in pixels, writes nothing:
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_map_dots.py
+
+# Apply:
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_map_dots.py --write
+
+# One chapter, coordinates given rather than read from the sheet:
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_map_dots.py \
+    --city Shanghai --lat 31.2304 --lon 121.4737 --write
+```
+
+A deck already within `--tolerance` (default 1 px — sub-pixel is invisible and is
+just rounding) is left untouched, so a re-run is a cheap no-op and the run is
+safe to interrupt and repeat. A deck whose slide 5 does not hold exactly one
+green dot and one green label is reported and skipped, never rewritten on a
+guess. The script imports the projection and the OOXML surgery from
+`create_chapter.py` — do not reimplement either there.
 
 ## Procedure
 

--- a/skills/aaif-create-chapter/scripts/backfill_map_dots.py
+++ b/skills/aaif-create-chapter/scripts/backfill_map_dots.py
@@ -1,28 +1,39 @@
 #!/usr/bin/env python3
 """Re-place the slide-5 "you-are-here" map dot in every EXISTING chapter deck.
 
-Chapters created before 2026-08-12 got their dot from `create_chapter.py`'s old
-hand-rolled projection (a linear lon2x plus a piecewise-linear lat2y, patched per
-city by a PIXEL_OVERRIDES table). That model was wrong everywhere — ~9% too wide
-with a ~20 px offset — so every one of those decks carries a misplaced dot (mean
-31 px, worst 60 px: Shanghai landed on Japan, Tokyo in the Pacific). The current
-Gall Stereographic fit in `create_chapter.py` is correct to 0.64 px and needs no
-overrides; this script walks the Chapters Drive and brings the old decks up to it.
+Chapters created before the Gall Stereographic fit shipped (PR #20) got their
+dot from `create_chapter.py`'s old placement, which was wrong in two separate
+ways — worth keeping apart, because they call for different reasoning:
+
+- The **projection** was a linear lon2x plus a piecewise-linear lat2y, about 9%
+  too wide with a ~20 px offset. Tokyo is the clean example: it landed roughly
+  21 degrees of longitude east, out in the Pacific.
+- Four cities never used that projection at all. Seoul, Sydney, Melbourne and
+  Shanghai sat in a hand-tuned `PIXEL_OVERRIDES` table, and `project_city`
+  returned the table's pixel and ignored lat/lon entirely. Shanghai's dot landed
+  on Honshu because that **override** was wrong, not because the formula was —
+  do not cite it as evidence about the projection.
+
+The current fit is correct to 0.64 px and needs no overrides; this script walks
+the Chapters Drive and brings the old decks up to it.
 
 It is a *backfill*, not a second implementation: the projection, the OOXML
 surgery and the Drive plumbing are all imported from `create_chapter.py`, so
-there is exactly one definition of where a dot belongs. Re-running is safe and
-cheap — a deck already within --tolerance of its target is left untouched, which
-is also what makes this the tool to reach for if the map art is ever refitted.
+there is exactly one definition of where a dot belongs. Re-running is a no-op on
+decks already within --tolerance, which is what makes this the tool to reach for
+if the map art is ever refitted.
 
 Coordinates come from the **Chapters & Teams** sheet's `Generated Geolocation`
 column, joined to Drive by the folder URL in `Chapter Folder` — not from
 geocoding the folder name. The sheet is what the website feed already draws, so
-the dot and the site agree by construction; it is also the only source that knows
-a folder still called "Scotland" is the Edinburgh chapter. A Drive folder with no
-sheet row is reported and skipped rather than guessed at.
+the dot and the site agree by construction; it is also the only source that maps
+a folder to its real city, and a folder's name can lag that city (they have been
+renamed before). A Drive folder with no sheet row is reported and skipped rather
+than guessed at.
 
-Read-only by default: it prints the per-chapter drift and changes nothing.
+Read-only by default: it prints the per-chapter drift and changes nothing. There
+is no undo beyond Drive's own revision history, so read a plan run before
+passing --write.
 
 Usage:
   # Plan (default) — report every chapter's drift in pixels, write nothing:
@@ -34,7 +45,7 @@ Usage:
   # One chapter, with coordinates given rather than read from the sheet:
   python backfill_map_dots.py --city Shanghai --lat 31.2304 --lon 121.4737 --write
 """
-import argparse, os, re, shutil, sys, tempfile
+import argparse, collections, os, re, shutil, sys, tempfile, zipfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import create_chapter as cc      # projection, OOXML surgery, Drive plumbing
@@ -46,38 +57,73 @@ COL_CITY, COL_FOLDER, COL_GEO = "City", "Chapter Folder", "Generated Geolocation
 DECK_NAME = "Slides.pptx"        # the deck that carries the slide-5 network map
 # TemplateCity's dot is the San Francisco anchor the label offsets are measured
 # from (see LABEL_DX/LABEL_DY in create_chapter) — moving it would redefine the
-# template, not fix a chapter. It has no sheet row either, so this is belt and
-# braces: it must never be treated as a chapter.
+# template, not fix a chapter. Guarded by name, and main() says so loudly if no
+# folder matches, because a renamed template would silently become a target.
 SKIP_FOLDERS = {"TemplateCity"}
 
-# Sub-pixel drift is invisible on a 1123 px map and is just rounding; only move a
-# dot that is actually in the wrong place, so a re-run is a cheap no-op.
+# A dot within a pixel of its target is rounding, not misplacement; only move a
+# dot actually in the wrong place, so a re-run is a cheap no-op.
 DEFAULT_TOLERANCE_PX = 1.0
+# Above this, --tolerance stops meaning "ignore rounding" and starts meaning
+# "report a broken estate as clean". Warned about, not forbidden.
+LOUD_TOLERANCE_PX = 50.0
 EMU_PER_PX_X = cc.MAP_EXT[0] / cc.MAP_PX[0]
 EMU_PER_PX_Y = cc.MAP_EXT[1] / cc.MAP_PX[1]
 
 FOLDER_ID_RE = re.compile(r"/folders/([A-Za-z0-9_-]+)")
 GEO_RE = re.compile(r"^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$")
 
+#: One parsed sheet row. `fid` is None when the row names no Drive folder;
+#: `latlon` is None exactly when `why` explains what stopped it being usable.
+Row = collections.namedtuple("Row", "city fid latlon why")
+#: read_chapter_coords()'s result. Attribute access, not unpacking: widening
+#: this from two values to three already broke every call site and test once.
+Sheet = collections.namedtuple("Sheet", "by_folder bad_rows unusable")
 
-def drift_px(current, target):
-    """Distance in map pixels between a deck's current dot and where it belongs."""
-    dx = (current[0] - target[0]) / EMU_PER_PX_X
-    dy = (current[1] - target[1]) / EMU_PER_PX_Y
+#: status -> (marker, phrase). One declaration, so adding a status cannot leave
+#: a half-updated lookup to KeyError mid-sweep, after N decks are already up.
+STATUS_DISPLAY = {"ok": ("=", "already correct"),
+                  "moved": ("+", "moved"),
+                  "would-move": ("~", "WOULD move")}
+
+
+def drift_px(current_emu, target_emu):
+    """Distance in map pixels between two EMU corner offsets.
+
+    Both arguments are **EMU**, not pixels. Handing this pixel pairs returns a
+    plausible small number rather than failing, so every deck would report
+    "already correct" and nothing would raise."""
+    dx = (current_emu[0] - target_emu[0]) / EMU_PER_PX_X
+    dy = (current_emu[1] - target_emu[1]) / EMU_PER_PX_Y
     return (dx * dx + dy * dy) ** 0.5
 
 
 def parse_geo(cell):
-    """Parse a `Generated Geolocation` cell ("37.7749, -122.4194") to (lat, lon),
-    or None if it is blank or not a coordinate pair. Range-checked: a garbled
-    pair would otherwise place a dot confidently in the wrong place."""
-    m = GEO_RE.match(cell or "")
+    """Parse a `Generated Geolocation` cell ("37.7749, -122.4194") to
+    ((lat, lon), None), or (None, reason) when it cannot be used.
+
+    The reason is worth carrying: "the cell is blank" and "the pair looks
+    transposed" call for different fixes by whoever maintains the sheet. A
+    swapped pair where BOTH values are inside +/-90 (London, Berlin) still
+    cannot be caught here — that one is only visible on the map."""
+    text = (cell or "").strip()
+    if not text:
+        return None, "%s is blank" % COL_GEO
+    m = GEO_RE.match(text)
     if not m:
-        return None
+        return None, "%s is not a coordinate pair (%r)" % (COL_GEO, text[:40])
     lat, lon = float(m.group(1)), float(m.group(2))
-    if not (-90 <= lat <= 90 and -180 <= lon <= 180):
-        return None
-    return lat, lon
+    if not (-90 <= lat <= 90):
+        # By far the most likely cause, and the one the operator can act on.
+        return None, ("%s latitude %.4f is out of range — transposed lat/lon?"
+                      % (COL_GEO, lat))
+    if not (-180 <= lon <= 180):
+        return None, "%s longitude %.4f is out of range" % (COL_GEO, lon)
+    if lat == 0 and lon == 0:
+        # Null Island is in range and parses cleanly, but it is what a failed
+        # geocode writes far more often than it is a real chapter.
+        return None, "%s is 0, 0 — a failed geocode, not a city" % COL_GEO
+    return (lat, lon), None
 
 
 def folder_id_from_url(cell):
@@ -89,19 +135,17 @@ def folder_id_from_url(cell):
 # Sheet
 # ----------------------------------------------------------------------------
 def read_chapter_coords():
-    """Return ({folder_id: (city, lat, lon)}, [(city, why)], {folder_id: (city, why)}).
+    """Return a Sheet: by_folder {fid: Row}, bad_rows [Row], unusable {fid: Row}.
 
-    The third value holds the rows that DO name a Drive folder but whose
-    coordinates are unusable. Without it a folder whose row exists but has no
-    geolocation is indistinguishable from one with no row at all, and the sweep
-    reports "no row on the sheet links to this folder" about a row that is
-    sitting right there.
+    `bad_rows` is every row that cannot place a dot; `unusable` is the subset of
+    those that DO name a Drive folder, keyed by it, so the sweep can tell "this
+    folder's row is blank" from "no row mentions this folder at all". Both are
+    derived from one pass rather than appended to separately — they are one
+    dataset, and two hand-maintained copies drifting apart is exactly how a
+    folder ends up reported as rowless when its row is sitting right there.
 
     Columns are resolved by header name, never by letter — the tab is a website
-    feed and its layout has moved before. A row missing its folder link or its
-    geolocation is left out of the map and reported, so the corresponding Drive
-    folder reads as unresolved rather than having its dot moved to a coordinate
-    the sheet never gave."""
+    feed and its layout has moved before."""
     res = cc.gws_json("sheets", "spreadsheets", "values", "get", params={
         "spreadsheetId": CHAPTERS_ID, "range": "'%s'!A:AZ" % CHAPTERS_TAB})
     rows = res.get("values", [])
@@ -115,75 +159,127 @@ def read_chapter_coords():
                  % (CHAPTERS_TAB, ", ".join(map(repr, missing))))
     i_city, i_folder, i_geo = (headers.index(c) for c in (COL_CITY, COL_FOLDER, COL_GEO))
 
-    coords, bad, unusable = {}, [], {}
+    by_folder, bad_rows, unusable = {}, [], {}
     for row in rows[1:]:
         def cell(i):
             return (row[i] if i < len(row) else "").strip()
         city = cell(i_city)
         if not city:
             continue
-        fid, geo = folder_id_from_url(cell(i_folder)), parse_geo(cell(i_geo))
-        if not fid or not geo:
-            why = ("no %s link" % COL_FOLDER if not fid
-                   else "no usable %s" % COL_GEO)
-            bad.append((city, why))
-            if fid:
-                unusable[fid] = (city, why)
+        fid = folder_id_from_url(cell(i_folder))
+        latlon, why = parse_geo(cell(i_geo))
+        if not fid:
+            bad_rows.append(Row(city, None, None, "no %s link" % COL_FOLDER))
             continue
-        coords[fid] = (city, geo[0], geo[1])
-    return coords, bad, unusable
+        if why:
+            r = Row(city, fid, None, why)
+            bad_rows.append(r)
+            unusable.setdefault(fid, r)
+            continue
+        if fid in by_folder:
+            # Two rows pointing at one folder. Picking one silently would place
+            # the dot for whichever row happens to sort later on the sheet.
+            bad_rows.append(Row(city, fid, latlon,
+                                "duplicate %s — already claimed by %r; NOT used"
+                                % (COL_FOLDER, by_folder[fid].city)))
+            continue
+        by_folder[fid] = Row(city, fid, latlon, None)
+    # A usable row wins over an unusable one for the same folder. Stated here
+    # rather than left to the order main() happens to check the two dicts in.
+    for fid in list(unusable):
+        if fid in by_folder:
+            del unusable[fid]
+    return Sheet(by_folder, bad_rows, unusable)
 
 
 # ----------------------------------------------------------------------------
 # Drive walk
 # ----------------------------------------------------------------------------
 def find_deck(folder_id):
-    """Return the id of the chapter's Slides.pptx, or None.
+    """Return (deck_id, reason): exactly one deck -> (id, None), otherwise
+    (None, reason).
 
     Looks at the chapter folder and then one level down, rather than hard-coding
     "Event Templates (Copy for Each Event)": that folder has been renamed once
     already, and a chapter whose deck simply was never cloned has to read as
-    missing rather than as an error."""
+    missing rather than as an error.
+
+    Ambiguity is reported, never resolved: a chapter holding two copies would
+    otherwise get an arbitrary one rewritten and reported as a success, and the
+    copy people actually present from might be the other one."""
     children = cc.list_children(folder_id)
-    for c in children:
-        if c["name"] == DECK_NAME and c["mimeType"] == cc.PPTX:
-            return c["id"]
+    hits = [c["id"] for c in children
+            if c["name"] == DECK_NAME and c["mimeType"] == cc.PPTX]
     for c in children:
         if c["mimeType"] != cc.FOLDER:
             continue
-        for g in cc.list_children(c["id"]):
-            if g["name"] == DECK_NAME and g["mimeType"] == cc.PPTX:
-                return g["id"]
-    return None
+        hits += [g["id"] for g in cc.list_children(c["id"])
+                 if g["name"] == DECK_NAME and g["mimeType"] == cc.PPTX]
+    if not hits:
+        return None, "no %s in the chapter folder" % DECK_NAME
+    if len(hits) > 1:
+        return None, ("%d copies of %s in this chapter folder — resolve by hand"
+                      % (len(hits), DECK_NAME))
+    return hits[0], None
 
 
-def chapter_folders(only_city=None):
+def chapter_folders(sheet, only_city=None):
+    """Chapter folders under the Chapters parent, minus the template.
+
+    `only_city` matches the Drive folder NAME or the city the sheet gives that
+    folder. Matching the folder name alone would make `--city Edinburgh` abort
+    on a folder still called "Scotland" — the very mismatch this script joins
+    through the sheet to avoid everywhere else."""
     kids = cc.list_children(cc.CHAPTERS_PARENT)
-    out = [k for k in kids
-           if k["mimeType"] == cc.FOLDER and k["name"] not in SKIP_FOLDERS]
+    folders = [k for k in kids if k["mimeType"] == cc.FOLDER]
+    if not any(k["name"] in SKIP_FOLDERS for k in folders):
+        print("  WARNING: no template folder (%s) under the Chapters parent — "
+              "it may have been renamed, and is no longer protected.\n"
+              % "/".join(sorted(SKIP_FOLDERS)))
+    out = [k for k in folders if k["name"] not in SKIP_FOLDERS]
     if only_city:
-        out = [k for k in out if k["name"] == only_city]
+        want = only_city.strip().casefold()
+
+        def matches(k):
+            row = sheet.by_folder.get(k["id"]) or sheet.unusable.get(k["id"])
+            return (k["name"].casefold() == want
+                    or (row is not None and row.city.casefold() == want))
+        out = [k for k in out if matches(k)]
         if not out:
-            sys.exit("ABORT: no chapter folder named %r under the Chapters folder."
-                     % only_city)
+            sys.exit("ABORT: no chapter folder named %r, and no row on %s gives "
+                     "that city to a chapter folder." % (only_city, CHAPTERS_TAB))
     return sorted(out, key=lambda k: k["name"])
 
 
 def process(deck_id, latlon, tmpdir, tolerance, write):
-    """Inspect one chapter's deck; move its dot when --write and it is off target.
+    """Inspect one chapter's deck; move its markers when --write and off target.
 
-    Returns (status, drift_in_px) where status is ok / moved / would-move, or
-    ("unreadable", None) when slide 5 does not hold exactly one green dot and one
-    green label — a deck that has drifted from the template is reported, never
-    rewritten on a guess."""
+    Returns (status, drift_px) with status in STATUS_DISPLAY, or (None, reason)
+    when slide 5 cannot be read — a deck that has drifted from the template is
+    reported, never rewritten on a guess. None is the same can't-evaluate
+    sentinel find_deck() and read_marker_offsets() already use, rather than a
+    fourth status the caller would immediately have to re-split out.
+
+    Drift is the WORSE of the dot and the label. Both are rewritten together, so
+    gating on the dot alone would leave a hand-dragged label uncorrectable and
+    would make a refit of LABEL_DX/LABEL_DY a silent estate-wide no-op."""
     tmp = os.path.join(tmpdir, "d" + deck_id + ".pptx")
     try:
         cc.gws_download(deck_id, tmp)
-        current = cc.read_marker_offsets(tmp)
+        # gws_download discards stdout, so an error body written at exit 0 would
+        # otherwise surface as a BadZipFile blaming the OOXML code.
+        if not os.path.exists(tmp) or os.path.getsize(tmp) == 0:
+            raise RuntimeError("download of deck %s wrote no file" % deck_id)
+        if not zipfile.is_zipfile(tmp):
+            raise RuntimeError("download of deck %s is not a .pptx (%d bytes) — "
+                               "an error body, not the deck"
+                               % (deck_id, os.path.getsize(tmp)))
+        current, why = cc.read_marker_offsets(tmp)
         if current is None:
-            return "unreadable", None
-        target, _label = cc.marker_offsets(*latlon)
-        d = drift_px(current[0], target)
+            return None, why
+        dot_target, label_target = cc.marker_offsets(*latlon)
+        d = max(drift_px(current[0], dot_target),
+                drift_px(current[1], label_target))
         if d <= tolerance:
             return "ok", d
         if not write:
@@ -201,7 +297,8 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--write", action="store_true",
                     help="Actually move the dots (default: report only)")
-    ap.add_argument("--city", help="Only the chapter folder with this NAME "
+    ap.add_argument("--city", help="Only this chapter: its Drive folder NAME, or "
+                                   "the city the sheet gives that folder "
                                    "(default: every chapter)")
     ap.add_argument("--lat", type=float, help="Latitude override (requires --city and --lon)")
     ap.add_argument("--lon", type=float, help="Longitude override (requires --city and --lat)")
@@ -214,67 +311,98 @@ def main():
         sys.exit("ABORT: --lat and --lon must be given together.")
     if args.lat is not None and not args.city:
         sys.exit("ABORT: --lat/--lon apply to one chapter; pass --city too.")
+    if args.tolerance < 0:
+        sys.exit("ABORT: --tolerance must not be negative (got %r) — every deck "
+                 "would be rewritten." % args.tolerance)
+    if args.tolerance > LOUD_TOLERANCE_PX:
+        print("  WARNING: --tolerance %.1f px exceeds any real drift; a "
+              "misplaced estate would report as already correct.\n"
+              % args.tolerance)
 
     override = (args.lat, args.lon) if args.lat is not None else None
-    coords, bad_rows, unusable = ({}, [], {}) if override else read_chapter_coords()
-    folders = chapter_folders(args.city)
+    # The sheet is still read under --lat/--lon: --city resolves through it, and
+    # its rows are what name the chapter in the report.
+    sheet = read_chapter_coords()
+    folders = chapter_folders(sheet, args.city)
     print("%s %d chapter folder(s) against %d sheet row(s), tolerance %.1f px.\n"
           % ("Moving dots in" if args.write else "Checking",
-             len(folders), len(coords), args.tolerance))
+             len(folders), len(sheet.by_folder), args.tolerance))
 
-    results, skipped = [], []
+    results, skipped, attention, failed = [], [], [], []
     tmpdir = tempfile.mkdtemp(prefix="aaif-map-dots-")
     try:
         for f in folders:
-            row = coords.get(f["id"])
-            # Report under the sheet's city, not the folder name: the folder
-            # still called "Scotland" is the Edinburgh chapter.
-            name = row[0] if row else f["name"]
+            row = sheet.by_folder.get(f["id"])
+            # Report under the sheet's city, not the folder name: a folder's
+            # name can lag the chapter's real city.
+            name = row.city if row else f["name"]
             if override:
                 latlon = override
             elif row:
-                latlon = row[1:]
-            elif f["id"] in unusable:
-                city, why = unusable[f["id"]]
-                skipped.append((city, "%s on %s" % (why, CHAPTERS_TAB)))
-                print("  ?  %-16s %s — dot left as-is" % (city, why))
+                latlon = row.latlon
+            elif f["id"] in sheet.unusable:
+                bad = sheet.unusable[f["id"]]
+                skipped.append((bad.city, "%s on %s" % (bad.why, CHAPTERS_TAB)))
+                print("  ?  %-16s %s — dot left as-is" % (bad.city, bad.why))
                 continue
             else:
                 skipped.append((f["name"], "no row on %s links to this folder"
                                 % CHAPTERS_TAB))
                 print("  ?  %-16s no sheet row — dot left as-is" % f["name"])
                 continue
-            deck_id = find_deck(f["id"])
+            deck_id, why = find_deck(f["id"])
             if deck_id is None:
-                skipped.append((name, "no %s in the chapter folder" % DECK_NAME))
-                print("  ?  %-16s no %s — nothing to fix" % (name, DECK_NAME))
+                skipped.append((name, why))
+                print("  ?  %-16s %s" % (name, why))
                 continue
-            status, d = process(deck_id, latlon, tmpdir, args.tolerance, args.write)
-            if status == "unreadable":
-                skipped.append((name, "slide 5 has no single green dot + label"))
-                print("  !  %-16s slide 5 markers not recognised — skipped" % name)
+            # One bad deck must not abort the sweep: without this the summary
+            # and the skip list never print, and the operator loses the record
+            # of what was already moved. Named exceptions only — a bare except
+            # would hide coding errors behind a per-chapter "FAILED" line.
+            try:
+                status, d = process(deck_id, latlon, tmpdir, args.tolerance,
+                                    args.write)
+            except (RuntimeError, OSError, zipfile.BadZipFile) as exc:
+                failed.append((name, str(exc)[:200]))
+                print("  X  %-16s FAILED: %s" % (name, str(exc)[:110]))
+                continue
+            if status is None:
+                attention.append((name, d))
+                print("  !  %-16s %s — skipped" % (name, d))
                 continue
             results.append((name, status, d))
-            mark = {"ok": "=", "moved": "+", "would-move": "~"}[status]
-            note = {"ok": "already correct", "moved": "moved",
-                    "would-move": "WOULD move"}[status]
+            mark, note = STATUS_DISPLAY[status]
             print("  %s  %-16s %-15s (%5.1f px off)" % (mark, name, note, d))
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
     off = [r for r in results if r[1] != "ok"]
-    print("\n%d chapter(s) checked: %d already correct, %d %s, %d skipped."
+    print("\n%d chapter(s) checked: %d already correct, %d %s, %d skipped, "
+          "%d need attention, %d failed."
           % (len(results), len(results) - len(off), len(off),
-             "moved" if args.write else "off (not moved)", len(skipped)))
+             "moved" if args.write else "off (not moved)", len(skipped),
+             len(attention), len(failed)))
     if off:
         worst = max(off, key=lambda r: r[2])
         print("Worst drift: %s at %.1f px." % (worst[0], worst[2]))
     for name, why in skipped:
         print("  skipped: %s — %s" % (name, why))
-    for city, why in bad_rows:
-        print("  sheet row unusable: %s — %s" % (city, why))
+    for name, why in attention:
+        print("  NEEDS ATTENTION: %s — %s" % (name, why))
+    for name, why in failed:
+        print("  FAILED: %s — %s" % (name, why))
+    for r in sheet.bad_rows:
+        print("  sheet row unusable: %s — %s" % (r.city, r.why))
     if off and not args.write:
         print("\nRe-run with --write to move them.")
+
+    # A run that could not evaluate part of the estate must not exit 0: a
+    # wrapper, a cron job, or a glance at $? would read it as a finished
+    # backfill. Benign skips (no row, no deck) are not failures; an unreadable
+    # deck or a hard error is.
+    if failed or attention:
+        sys.exit("\n%d deck(s) failed and %d need attention — those chapters "
+                 "were NOT backfilled." % (len(failed), len(attention)))
 
 
 if __name__ == "__main__":

--- a/skills/aaif-create-chapter/scripts/backfill_map_dots.py
+++ b/skills/aaif-create-chapter/scripts/backfill_map_dots.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Re-place the slide-5 "you-are-here" map dot in every EXISTING chapter deck.
+
+Chapters created before 2026-08-12 got their dot from `create_chapter.py`'s old
+hand-rolled projection (a linear lon2x plus a piecewise-linear lat2y, patched per
+city by a PIXEL_OVERRIDES table). That model was wrong everywhere — ~9% too wide
+with a ~20 px offset — so every one of those decks carries a misplaced dot (mean
+31 px, worst 60 px: Shanghai landed on Japan, Tokyo in the Pacific). The current
+Gall Stereographic fit in `create_chapter.py` is correct to 0.64 px and needs no
+overrides; this script walks the Chapters Drive and brings the old decks up to it.
+
+It is a *backfill*, not a second implementation: the projection, the OOXML
+surgery and the Drive plumbing are all imported from `create_chapter.py`, so
+there is exactly one definition of where a dot belongs. Re-running is safe and
+cheap — a deck already within --tolerance of its target is left untouched, which
+is also what makes this the tool to reach for if the map art is ever refitted.
+
+Coordinates come from the **Chapters & Teams** sheet's `Generated Geolocation`
+column, joined to Drive by the folder URL in `Chapter Folder` — not from
+geocoding the folder name. The sheet is what the website feed already draws, so
+the dot and the site agree by construction; it is also the only source that knows
+a folder still called "Scotland" is the Edinburgh chapter. A Drive folder with no
+sheet row is reported and skipped rather than guessed at.
+
+Read-only by default: it prints the per-chapter drift and changes nothing.
+
+Usage:
+  # Plan (default) — report every chapter's drift in pixels, write nothing:
+  python backfill_map_dots.py
+
+  # Apply to the whole estate:
+  python backfill_map_dots.py --write
+
+  # One chapter, with coordinates given rather than read from the sheet:
+  python backfill_map_dots.py --city Shanghai --lat 31.2304 --lon 121.4737 --write
+"""
+import argparse, os, re, shutil, sys, tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import create_chapter as cc      # projection, OOXML surgery, Drive plumbing
+
+CHAPTERS_ID = "18_7aHD45-5NhlN6IZKW2QzswZlDHVb8nBSP7rl5-yWg"   # "Chapters List"
+CHAPTERS_TAB = "Chapters & Teams"
+COL_CITY, COL_FOLDER, COL_GEO = "City", "Chapter Folder", "Generated Geolocation"
+
+DECK_NAME = "Slides.pptx"        # the deck that carries the slide-5 network map
+# TemplateCity's dot is the San Francisco anchor the label offsets are measured
+# from (see LABEL_DX/LABEL_DY in create_chapter) — moving it would redefine the
+# template, not fix a chapter. It has no sheet row either, so this is belt and
+# braces: it must never be treated as a chapter.
+SKIP_FOLDERS = {"TemplateCity"}
+
+# Sub-pixel drift is invisible on a 1123 px map and is just rounding; only move a
+# dot that is actually in the wrong place, so a re-run is a cheap no-op.
+DEFAULT_TOLERANCE_PX = 1.0
+EMU_PER_PX_X = cc.MAP_EXT[0] / cc.MAP_PX[0]
+EMU_PER_PX_Y = cc.MAP_EXT[1] / cc.MAP_PX[1]
+
+FOLDER_ID_RE = re.compile(r"/folders/([A-Za-z0-9_-]+)")
+GEO_RE = re.compile(r"^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$")
+
+
+def drift_px(current, target):
+    """Distance in map pixels between a deck's current dot and where it belongs."""
+    dx = (current[0] - target[0]) / EMU_PER_PX_X
+    dy = (current[1] - target[1]) / EMU_PER_PX_Y
+    return (dx * dx + dy * dy) ** 0.5
+
+
+def parse_geo(cell):
+    """Parse a `Generated Geolocation` cell ("37.7749, -122.4194") to (lat, lon),
+    or None if it is blank or not a coordinate pair. Range-checked: a garbled
+    pair would otherwise place a dot confidently in the wrong place."""
+    m = GEO_RE.match(cell or "")
+    if not m:
+        return None
+    lat, lon = float(m.group(1)), float(m.group(2))
+    if not (-90 <= lat <= 90 and -180 <= lon <= 180):
+        return None
+    return lat, lon
+
+
+def folder_id_from_url(cell):
+    m = FOLDER_ID_RE.search(cell or "")
+    return m.group(1) if m else None
+
+
+# ----------------------------------------------------------------------------
+# Sheet
+# ----------------------------------------------------------------------------
+def read_chapter_coords():
+    """Return ({folder_id: (city, lat, lon)}, [(city, why)], {folder_id: (city, why)}).
+
+    The third value holds the rows that DO name a Drive folder but whose
+    coordinates are unusable. Without it a folder whose row exists but has no
+    geolocation is indistinguishable from one with no row at all, and the sweep
+    reports "no row on the sheet links to this folder" about a row that is
+    sitting right there.
+
+    Columns are resolved by header name, never by letter — the tab is a website
+    feed and its layout has moved before. A row missing its folder link or its
+    geolocation is left out of the map and reported, so the corresponding Drive
+    folder reads as unresolved rather than having its dot moved to a coordinate
+    the sheet never gave."""
+    res = cc.gws_json("sheets", "spreadsheets", "values", "get", params={
+        "spreadsheetId": CHAPTERS_ID, "range": "'%s'!A:AZ" % CHAPTERS_TAB})
+    rows = res.get("values", [])
+    if not rows:
+        sys.exit("ABORT: chapters tab %r came back empty." % CHAPTERS_TAB)
+    headers = [h.strip() for h in rows[0]]
+    missing = [c for c in (COL_CITY, COL_FOLDER, COL_GEO) if c not in headers]
+    if missing:
+        sys.exit("ABORT: %s is missing column(s) %s — the tab was restructured; "
+                 "re-point this script at the new header names."
+                 % (CHAPTERS_TAB, ", ".join(map(repr, missing))))
+    i_city, i_folder, i_geo = (headers.index(c) for c in (COL_CITY, COL_FOLDER, COL_GEO))
+
+    coords, bad, unusable = {}, [], {}
+    for row in rows[1:]:
+        def cell(i):
+            return (row[i] if i < len(row) else "").strip()
+        city = cell(i_city)
+        if not city:
+            continue
+        fid, geo = folder_id_from_url(cell(i_folder)), parse_geo(cell(i_geo))
+        if not fid or not geo:
+            why = ("no %s link" % COL_FOLDER if not fid
+                   else "no usable %s" % COL_GEO)
+            bad.append((city, why))
+            if fid:
+                unusable[fid] = (city, why)
+            continue
+        coords[fid] = (city, geo[0], geo[1])
+    return coords, bad, unusable
+
+
+# ----------------------------------------------------------------------------
+# Drive walk
+# ----------------------------------------------------------------------------
+def find_deck(folder_id):
+    """Return the id of the chapter's Slides.pptx, or None.
+
+    Looks at the chapter folder and then one level down, rather than hard-coding
+    "Event Templates (Copy for Each Event)": that folder has been renamed once
+    already, and a chapter whose deck simply was never cloned has to read as
+    missing rather than as an error."""
+    children = cc.list_children(folder_id)
+    for c in children:
+        if c["name"] == DECK_NAME and c["mimeType"] == cc.PPTX:
+            return c["id"]
+    for c in children:
+        if c["mimeType"] != cc.FOLDER:
+            continue
+        for g in cc.list_children(c["id"]):
+            if g["name"] == DECK_NAME and g["mimeType"] == cc.PPTX:
+                return g["id"]
+    return None
+
+
+def chapter_folders(only_city=None):
+    kids = cc.list_children(cc.CHAPTERS_PARENT)
+    out = [k for k in kids
+           if k["mimeType"] == cc.FOLDER and k["name"] not in SKIP_FOLDERS]
+    if only_city:
+        out = [k for k in out if k["name"] == only_city]
+        if not out:
+            sys.exit("ABORT: no chapter folder named %r under the Chapters folder."
+                     % only_city)
+    return sorted(out, key=lambda k: k["name"])
+
+
+def process(deck_id, latlon, tmpdir, tolerance, write):
+    """Inspect one chapter's deck; move its dot when --write and it is off target.
+
+    Returns (status, drift_in_px) where status is ok / moved / would-move, or
+    ("unreadable", None) when slide 5 does not hold exactly one green dot and one
+    green label — a deck that has drifted from the template is reported, never
+    rewritten on a guess."""
+    tmp = os.path.join(tmpdir, "d" + deck_id + ".pptx")
+    try:
+        cc.gws_download(deck_id, tmp)
+        current = cc.read_marker_offsets(tmp)
+        if current is None:
+            return "unreadable", None
+        target, _label = cc.marker_offsets(*latlon)
+        d = drift_px(current[0], target)
+        if d <= tolerance:
+            return "ok", d
+        if not write:
+            return "would-move", d
+        cc.reposition_map_marker(tmp, *latlon)
+        cc.gws_upload(deck_id, tmp, cc.PPTX)
+        return "moved", d
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--write", action="store_true",
+                    help="Actually move the dots (default: report only)")
+    ap.add_argument("--city", help="Only the chapter folder with this NAME "
+                                   "(default: every chapter)")
+    ap.add_argument("--lat", type=float, help="Latitude override (requires --city and --lon)")
+    ap.add_argument("--lon", type=float, help="Longitude override (requires --city and --lat)")
+    ap.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE_PX,
+                    help="Leave a dot alone if it is within this many map pixels "
+                         "of its target (default: %(default)s)")
+    args = ap.parse_args()
+
+    if (args.lat is None) != (args.lon is None):
+        sys.exit("ABORT: --lat and --lon must be given together.")
+    if args.lat is not None and not args.city:
+        sys.exit("ABORT: --lat/--lon apply to one chapter; pass --city too.")
+
+    override = (args.lat, args.lon) if args.lat is not None else None
+    coords, bad_rows, unusable = ({}, [], {}) if override else read_chapter_coords()
+    folders = chapter_folders(args.city)
+    print("%s %d chapter folder(s) against %d sheet row(s), tolerance %.1f px.\n"
+          % ("Moving dots in" if args.write else "Checking",
+             len(folders), len(coords), args.tolerance))
+
+    results, skipped = [], []
+    tmpdir = tempfile.mkdtemp(prefix="aaif-map-dots-")
+    try:
+        for f in folders:
+            row = coords.get(f["id"])
+            # Report under the sheet's city, not the folder name: the folder
+            # still called "Scotland" is the Edinburgh chapter.
+            name = row[0] if row else f["name"]
+            if override:
+                latlon = override
+            elif row:
+                latlon = row[1:]
+            elif f["id"] in unusable:
+                city, why = unusable[f["id"]]
+                skipped.append((city, "%s on %s" % (why, CHAPTERS_TAB)))
+                print("  ?  %-16s %s — dot left as-is" % (city, why))
+                continue
+            else:
+                skipped.append((f["name"], "no row on %s links to this folder"
+                                % CHAPTERS_TAB))
+                print("  ?  %-16s no sheet row — dot left as-is" % f["name"])
+                continue
+            deck_id = find_deck(f["id"])
+            if deck_id is None:
+                skipped.append((name, "no %s in the chapter folder" % DECK_NAME))
+                print("  ?  %-16s no %s — nothing to fix" % (name, DECK_NAME))
+                continue
+            status, d = process(deck_id, latlon, tmpdir, args.tolerance, args.write)
+            if status == "unreadable":
+                skipped.append((name, "slide 5 has no single green dot + label"))
+                print("  !  %-16s slide 5 markers not recognised — skipped" % name)
+                continue
+            results.append((name, status, d))
+            mark = {"ok": "=", "moved": "+", "would-move": "~"}[status]
+            note = {"ok": "already correct", "moved": "moved",
+                    "would-move": "WOULD move"}[status]
+            print("  %s  %-16s %-15s (%5.1f px off)" % (mark, name, note, d))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    off = [r for r in results if r[1] != "ok"]
+    print("\n%d chapter(s) checked: %d already correct, %d %s, %d skipped."
+          % (len(results), len(results) - len(off), len(off),
+             "moved" if args.write else "off (not moved)", len(skipped)))
+    if off:
+        worst = max(off, key=lambda r: r[2])
+        print("Worst drift: %s at %.1f px." % (worst[0], worst[2]))
+    for name, why in skipped:
+        print("  skipped: %s — %s" % (name, why))
+    for city, why in bad_rows:
+        print("  sheet row unusable: %s — %s" % (city, why))
+    if off and not args.write:
+        print("\nRe-run with --write to move them.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -200,6 +200,9 @@ LABEL_DX, LABEL_DY = -425196, 224028   # label-corner minus dot-corner (SF templ
 # carries an EMPTY <a:t></a:t>, so text presence can't tell them apart — discriminate
 # by the dot's 155448x155448 ext (its signature).
 DOT_EXT_RE = re.compile(r'<a:ext cx="%d" cy="%d"\s*/>' % (DOT_SIZE, DOT_SIZE))
+# Captures x and y: reposition_map_marker() only needs to MATCH the element, but
+# read_marker_offsets() extracts the coordinates from these two groups. Removing
+# them to "simplify" would silently break the read side.
 OFF_RE = re.compile(r'<a:off x="(-?\d+)" y="(-?\d+)"\s*/>')   # tolerate a re-saved " />"
 SP_RE = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)            # slide 5 shapes are flat
 
@@ -231,32 +234,58 @@ def marker_offsets(lat, lon):
     return dot_off, label_off
 
 def read_marker_offsets(path):
-    """Return (dot_off, label_off) as EMU (x, y) pairs for the slide-5 markers of
-    an EXISTING deck, or None when there is nothing to read (slide 5 absent, no
-    green marker shapes, or not exactly one dot + one label). The read-side twin
-    of marker_offsets(): compare the two to tell a deck whose dot is already in
-    the right place from one that still needs moving, without rewriting the file.
-    Deliberately returns None instead of raising — a caller sweeping the whole
-    chapter estate reports an odd deck and moves on."""
+    """Return (offsets, reason) for the slide-5 markers of an EXISTING deck.
+
+    On success: ((dot_off, label_off), None), each an EMU (x, y) pair, in the
+    same order marker_offsets() returns them. On anything else: (None, reason),
+    where reason is a short human-readable string.
+
+    The read-side twin of marker_offsets(): compare the two to tell a deck whose
+    dot is already in the right place from one that still needs moving, without
+    rewriting the file. Deliberately returns a reason instead of raising — a
+    caller sweeping the whole chapter estate reports an odd deck and moves on.
+
+    The reason is not decoration. The four failure modes want different human
+    responses: a deck with no slide 5 is probably an older template and is
+    nothing to worry about, while a deck with TWO green dots is the state
+    reposition_map_marker() raises "template drift?" over. Collapsing them into
+    one bare None made the sweep print the same line for both, and the quieter
+    reading won."""
     with zipfile.ZipFile(path) as z:
         if SLIDE5 not in z.namelist():
-            return None
+            return None, "no %s — an older template?" % SLIDE5
         xml = z.read(SLIDE5).decode("utf-8")
-    found = {}
+    found, green_without_off = {}, 0
     for m in SP_RE.finditer(xml):
         block = m.group(0)
         if GREEN not in block:
             continue
         off = OFF_RE.search(block)
         if not off:
+            # A green shape whose <a:off> is inherited from a layout placeholder.
+            # Counted rather than dropped: reposition_map_marker() DOES count it
+            # into `green` and then trips its dot_moved != 1 guard, so a deck
+            # that is silently skipped here would pass a plan run and raise
+            # mid-write. Naming it keeps the two sides telling one story.
+            green_without_off += 1
             continue
         key = "dot" if DOT_EXT_RE.search(block) else "label"
         if key in found:
-            return None      # two dots or two labels — template drift, not our call
+            # Two dots or two labels — template drift, not our call.
+            return None, ("slide 5 has TWO green %ss — template drift; inspect "
+                          "before rewriting" % key)
         found[key] = (int(off.group(1)), int(off.group(2)))
+    if not found:
+        extra = (" (%d green shape(s) had no <a:off>)" % green_without_off
+                 if green_without_off else "")
+        return None, "slide 5 has no green (%s) marker shapes%s" % (GREEN, extra)
     if set(found) != {"dot", "label"}:
-        return None
-    return found["dot"], found["label"]
+        missing = ({"dot", "label"} - set(found)).pop()
+        extra = (" (%d green shape(s) had no <a:off>)" % green_without_off
+                 if green_without_off else "")
+        return None, "slide 5 has a green %s but no %s%s" % (
+            sorted(found)[0], missing, extra)
+    return (found["dot"], found["label"]), None
 
 def reposition_map_marker(path, lat, lon):
     """Move the green dot + its label on slide 5 of a .pptx to (lat, lon).

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -200,6 +200,8 @@ LABEL_DX, LABEL_DY = -425196, 224028   # label-corner minus dot-corner (SF templ
 # carries an EMPTY <a:t></a:t>, so text presence can't tell them apart — discriminate
 # by the dot's 155448x155448 ext (its signature).
 DOT_EXT_RE = re.compile(r'<a:ext cx="%d" cy="%d"\s*/>' % (DOT_SIZE, DOT_SIZE))
+OFF_RE = re.compile(r'<a:off x="(-?\d+)" y="(-?\d+)"\s*/>')   # tolerate a re-saved " />"
+SP_RE = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)            # slide 5 shapes are flat
 
 # The map is a Gall Stereographic projection, fitted 2026-07-30 against Natural
 # Earth 110m coastlines composited over the drawn map (mean residual 0.64 px —
@@ -228,6 +230,34 @@ def marker_offsets(lat, lon):
     label_off = (dot_off[0] + LABEL_DX, dot_off[1] + LABEL_DY)
     return dot_off, label_off
 
+def read_marker_offsets(path):
+    """Return (dot_off, label_off) as EMU (x, y) pairs for the slide-5 markers of
+    an EXISTING deck, or None when there is nothing to read (slide 5 absent, no
+    green marker shapes, or not exactly one dot + one label). The read-side twin
+    of marker_offsets(): compare the two to tell a deck whose dot is already in
+    the right place from one that still needs moving, without rewriting the file.
+    Deliberately returns None instead of raising — a caller sweeping the whole
+    chapter estate reports an odd deck and moves on."""
+    with zipfile.ZipFile(path) as z:
+        if SLIDE5 not in z.namelist():
+            return None
+        xml = z.read(SLIDE5).decode("utf-8")
+    found = {}
+    for m in SP_RE.finditer(xml):
+        block = m.group(0)
+        if GREEN not in block:
+            continue
+        off = OFF_RE.search(block)
+        if not off:
+            continue
+        key = "dot" if DOT_EXT_RE.search(block) else "label"
+        if key in found:
+            return None      # two dots or two labels — template drift, not our call
+        found[key] = (int(off.group(1)), int(off.group(2)))
+    if set(found) != {"dot", "label"}:
+        return None
+    return found["dot"], found["label"]
+
 def reposition_map_marker(path, lat, lon):
     """Move the green dot + its label on slide 5 of a .pptx to (lat, lon).
 
@@ -245,9 +275,6 @@ def reposition_map_marker(path, lat, lon):
         xml = z.read(SLIDE5).decode("utf-8")
 
     dot_off, label_off = marker_offsets(lat, lon)
-    off_re = re.compile(r'<a:off x="-?\d+" y="-?\d+"\s*/>')   # tolerate a re-saved " />"
-    sp_re = re.compile(r"<p:sp\b[^>]*>.*?</p:sp>", re.S)      # slide 5 shapes are flat
-
     green = 0
     dot_moved = label_moved = 0
     def move_sp(m):
@@ -258,7 +285,7 @@ def reposition_map_marker(path, lat, lon):
         green += 1
         # The dot is the small square shape; the label is the wide text box.
         is_dot = bool(DOT_EXT_RE.search(block))
-        block, n = off_re.subn(
+        block, n = OFF_RE.subn(
             '<a:off x="%d" y="%d"/>' % (dot_off if is_dot else label_off),
             block, count=1)
         if is_dot:
@@ -267,7 +294,7 @@ def reposition_map_marker(path, lat, lon):
             label_moved += n
         return block
 
-    new_xml = sp_re.sub(move_sp, xml)
+    new_xml = SP_RE.sub(move_sp, xml)
     if green == 0:
         print("      note: slide 5 has no green (%s) marker shapes; "
               "leaving map dot as-is." % GREEN)

--- a/skills/aaif-create-chapter/scripts/test_backfill_map_dots.py
+++ b/skills/aaif-create-chapter/scripts/test_backfill_map_dots.py
@@ -1,0 +1,338 @@
+"""Unit tests for the map-dot backfill (backfill_map_dots.py).
+
+The projection itself is tested in test_create_chapter.py — the backfill imports
+it rather than reimplementing it. What is tested here is everything that decides
+*which* dot moves *where*: parsing the sheet, joining it to Drive, and the
+already-correct/would-move/moved decision that keeps a re-run a no-op.
+
+Run: python3 skills/aaif-create-chapter/scripts/test_backfill_map_dots.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+import backfill_map_dots as bf  # noqa: E402
+import create_chapter as cc  # noqa: E402
+
+SF = (37.7749, -122.4194)
+URL = "https://drive.google.com/drive/folders/%s"
+
+
+def sheet(*rows, headers=None):
+    """A fake gws_json values.get response for the Chapters tab."""
+    headers = headers or [bf.COL_CITY, bf.COL_FOLDER, bf.COL_GEO]
+    return {"values": [headers] + [list(r) for r in rows]}
+
+
+class TestParseGeo(unittest.TestCase):
+    """The `Generated Geolocation` cell is hand-editable free text on a sheet
+    other people maintain — a value that isn't a coordinate pair has to read as
+    "no coordinate", never as a coordinate that happens to parse."""
+
+    def test_parses_a_plain_pair(self):
+        self.assertEqual(bf.parse_geo("37.7749, -122.4194"), SF)
+
+    def test_tolerates_surrounding_and_inner_whitespace(self):
+        self.assertEqual(bf.parse_geo("  37.7749 ,-122.4194  "), SF)
+
+    def test_parses_integers_and_negative_latitude(self):
+        self.assertEqual(bf.parse_geo("-34, 151"), (-34.0, 151.0))
+
+    def test_none_for_blank_and_missing(self):
+        for cell in ("", "   ", None):
+            self.assertIsNone(bf.parse_geo(cell), cell)
+
+    def test_none_for_prose(self):
+        for cell in ("TBD", "see notes", "37.7749", "37.7749, -122.4194, 0"):
+            self.assertIsNone(bf.parse_geo(cell), cell)
+
+    def test_none_when_out_of_range(self):
+        """A swapped pair for a high-latitude city (e.g. "24.9384, 60.1699"
+        written the wrong way round) is in range and can't be caught here, but a
+        genuinely impossible value must not become a dot."""
+        for cell in ("91, 0", "-91, 0", "0, 181", "0, -181"):
+            self.assertIsNone(bf.parse_geo(cell), cell)
+
+
+class TestFolderIdFromUrl(unittest.TestCase):
+    def test_extracts_the_id(self):
+        self.assertEqual(bf.folder_id_from_url(URL % "1AbC-_9"), "1AbC-_9")
+
+    def test_extracts_with_a_query_string(self):
+        self.assertEqual(bf.folder_id_from_url(URL % "1AbC" + "?usp=sharing"), "1AbC")
+
+    def test_none_for_blank_or_non_folder_link(self):
+        for cell in ("", None, "https://drive.google.com/file/d/1AbC/view", "n/a"):
+            self.assertIsNone(bf.folder_id_from_url(cell), cell)
+
+
+class TestDriftPx(unittest.TestCase):
+    def test_zero_when_identical(self):
+        self.assertEqual(bf.drift_px((100, 200), (100, 200)), 0.0)
+
+    def test_one_pixel_step_reads_as_one_pixel(self):
+        target = cc.marker_offsets(*SF)[0]
+        moved = (target[0] + round(bf.EMU_PER_PX_X), target[1])
+        self.assertAlmostEqual(bf.drift_px(moved, target), 1.0, places=3)
+
+    def test_combines_both_axes(self):
+        target = (0, 0)
+        off = (round(3 * bf.EMU_PER_PX_X), round(4 * bf.EMU_PER_PX_Y))
+        self.assertAlmostEqual(bf.drift_px(off, target), 5.0, places=3)
+
+
+class TestReadChapterCoords(unittest.TestCase):
+    def read(self, response):
+        with mock.patch.object(cc, "gws_json", return_value=response):
+            return bf.read_chapter_coords()
+
+    def test_keys_by_drive_folder_id(self):
+        coords, bad, _ = self.read(sheet(
+            ("San Francisco", URL % "fid1", "37.7749, -122.4194"),
+            ("Tokyo", URL % "fid2", "35.6762, 139.6503")))
+        self.assertEqual(bad, [])
+        self.assertEqual(coords["fid1"], ("San Francisco", 37.7749, -122.4194))
+        self.assertEqual(coords["fid2"], ("Tokyo", 35.6762, 139.6503))
+
+    def test_columns_are_found_by_header_name_not_position(self):
+        """The tab is a website feed and has been restructured before; a column
+        reorder must move the reads with it."""
+        coords, _, _ = self.read(sheet(
+            ("37.7749, -122.4194", "San Francisco", "ignored", URL % "fid1"),
+            headers=[bf.COL_GEO, bf.COL_CITY, "Summary", bf.COL_FOLDER]))
+        self.assertEqual(coords["fid1"], ("San Francisco", 37.7749, -122.4194))
+
+    def test_row_without_a_folder_link_is_reported_not_guessed(self):
+        coords, bad, _ = self.read(sheet(("Lagos", "", "6.5244, 3.3792")))
+        self.assertEqual(coords, {})
+        self.assertEqual(bad, [("Lagos", "no %s link" % bf.COL_FOLDER)])
+
+    def test_row_without_usable_coordinates_is_reported(self):
+        coords, bad, unusable = self.read(sheet(("Lagos", URL % "fid1", "TBD")))
+        self.assertEqual(coords, {})
+        self.assertEqual(bad, [("Lagos", "no usable %s" % bf.COL_GEO)])
+        # Keyed by folder id so the sweep can tell this folder apart from one
+        # the sheet genuinely says nothing about.
+        self.assertEqual(unusable,
+                         {"fid1": ("Lagos", "no usable %s" % bf.COL_GEO)})
+
+    def test_row_without_a_folder_link_is_not_in_unusable(self):
+        """No folder id means there is nothing to key on — the row is reported,
+        but no Drive folder can be attributed to it."""
+        _coords, bad, unusable = self.read(sheet(("Lagos", "", "6.5244, 3.3792")))
+        self.assertEqual(bad, [("Lagos", "no %s link" % bf.COL_FOLDER)])
+        self.assertEqual(unusable, {})
+
+    def test_blank_city_rows_are_ignored_silently(self):
+        """Trailing blank rows are normal on a sheet — they are not findings."""
+        coords, bad, unusable = self.read(sheet(("", "", ""), ("  ", "", "")))
+        self.assertEqual((coords, bad, unusable), ({}, [], {}))
+
+    def test_short_rows_do_not_raise(self):
+        """Sheets truncates trailing empty cells, so a row can be shorter than
+        the header."""
+        coords, bad, _ = self.read(sheet(("Lagos",)))
+        self.assertEqual(coords, {})
+        self.assertEqual(bad, [("Lagos", "no %s link" % bf.COL_FOLDER)])
+
+    def test_aborts_when_a_column_is_missing(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.read(sheet(headers=[bf.COL_CITY, bf.COL_FOLDER]))
+        self.assertIn(bf.COL_GEO, str(cm.exception))
+
+    def test_aborts_on_an_empty_tab(self):
+        """An empty read is a failure, not "no chapters" — treating it as the
+        latter would make the whole backfill silently do nothing."""
+        with self.assertRaises(SystemExit):
+            self.read({"values": []})
+
+
+class TestChapterFolders(unittest.TestCase):
+    KIDS = [
+        {"id": "f1", "name": "Tokyo", "mimeType": cc.FOLDER},
+        {"id": "f2", "name": "Amsterdam", "mimeType": cc.FOLDER},
+        {"id": "f3", "name": "TemplateCity", "mimeType": cc.FOLDER},
+        {"id": "f4", "name": "Intro to AAIF", "mimeType": cc.PPTX},
+    ]
+
+    def folders(self, only_city=None):
+        with mock.patch.object(cc, "list_children", return_value=self.KIDS):
+            return bf.chapter_folders(only_city)
+
+    def test_skips_the_template_and_non_folders(self):
+        self.assertEqual([f["name"] for f in self.folders()], ["Amsterdam", "Tokyo"])
+
+    def test_city_filter_selects_one(self):
+        self.assertEqual([f["id"] for f in self.folders("Tokyo")], ["f1"])
+
+    def test_city_filter_aborts_on_an_unknown_name(self):
+        with self.assertRaises(SystemExit):
+            self.folders("Atlantis")
+
+    def test_city_filter_cannot_select_the_template(self):
+        with self.assertRaises(SystemExit):
+            self.folders("TemplateCity")
+
+
+class TestFindDeck(unittest.TestCase):
+    def find(self, tree):
+        with mock.patch.object(cc, "list_children", side_effect=lambda fid: tree[fid]):
+            return bf.find_deck("chapter")
+
+    def test_finds_the_deck_one_level_down(self):
+        self.assertEqual(self.find({
+            "chapter": [{"id": "sub", "name": "Event Templates (Copy for Each Event)",
+                         "mimeType": cc.FOLDER}],
+            "sub": [{"id": "deck", "name": "Slides.pptx", "mimeType": cc.PPTX}],
+        }), "deck")
+
+    def test_finds_the_deck_at_the_top_level(self):
+        self.assertEqual(self.find({
+            "chapter": [{"id": "deck", "name": "Slides.pptx", "mimeType": cc.PPTX}],
+        }), "deck")
+
+    def test_none_when_the_deck_was_never_cloned(self):
+        self.assertIsNone(self.find({
+            "chapter": [{"id": "sub", "name": "Banners", "mimeType": cc.FOLDER}],
+            "sub": [{"id": "x", "name": "Square Logo.pptx", "mimeType": cc.PPTX}],
+        }))
+
+    def test_ignores_a_google_slides_file_of_the_same_name(self):
+        """Only a stored .pptx can be byte-rewritten; a native Slides file of the
+        same name is a different thing and must not be treated as the deck."""
+        self.assertIsNone(self.find({
+            "chapter": [{"id": "g", "name": "Slides.pptx",
+                         "mimeType": "application/vnd.google-apps.presentation"}],
+        }))
+
+
+class TestProcess(unittest.TestCase):
+    """The move/skip decision, with Drive and the OOXML surgery stubbed out."""
+
+    def setUp(self):
+        self.uploads, self.moves = [], []
+        self.current = cc.marker_offsets(*SF)[0]     # default: already correct
+        self.tmpdir = None
+
+    def run_process(self, latlon=SF, write=False, tolerance=1.0):
+        self.tmpdir = tempfile.mkdtemp()
+        seen = {}
+
+        def fake_download(_fid, out):
+            with open(out, "wb") as f:
+                f.write(b"deck")
+            seen["path"] = out
+
+        with mock.patch.object(cc, "gws_download", fake_download), \
+             mock.patch.object(cc, "read_marker_offsets",
+                               lambda _p: (self.current, (0, 0)) if self.current else None), \
+             mock.patch.object(cc, "reposition_map_marker",
+                               lambda p, la, lo: self.moves.append((p, la, lo))), \
+             mock.patch.object(cc, "gws_upload",
+                               lambda fid, p, mime: self.uploads.append((fid, mime))):
+            out = bf.process("deck1", latlon, self.tmpdir, tolerance, write)
+        self.seen = seen
+        return out
+
+    def tearDown(self):
+        if self.tmpdir:
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_already_correct_deck_is_left_alone_even_with_write(self):
+        status, drift = self.run_process(write=True)
+        self.assertEqual(status, "ok")
+        self.assertLess(drift, 1.0)
+        self.assertEqual((self.moves, self.uploads), ([], []))
+
+    def test_sub_pixel_drift_is_within_tolerance(self):
+        """A dot placed from a slightly different geocode rounds to a few EMU —
+        invisible, and re-uploading 80 decks for it would be pure churn."""
+        self.current = (self.current[0] + 40, self.current[1] + 40)
+        self.assertEqual(self.run_process(write=True)[0], "ok")
+        self.assertEqual(self.uploads, [])
+
+    def test_plan_run_never_uploads(self):
+        self.current = (self.current[0] + 10 ** 6, self.current[1])
+        status, drift = self.run_process(write=False)
+        self.assertEqual(status, "would-move")
+        self.assertGreater(drift, 1.0)
+        self.assertEqual((self.moves, self.uploads), ([], []))
+
+    def test_write_run_repositions_then_uploads_as_pptx(self):
+        self.current = (self.current[0] + 10 ** 6, self.current[1])
+        self.assertEqual(self.run_process(write=True)[0], "moved")
+        self.assertEqual([(la, lo) for _p, la, lo in self.moves], [SF])
+        self.assertEqual(self.uploads, [("deck1", cc.PPTX)])
+
+    def test_unrecognised_slide5_is_reported_not_rewritten(self):
+        self.current = None
+        self.assertEqual(self.run_process(write=True), ("unreadable", None))
+        self.assertEqual((self.moves, self.uploads), ([], []))
+
+    def test_the_downloaded_deck_is_removed_afterwards(self):
+        """Chapter decks are chapter data; they must not be left on disk."""
+        self.run_process(write=True)
+        self.assertFalse(os.path.exists(self.seen["path"]))
+
+    def test_the_deck_is_removed_even_when_the_upload_raises(self):
+        self.current = (self.current[0] + 10 ** 6, self.current[1])
+        self.tmpdir = tempfile.mkdtemp()
+        seen = {}
+
+        def fake_download(_fid, out):
+            with open(out, "wb") as f:
+                f.write(b"deck")
+            seen["path"] = out
+
+        def boom(*_a, **_k):
+            raise RuntimeError("gws failed")
+
+        with mock.patch.object(cc, "gws_download", fake_download), \
+             mock.patch.object(cc, "read_marker_offsets", lambda _p: (self.current, (0, 0))), \
+             mock.patch.object(cc, "reposition_map_marker", lambda *a: None), \
+             mock.patch.object(cc, "gws_upload", boom):
+            with self.assertRaises(RuntimeError):
+                bf.process("deck1", SF, self.tmpdir, 1.0, True)
+        self.assertFalse(os.path.exists(seen["path"]))
+
+
+class TestDefaultIsReadOnly(unittest.TestCase):
+    def test_write_defaults_to_false(self):
+        """Repo rule: a script that writes on its default invocation is a bug.
+
+        Driven through a chapter that genuinely IS off target, so the run has
+        something to write and the assertion means something."""
+        off = cc.marker_offsets(*SF)[0]
+        far = (off[0] + 10 ** 6, off[1])
+        with mock.patch.object(sys, "argv", ["backfill_map_dots.py"]), \
+             mock.patch.object(bf, "read_chapter_coords",
+                               return_value=({"f1": ("San Francisco",) + SF}, [], {})), \
+             mock.patch.object(bf, "chapter_folders",
+                               return_value=[{"id": "f1", "name": "San Francisco",
+                                              "mimeType": cc.FOLDER}]), \
+             mock.patch.object(bf, "find_deck", return_value="deck1"), \
+             mock.patch.object(cc, "gws_download",
+                               lambda _fid, out: open(out, "wb").close()), \
+             mock.patch.object(cc, "read_marker_offsets", lambda _p: (far, (0, 0))), \
+             mock.patch.object(cc, "reposition_map_marker",
+                               side_effect=AssertionError("rewrote a deck!")), \
+             mock.patch.object(cc, "gws_upload", side_effect=AssertionError("wrote!")):
+            bf.main()
+
+    def test_lat_without_lon_aborts(self):
+        with mock.patch.object(sys, "argv", ["x", "--city", "Tokyo", "--lat", "1"]):
+            with self.assertRaises(SystemExit):
+                bf.main()
+
+    def test_coordinate_override_requires_a_city(self):
+        with mock.patch.object(sys, "argv", ["x", "--lat", "1", "--lon", "2"]):
+            with self.assertRaises(SystemExit):
+                bf.main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-create-chapter/scripts/test_backfill_map_dots.py
+++ b/skills/aaif-create-chapter/scripts/test_backfill_map_dots.py
@@ -5,18 +5,34 @@ it rather than reimplementing it. What is tested here is everything that decides
 *which* dot moves *where*: parsing the sheet, joining it to Drive, and the
 already-correct/would-move/moved decision that keeps a re-run a no-op.
 
+Four invariants carry the safety of this script, and each is pinned by a named
+test rather than by a comment:
+
+  (a) it never writes on a default invocation   -> TestDefaultIsReadOnly
+  (b) it never moves a dot on a guessed coord   -> TestMainSkipBranches
+  (c) a re-run is a no-op                       -> TestReRunIsANoOp
+  (d) a non-template deck is skipped, not moved -> TestProcess + test_create_chapter
+
+Nothing here may touch the network. TestNoNetwork guards that globally: a
+regression in an early argument check used to let a "unit" test list the live
+Chapters folder and download a production deck.
+
 Run: python3 skills/aaif-create-chapter/scripts/test_backfill_map_dots.py
 """
+import contextlib
+import io
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+import zipfile
 from unittest import mock
 
 sys.path.insert(0, os.path.dirname(__file__))
 import backfill_map_dots as bf  # noqa: E402
 import create_chapter as cc  # noqa: E402
+from test_create_chapter import DOT_SP, LABEL_SP, make_pptx, slide5  # noqa: E402
 
 SF = (37.7749, -122.4194)
 URL = "https://drive.google.com/drive/folders/%s"
@@ -28,34 +44,118 @@ def sheet(*rows, headers=None):
     return {"values": [headers] + [list(r) for r in rows]}
 
 
+def row(city, fid, geo):
+    """One Chapters-tab row: city, folder link, geolocation cell."""
+    return (city, URL % fid if fid else "", geo)
+
+
+def folder(fid, name):
+    return {"id": fid, "name": name, "mimeType": cc.FOLDER}
+
+
+def stub_download(_fid, out):
+    """A minimal but REAL zip: process() rejects an empty or non-pptx download,
+    so a stub that writes nothing would be caught by that check rather than
+    reaching the code under test."""
+    with zipfile.ZipFile(out, "w") as z:
+        z.writestr("x", "y")
+
+
+def quiet(fn, *a, **kw):
+    """Run fn, swallowing its report. main() prints a full chapter table."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        out = fn(*a, **kw)
+    return out, buf.getvalue()
+
+
+class TestNoNetwork(unittest.TestCase):
+    """Nothing in this suite may reach Drive or Sheets.
+
+    `test_lat_without_lon_aborts` and its sibling once mocked only sys.argv.
+    They passed because main() exits early — but with that guard removed the
+    suite listed the real Chapters folder and downloaded a production deck.
+    A unit suite that CI runs on every PR must not be one regression away from
+    touching the estate, so the network is denied for the whole class and the
+    aborts assert their reason rather than merely that *something* exited."""
+
+    def setUp(self):
+        for name in ("gws_json", "gws_download", "gws_upload", "list_children"):
+            p = mock.patch.object(cc, name,
+                                  side_effect=AssertionError("touched the network"))
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_lat_without_lon_aborts_before_any_io(self):
+        with mock.patch.object(sys, "argv", ["x", "--city", "Tokyo", "--lat", "1"]):
+            with self.assertRaises(SystemExit) as cm:
+                bf.main()
+        self.assertIn("--lat and --lon", str(cm.exception))
+
+    def test_coordinate_override_requires_a_city(self):
+        with mock.patch.object(sys, "argv", ["x", "--lat", "1", "--lon", "2"]):
+            with self.assertRaises(SystemExit) as cm:
+                bf.main()
+        self.assertIn("--city", str(cm.exception))
+
+    def test_negative_tolerance_aborts(self):
+        """Every deck would read as off target and be rewritten."""
+        with mock.patch.object(sys, "argv", ["x", "--tolerance", "-1"]):
+            with self.assertRaises(SystemExit) as cm:
+                bf.main()
+        self.assertIn("negative", str(cm.exception))
+
+
 class TestParseGeo(unittest.TestCase):
     """The `Generated Geolocation` cell is hand-editable free text on a sheet
     other people maintain — a value that isn't a coordinate pair has to read as
     "no coordinate", never as a coordinate that happens to parse."""
 
+    def geo(self, cell):
+        latlon, why = bf.parse_geo(cell)
+        return latlon
+
     def test_parses_a_plain_pair(self):
-        self.assertEqual(bf.parse_geo("37.7749, -122.4194"), SF)
+        self.assertEqual(bf.parse_geo("37.7749, -122.4194"), (SF, None))
 
     def test_tolerates_surrounding_and_inner_whitespace(self):
-        self.assertEqual(bf.parse_geo("  37.7749 ,-122.4194  "), SF)
+        self.assertEqual(self.geo("  37.7749 ,-122.4194  "), SF)
 
     def test_parses_integers_and_negative_latitude(self):
-        self.assertEqual(bf.parse_geo("-34, 151"), (-34.0, 151.0))
+        self.assertEqual(self.geo("-34, 151"), (-34.0, 151.0))
 
     def test_none_for_blank_and_missing(self):
         for cell in ("", "   ", None):
-            self.assertIsNone(bf.parse_geo(cell), cell)
+            latlon, why = bf.parse_geo(cell)
+            self.assertIsNone(latlon, cell)
+            self.assertIn("blank", why)
 
     def test_none_for_prose(self):
         for cell in ("TBD", "see notes", "37.7749", "37.7749, -122.4194, 0"):
-            self.assertIsNone(bf.parse_geo(cell), cell)
+            latlon, why = bf.parse_geo(cell)
+            self.assertIsNone(latlon, cell)
+            self.assertIn("not a coordinate pair", why)
 
     def test_none_when_out_of_range(self):
         """A swapped pair for a high-latitude city (e.g. "24.9384, 60.1699"
         written the wrong way round) is in range and can't be caught here, but a
         genuinely impossible value must not become a dot."""
         for cell in ("91, 0", "-91, 0", "0, 181", "0, -181"):
-            self.assertIsNone(bf.parse_geo(cell), cell)
+            self.assertIsNone(self.geo(cell), cell)
+
+    def test_an_out_of_range_latitude_names_transposition(self):
+        """The likeliest cause, and the one the sheet's owner can act on —
+        distinct from "the cell is blank", which needs a different fix."""
+        latlon, why = bf.parse_geo("121.4737, 31.2304")
+        self.assertIsNone(latlon)
+        self.assertIn("transposed", why)
+
+    def test_null_island_is_rejected(self):
+        """0, 0 is in range and parses cleanly, but it is overwhelmingly a
+        failed geocode rather than a chapter in the Atlantic."""
+        latlon, why = bf.parse_geo("0, 0")
+        self.assertIsNone(latlon)
+        self.assertIn("failed geocode", why)
 
 
 class TestFolderIdFromUrl(unittest.TestCase):
@@ -71,8 +171,22 @@ class TestFolderIdFromUrl(unittest.TestCase):
 
 
 class TestDriftPx(unittest.TestCase):
+    def test_the_emu_per_pixel_scale_is_what_we_think(self):
+        """Asserted against an independent literal, not derived from the module.
+
+        Every other test here builds its inputs by multiplying EMU_PER_PX_*, so
+        a wrong scale would cancel out and pass. It would not cancel out in
+        production: doubling it silently doubles the effective --tolerance, and
+        genuinely misplaced dots start reporting "already correct"."""
+        self.assertAlmostEqual(bf.EMU_PER_PX_X, 4804.06, places=1)
+        self.assertAlmostEqual(bf.EMU_PER_PX_Y, 4804.06, places=1)
+
     def test_zero_when_identical(self):
         self.assertEqual(bf.drift_px((100, 200), (100, 200)), 0.0)
+
+    def test_a_literal_emu_step_reads_as_the_expected_pixels(self):
+        """A fixed EMU offset, not one computed from the constant under test."""
+        self.assertAlmostEqual(bf.drift_px((48041, 0), (0, 0)), 10.0, places=1)
 
     def test_one_pixel_step_reads_as_one_pixel(self):
         target = cc.marker_offsets(*SF)[0]
@@ -91,53 +205,65 @@ class TestReadChapterCoords(unittest.TestCase):
             return bf.read_chapter_coords()
 
     def test_keys_by_drive_folder_id(self):
-        coords, bad, _ = self.read(sheet(
-            ("San Francisco", URL % "fid1", "37.7749, -122.4194"),
-            ("Tokyo", URL % "fid2", "35.6762, 139.6503")))
-        self.assertEqual(bad, [])
-        self.assertEqual(coords["fid1"], ("San Francisco", 37.7749, -122.4194))
-        self.assertEqual(coords["fid2"], ("Tokyo", 35.6762, 139.6503))
+        s = self.read(sheet(row("San Francisco", "fid1", "37.7749, -122.4194"),
+                            row("Tokyo", "fid2", "35.6762, 139.6503")))
+        self.assertEqual(s.bad_rows, [])
+        self.assertEqual(s.by_folder["fid1"].city, "San Francisco")
+        self.assertEqual(s.by_folder["fid1"].latlon, SF)
+        self.assertEqual(s.by_folder["fid2"].latlon, (35.6762, 139.6503))
 
     def test_columns_are_found_by_header_name_not_position(self):
         """The tab is a website feed and has been restructured before; a column
         reorder must move the reads with it."""
-        coords, _, _ = self.read(sheet(
+        s = self.read(sheet(
             ("37.7749, -122.4194", "San Francisco", "ignored", URL % "fid1"),
             headers=[bf.COL_GEO, bf.COL_CITY, "Summary", bf.COL_FOLDER]))
-        self.assertEqual(coords["fid1"], ("San Francisco", 37.7749, -122.4194))
+        self.assertEqual(s.by_folder["fid1"].latlon, SF)
 
     def test_row_without_a_folder_link_is_reported_not_guessed(self):
-        coords, bad, _ = self.read(sheet(("Lagos", "", "6.5244, 3.3792")))
-        self.assertEqual(coords, {})
-        self.assertEqual(bad, [("Lagos", "no %s link" % bf.COL_FOLDER)])
+        s = self.read(sheet(row("Lagos", None, "6.5244, 3.3792")))
+        self.assertEqual(s.by_folder, {})
+        self.assertEqual([(r.city, r.why) for r in s.bad_rows],
+                         [("Lagos", "no %s link" % bf.COL_FOLDER)])
+        self.assertEqual(s.unusable, {},
+                         "no folder id means no folder can be attributed")
 
-    def test_row_without_usable_coordinates_is_reported(self):
-        coords, bad, unusable = self.read(sheet(("Lagos", URL % "fid1", "TBD")))
-        self.assertEqual(coords, {})
-        self.assertEqual(bad, [("Lagos", "no usable %s" % bf.COL_GEO)])
-        # Keyed by folder id so the sweep can tell this folder apart from one
-        # the sheet genuinely says nothing about.
-        self.assertEqual(unusable,
-                         {"fid1": ("Lagos", "no usable %s" % bf.COL_GEO)})
+    def test_row_without_usable_coordinates_is_keyed_by_its_folder(self):
+        """This is the whole reason `unusable` exists: without it the sweep
+        reports "no row links to this folder" about a row sitting right there."""
+        s = self.read(sheet(row("Lagos", "fid1", "TBD")))
+        self.assertEqual(s.by_folder, {})
+        self.assertEqual(s.unusable["fid1"].city, "Lagos")
+        self.assertIn("not a coordinate pair", s.unusable["fid1"].why)
+        self.assertEqual([r.city for r in s.bad_rows], ["Lagos"])
 
-    def test_row_without_a_folder_link_is_not_in_unusable(self):
-        """No folder id means there is nothing to key on — the row is reported,
-        but no Drive folder can be attributed to it."""
-        _coords, bad, unusable = self.read(sheet(("Lagos", "", "6.5244, 3.3792")))
-        self.assertEqual(bad, [("Lagos", "no %s link" % bf.COL_FOLDER)])
-        self.assertEqual(unusable, {})
+    def test_duplicate_folder_links_are_reported_not_silently_resolved(self):
+        """Two rows claiming one folder would otherwise place the dot for
+        whichever sorts later, with nothing in the output saying so."""
+        s = self.read(sheet(row("Scotland", "fid1", "55.9533, -3.1883"),
+                            row("Edinburgh", "fid1", "51.5074, -0.1278")))
+        self.assertEqual(s.by_folder["fid1"].city, "Scotland", "first row wins")
+        dupes = [r for r in s.bad_rows if "duplicate" in r.why]
+        self.assertEqual([r.city for r in dupes], ["Edinburgh"])
+
+    def test_a_usable_row_beats_an_unusable_one_for_the_same_folder(self):
+        s = self.read(sheet(row("Tokyo", "fid1", "TBD"),
+                            row("Tokyo", "fid1", "35.6762, 139.6503")))
+        self.assertEqual(s.by_folder["fid1"].latlon, (35.6762, 139.6503))
+        self.assertNotIn("fid1", s.unusable)
 
     def test_blank_city_rows_are_ignored_silently(self):
         """Trailing blank rows are normal on a sheet — they are not findings."""
-        coords, bad, unusable = self.read(sheet(("", "", ""), ("  ", "", "")))
-        self.assertEqual((coords, bad, unusable), ({}, [], {}))
+        s = self.read(sheet(("", "", ""), ("  ", "", "")))
+        self.assertEqual((s.by_folder, s.bad_rows, s.unusable), ({}, [], {}))
 
     def test_short_rows_do_not_raise(self):
         """Sheets truncates trailing empty cells, so a row can be shorter than
         the header."""
-        coords, bad, _ = self.read(sheet(("Lagos",)))
-        self.assertEqual(coords, {})
-        self.assertEqual(bad, [("Lagos", "no %s link" % bf.COL_FOLDER)])
+        s = self.read(sheet(("Lagos",)))
+        self.assertEqual(s.by_folder, {})
+        self.assertEqual([r.why for r in s.bad_rows],
+                         ["no %s link" % bf.COL_FOLDER])
 
     def test_aborts_when_a_column_is_missing(self):
         with self.assertRaises(SystemExit) as cm:
@@ -152,22 +278,35 @@ class TestReadChapterCoords(unittest.TestCase):
 
 
 class TestChapterFolders(unittest.TestCase):
-    KIDS = [
-        {"id": "f1", "name": "Tokyo", "mimeType": cc.FOLDER},
-        {"id": "f2", "name": "Amsterdam", "mimeType": cc.FOLDER},
-        {"id": "f3", "name": "TemplateCity", "mimeType": cc.FOLDER},
-        {"id": "f4", "name": "Intro to AAIF", "mimeType": cc.PPTX},
-    ]
+    KIDS = [folder("f1", "Tokyo"), folder("f2", "Scotland"),
+            folder("f3", "TemplateCity"),
+            {"id": "f4", "name": "Intro to AAIF", "mimeType": cc.PPTX}]
 
-    def folders(self, only_city=None):
-        with mock.patch.object(cc, "list_children", return_value=self.KIDS):
-            return bf.chapter_folders(only_city)
+    def sheet_for(self):
+        return bf.Sheet(
+            by_folder={"f2": bf.Row("Edinburgh", "f2", (55.95, -3.19), None)},
+            bad_rows=[], unusable={})
+
+    def folders(self, only_city=None, kids=None):
+        with mock.patch.object(cc, "list_children",
+                               return_value=self.KIDS if kids is None else kids):
+            out, _ = quiet(bf.chapter_folders, self.sheet_for(), only_city)
+            return out
 
     def test_skips_the_template_and_non_folders(self):
-        self.assertEqual([f["name"] for f in self.folders()], ["Amsterdam", "Tokyo"])
+        self.assertEqual([f["name"] for f in self.folders()], ["Scotland", "Tokyo"])
 
-    def test_city_filter_selects_one(self):
+    def test_city_filter_selects_by_folder_name(self):
         self.assertEqual([f["id"] for f in self.folders("Tokyo")], ["f1"])
+
+    def test_city_filter_selects_by_the_sheets_city(self):
+        """A folder's name can lag its chapter's city. Matching only the folder
+        name would make `--city Edinburgh` abort on the folder still called
+        "Scotland" — the exact mismatch the sheet join exists to bridge."""
+        self.assertEqual([f["id"] for f in self.folders("Edinburgh")], ["f2"])
+
+    def test_city_filter_is_case_insensitive(self):
+        self.assertEqual([f["id"] for f in self.folders("tokyo")], ["f1"])
 
     def test_city_filter_aborts_on_an_unknown_name(self):
         with self.assertRaises(SystemExit):
@@ -176,6 +315,15 @@ class TestChapterFolders(unittest.TestCase):
     def test_city_filter_cannot_select_the_template(self):
         with self.assertRaises(SystemExit):
             self.folders("TemplateCity")
+
+    def test_warns_when_the_template_folder_is_absent(self):
+        """A renamed template is no longer protected by name, and rewriting it
+        would redefine LABEL_DX/LABEL_DY for every future chapter."""
+        kids = [folder("f1", "Tokyo")]
+        with mock.patch.object(cc, "list_children", return_value=kids):
+            _out, printed = quiet(bf.chapter_folders, self.sheet_for(), None)
+        self.assertIn("WARNING", printed)
+        self.assertIn("TemplateCity", printed)
 
 
 class TestFindDeck(unittest.TestCase):
@@ -188,18 +336,20 @@ class TestFindDeck(unittest.TestCase):
             "chapter": [{"id": "sub", "name": "Event Templates (Copy for Each Event)",
                          "mimeType": cc.FOLDER}],
             "sub": [{"id": "deck", "name": "Slides.pptx", "mimeType": cc.PPTX}],
-        }), "deck")
+        }), ("deck", None))
 
     def test_finds_the_deck_at_the_top_level(self):
         self.assertEqual(self.find({
             "chapter": [{"id": "deck", "name": "Slides.pptx", "mimeType": cc.PPTX}],
-        }), "deck")
+        }), ("deck", None))
 
     def test_none_when_the_deck_was_never_cloned(self):
-        self.assertIsNone(self.find({
+        deck, why = self.find({
             "chapter": [{"id": "sub", "name": "Banners", "mimeType": cc.FOLDER}],
             "sub": [{"id": "x", "name": "Square Logo.pptx", "mimeType": cc.PPTX}],
-        }))
+        })
+        self.assertIsNone(deck)
+        self.assertIn("no Slides.pptx", why)
 
     def test_ignores_a_google_slides_file_of_the_same_name(self):
         """Only a stored .pptx can be byte-rewritten; a native Slides file of the
@@ -207,7 +357,18 @@ class TestFindDeck(unittest.TestCase):
         self.assertIsNone(self.find({
             "chapter": [{"id": "g", "name": "Slides.pptx",
                          "mimeType": "application/vnd.google-apps.presentation"}],
-        }))
+        })[0])
+
+    def test_two_copies_are_reported_not_arbitrarily_picked(self):
+        """Rewriting one of two decks and reporting success would leave the copy
+        people actually present from untouched, with nothing hinting it exists."""
+        deck, why = self.find({
+            "chapter": [{"id": "d1", "name": "Slides.pptx", "mimeType": cc.PPTX},
+                        {"id": "sub", "name": "Event Templates", "mimeType": cc.FOLDER}],
+            "sub": [{"id": "d2", "name": "Slides.pptx", "mimeType": cc.PPTX}],
+        })
+        self.assertIsNone(deck)
+        self.assertIn("2 copies", why)
 
 
 class TestProcess(unittest.TestCase):
@@ -215,7 +376,8 @@ class TestProcess(unittest.TestCase):
 
     def setUp(self):
         self.uploads, self.moves = [], []
-        self.current = cc.marker_offsets(*SF)[0]     # default: already correct
+        dot, label = cc.marker_offsets(*SF)
+        self.current = (dot, label)          # default: already correct
         self.tmpdir = None
 
     def run_process(self, latlon=SF, write=False, tolerance=1.0):
@@ -223,13 +385,14 @@ class TestProcess(unittest.TestCase):
         seen = {}
 
         def fake_download(_fid, out):
-            with open(out, "wb") as f:
-                f.write(b"deck")
+            with zipfile.ZipFile(out, "w") as z:
+                z.writestr("x", "y")         # a real zip: process() checks
             seen["path"] = out
 
+        reader = ((self.current, None) if self.current
+                  else (None, "slide 5 has no green marker shapes"))
         with mock.patch.object(cc, "gws_download", fake_download), \
-             mock.patch.object(cc, "read_marker_offsets",
-                               lambda _p: (self.current, (0, 0)) if self.current else None), \
+             mock.patch.object(cc, "read_marker_offsets", lambda _p: reader), \
              mock.patch.object(cc, "reposition_map_marker",
                                lambda p, la, lo: self.moves.append((p, la, lo))), \
              mock.patch.object(cc, "gws_upload",
@@ -242,6 +405,14 @@ class TestProcess(unittest.TestCase):
         if self.tmpdir:
             shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    def nudge_dot(self, dx):
+        dot, label = self.current
+        self.current = ((dot[0] + dx, dot[1]), label)
+
+    def nudge_label(self, dx):
+        dot, label = self.current
+        self.current = (dot, (label[0] + dx, label[1]))
+
     def test_already_correct_deck_is_left_alone_even_with_write(self):
         status, drift = self.run_process(write=True)
         self.assertEqual(status, "ok")
@@ -251,27 +422,71 @@ class TestProcess(unittest.TestCase):
     def test_sub_pixel_drift_is_within_tolerance(self):
         """A dot placed from a slightly different geocode rounds to a few EMU —
         invisible, and re-uploading 80 decks for it would be pure churn."""
-        self.current = (self.current[0] + 40, self.current[1] + 40)
+        self.nudge_dot(40)
         self.assertEqual(self.run_process(write=True)[0], "ok")
         self.assertEqual(self.uploads, [])
 
+    def test_just_inside_the_tolerance_is_left_alone(self):
+        self.nudge_dot(round(0.9 * bf.EMU_PER_PX_X))
+        self.assertEqual(self.run_process(write=True)[0], "ok")
+        self.assertEqual(self.uploads, [])
+
+    def test_just_outside_the_tolerance_is_moved(self):
+        """The 1 px boundary is the whole no-op guarantee; pin both sides."""
+        self.nudge_dot(round(1.1 * bf.EMU_PER_PX_X))
+        self.assertEqual(self.run_process(write=True)[0], "moved")
+        self.assertEqual(self.uploads, [("deck1", cc.PPTX)])
+
+    def test_a_dragged_label_alone_is_detected_and_repaired(self):
+        """read_marker_offsets returns both offsets and reposition rewrites both,
+        so gating on the dot would leave a hand-dragged label uncorrectable —
+        and would make a refit of LABEL_DX/LABEL_DY a silent estate-wide no-op."""
+        self.nudge_label(10 ** 6)
+        status, drift = self.run_process(write=True)
+        self.assertEqual(status, "moved")
+        self.assertGreater(drift, 1.0)
+        self.assertEqual(self.uploads, [("deck1", cc.PPTX)])
+
     def test_plan_run_never_uploads(self):
-        self.current = (self.current[0] + 10 ** 6, self.current[1])
+        self.nudge_dot(10 ** 6)
         status, drift = self.run_process(write=False)
         self.assertEqual(status, "would-move")
         self.assertGreater(drift, 1.0)
         self.assertEqual((self.moves, self.uploads), ([], []))
 
     def test_write_run_repositions_then_uploads_as_pptx(self):
-        self.current = (self.current[0] + 10 ** 6, self.current[1])
+        self.nudge_dot(10 ** 6)
         self.assertEqual(self.run_process(write=True)[0], "moved")
         self.assertEqual([(la, lo) for _p, la, lo in self.moves], [SF])
         self.assertEqual(self.uploads, [("deck1", cc.PPTX)])
 
     def test_unrecognised_slide5_is_reported_not_rewritten(self):
         self.current = None
-        self.assertEqual(self.run_process(write=True), ("unreadable", None))
+        status, why = self.run_process(write=True)
+        self.assertIsNone(status)
+        self.assertIn("no green", why)
         self.assertEqual((self.moves, self.uploads), ([], []))
+
+    def test_a_download_that_wrote_nothing_raises_naming_the_download(self):
+        """gws_download ignores stdout, so an error body at exit 0 would
+        otherwise surface as a BadZipFile blaming the OOXML code."""
+        self.tmpdir = tempfile.mkdtemp()
+        with mock.patch.object(cc, "gws_download", lambda _f, out: None):
+            with self.assertRaises(RuntimeError) as cm:
+                bf.process("deck1", SF, self.tmpdir, 1.0, False)
+        self.assertIn("wrote no file", str(cm.exception))
+
+    def test_a_download_that_is_not_a_pptx_raises_naming_the_download(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+        def html_body(_fid, out):
+            with open(out, "wb") as f:
+                f.write(b"<html>error</html>")
+
+        with mock.patch.object(cc, "gws_download", html_body):
+            with self.assertRaises(RuntimeError) as cm:
+                bf.process("deck1", SF, self.tmpdir, 1.0, False)
+        self.assertIn("not a .pptx", str(cm.exception))
 
     def test_the_downloaded_deck_is_removed_afterwards(self):
         """Chapter decks are chapter data; they must not be left on disk."""
@@ -279,20 +494,21 @@ class TestProcess(unittest.TestCase):
         self.assertFalse(os.path.exists(self.seen["path"]))
 
     def test_the_deck_is_removed_even_when_the_upload_raises(self):
-        self.current = (self.current[0] + 10 ** 6, self.current[1])
+        self.nudge_dot(10 ** 6)
         self.tmpdir = tempfile.mkdtemp()
         seen = {}
 
         def fake_download(_fid, out):
-            with open(out, "wb") as f:
-                f.write(b"deck")
+            with zipfile.ZipFile(out, "w") as z:
+                z.writestr("x", "y")
             seen["path"] = out
 
         def boom(*_a, **_k):
             raise RuntimeError("gws failed")
 
         with mock.patch.object(cc, "gws_download", fake_download), \
-             mock.patch.object(cc, "read_marker_offsets", lambda _p: (self.current, (0, 0))), \
+             mock.patch.object(cc, "read_marker_offsets",
+                               lambda _p: (self.current, None)), \
              mock.patch.object(cc, "reposition_map_marker", lambda *a: None), \
              mock.patch.object(cc, "gws_upload", boom):
             with self.assertRaises(RuntimeError):
@@ -300,38 +516,146 @@ class TestProcess(unittest.TestCase):
         self.assertFalse(os.path.exists(seen["path"]))
 
 
+class TestReRunIsANoOp(unittest.TestCase):
+    """Invariant (c), end to end on a real .pptx.
+
+    TestProcess stubs read_marker_offsets AND reposition_map_marker, so the seam
+    between them is never exercised inside process(). This drives the real pair
+    through a real fixture deck: after one --write pass, a second pass must
+    report "ok" and upload nothing."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.deck = os.path.join(self.tmpdir, "fixture.pptx")
+        make_pptx(self.deck, slide5(DOT_SP, LABEL_SP))
+        self.uploads = []
+
+    def run_once(self, latlon):
+        def fake_download(_fid, out):
+            shutil.copyfile(self.deck, out)
+
+        def fake_upload(fid, path, mime):
+            shutil.copyfile(path, self.deck)      # persist, like Drive would
+            self.uploads.append(fid)
+
+        with mock.patch.object(cc, "gws_download", fake_download), \
+             mock.patch.object(cc, "gws_upload", fake_upload):
+            return bf.process("deck1", latlon, self.tmpdir, 1.0, True)
+
+    def test_second_pass_moves_nothing(self):
+        tokyo = (35.6762, 139.6503)
+        first, drift = self.run_once(tokyo)
+        self.assertEqual(first, "moved")
+        self.assertGreater(drift, 1.0)
+        self.assertEqual(self.uploads, ["deck1"])
+
+        second, drift2 = self.run_once(tokyo)
+        self.assertEqual(second, "ok", "a re-run must be a no-op")
+        self.assertLessEqual(drift2, 1.0)
+        self.assertEqual(self.uploads, ["deck1"], "nothing re-uploaded")
+
+
+class TestMainSkipBranches(unittest.TestCase):
+    """Invariant (b): a folder the sheet cannot place is skipped, never guessed.
+
+    Replacing either branch with a fallback coordinate used to pass the whole
+    suite — the promise lived only in a docstring. These drive main() and assert
+    that the write path is never reached."""
+
+    def drive(self, sheet_obj, argv=("backfill_map_dots.py",)):
+        never = mock.patch.object(
+            cc, "reposition_map_marker",
+            side_effect=AssertionError("moved a dot without a sheet coordinate"))
+        never_up = mock.patch.object(
+            cc, "gws_upload", side_effect=AssertionError("uploaded a deck"))
+        with mock.patch.object(sys, "argv", list(argv)), \
+             mock.patch.object(bf, "read_chapter_coords", return_value=sheet_obj), \
+             mock.patch.object(bf, "chapter_folders",
+                               return_value=[folder("f1", "Tokyo")]), \
+             mock.patch.object(bf, "find_deck", return_value=("deck1", None)), \
+             mock.patch.object(cc, "gws_download", stub_download), \
+             never, never_up:
+            return quiet(bf.main)
+
+    def test_a_folder_with_no_sheet_row_is_skipped(self):
+        _out, printed = self.drive(bf.Sheet({}, [], {}))
+        self.assertIn("no sheet row", printed)
+
+    def test_a_folder_whose_row_has_no_coordinates_is_skipped(self):
+        """And is named for what it is — not reported as having no row at all,
+        which sends the reader looking for a row that is sitting right there."""
+        bad = bf.Row("Tokyo", "f1", None, "%s is blank" % bf.COL_GEO)
+        _out, printed = self.drive(bf.Sheet({}, [bad], {"f1": bad}))
+        self.assertIn("is blank", printed)
+        self.assertNotIn("no sheet row", printed)
+
+
 class TestDefaultIsReadOnly(unittest.TestCase):
+    OFF = None      # set in setUp: a dot genuinely far from target
+
+    def setUp(self):
+        dot, label = cc.marker_offsets(*SF)
+        self.OFF = ((dot[0] + 10 ** 6, dot[1]), label)
+        self.sheet = bf.Sheet({"f1": bf.Row("San Francisco", "f1", SF, None)},
+                              [], {})
+
+    def drive(self, argv, on_upload):
+        with mock.patch.object(sys, "argv", list(argv)), \
+             mock.patch.object(bf, "read_chapter_coords", return_value=self.sheet), \
+             mock.patch.object(bf, "chapter_folders",
+                               return_value=[folder("f1", "San Francisco")]), \
+             mock.patch.object(bf, "find_deck", return_value=("deck1", None)), \
+             mock.patch.object(cc, "gws_download", stub_download), \
+             mock.patch.object(cc, "read_marker_offsets", lambda _p: (self.OFF, None)), \
+             mock.patch.object(cc, "reposition_map_marker", lambda *a: None), \
+             mock.patch.object(cc, "gws_upload", on_upload):
+            return quiet(bf.main)
+
     def test_write_defaults_to_false(self):
         """Repo rule: a script that writes on its default invocation is a bug.
 
         Driven through a chapter that genuinely IS off target, so the run has
         something to write and the assertion means something."""
-        off = cc.marker_offsets(*SF)[0]
-        far = (off[0] + 10 ** 6, off[1])
+        boom = mock.Mock(side_effect=AssertionError("wrote without --write!"))
+        _out, printed = self.drive(["backfill_map_dots.py"], boom)
+        self.assertIn("WOULD move", printed)
+
+    def test_write_actually_writes(self):
+        """The mirror of the above. Without it, hardcoding the flag to False
+        makes --write a silent estate-wide no-op that the summary still reports
+        as a successful backfill — and the whole suite still passes."""
+        uploads = []
+        _out, printed = self.drive(["backfill_map_dots.py", "--write"],
+                                   lambda fid, p, mime: uploads.append(fid))
+        self.assertEqual(uploads, ["deck1"])
+        self.assertIn("moved", printed)
+
+
+class TestExitStatus(unittest.TestCase):
+    """A run that could not evaluate part of the estate must not exit 0 — a
+    cron, a wrapper, or a glance at $? would read it as a finished backfill."""
+
+    def drive(self, reader):
+        sheet_obj = bf.Sheet({"f1": bf.Row("Tokyo", "f1", SF, None)}, [], {})
         with mock.patch.object(sys, "argv", ["backfill_map_dots.py"]), \
-             mock.patch.object(bf, "read_chapter_coords",
-                               return_value=({"f1": ("San Francisco",) + SF}, [], {})), \
+             mock.patch.object(bf, "read_chapter_coords", return_value=sheet_obj), \
              mock.patch.object(bf, "chapter_folders",
-                               return_value=[{"id": "f1", "name": "San Francisco",
-                                              "mimeType": cc.FOLDER}]), \
-             mock.patch.object(bf, "find_deck", return_value="deck1"), \
-             mock.patch.object(cc, "gws_download",
-                               lambda _fid, out: open(out, "wb").close()), \
-             mock.patch.object(cc, "read_marker_offsets", lambda _p: (far, (0, 0))), \
-             mock.patch.object(cc, "reposition_map_marker",
-                               side_effect=AssertionError("rewrote a deck!")), \
-             mock.patch.object(cc, "gws_upload", side_effect=AssertionError("wrote!")):
-            bf.main()
+                               return_value=[folder("f1", "Tokyo")]), \
+             mock.patch.object(bf, "find_deck", return_value=("deck1", None)), \
+             mock.patch.object(cc, "gws_download", stub_download), \
+             mock.patch.object(cc, "read_marker_offsets", reader):
+            return quiet(bf.main)
 
-    def test_lat_without_lon_aborts(self):
-        with mock.patch.object(sys, "argv", ["x", "--city", "Tokyo", "--lat", "1"]):
-            with self.assertRaises(SystemExit):
-                bf.main()
+    def test_an_unreadable_deck_exits_non_zero(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.drive(lambda _p: (None, "slide 5 has TWO green dots"))
+        self.assertIn("NOT backfilled", str(cm.exception))
 
-    def test_coordinate_override_requires_a_city(self):
-        with mock.patch.object(sys, "argv", ["x", "--lat", "1", "--lon", "2"]):
-            with self.assertRaises(SystemExit):
-                bf.main()
+    def test_a_clean_run_exits_zero(self):
+        dot, label = cc.marker_offsets(*SF)
+        _out, printed = self.drive(lambda _p: ((dot, label), None))
+        self.assertIn("already correct", printed)
 
 
 if __name__ == "__main__":

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -235,7 +235,9 @@ class TestReadMarkerOffsets(unittest.TestCase):
     """read_marker_offsets() is the read-side twin of marker_offsets(): the
     backfill uses it to tell an already-correct deck from one that still needs
     moving. It must agree exactly with what reposition_map_marker() writes, and
-    must return None — never a guess — on anything that isn't the template."""
+    must return a REASON — never a guess — on anything that isn't the template.
+    The reason matters: "no slide 5" and "two green dots" want different human
+    responses, and a bare None made the sweep print them identically."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -248,7 +250,7 @@ class TestReadMarkerOffsets(unittest.TestCase):
     def test_reads_the_template_offsets(self):
         make_pptx(self.path, slide5(DOT_SP, LABEL_SP, OTHER_SP))
         self.assertEqual(cc.read_marker_offsets(self.path),
-                         ((4074942, 2650779), (3649553, 2875998)))
+                         (((4074942, 2650779), (3649553, 2875998)), None))
 
     def test_round_trips_with_reposition(self):
         """What reposition writes is exactly what this reads back — the property
@@ -256,32 +258,53 @@ class TestReadMarkerOffsets(unittest.TestCase):
         make_pptx(self.path, slide5(DOT_SP, LABEL_SP, OTHER_SP))
         cc.reposition_map_marker(self.path, 35.6762, 139.6503)   # Tokyo
         self.assertEqual(cc.read_marker_offsets(self.path),
-                         cc.marker_offsets(35.6762, 139.6503))
+                         (cc.marker_offsets(35.6762, 139.6503), None))
 
     def test_tolerates_a_re_saved_self_close(self):
         """PowerPoint re-saves <a:off .../> with a space; OFF_RE allows it."""
         make_pptx(self.path, slide5(
             green_sp((10, 20), (cc.DOT_SIZE, cc.DOT_SIZE), text="", off_selfclose=" />"),
             green_sp((30, 40), (2000000, 300000), text="X", off_selfclose=" />")))
-        self.assertEqual(cc.read_marker_offsets(self.path), ((10, 20), (30, 40)))
+        self.assertEqual(cc.read_marker_offsets(self.path),
+                         (((10, 20), (30, 40)), None))
 
     def test_none_when_slide5_is_absent(self):
         make_pptx(self.path, slide_xml=None)
-        self.assertIsNone(cc.read_marker_offsets(self.path))
+        offsets, why = cc.read_marker_offsets(self.path)
+        self.assertIsNone(offsets)
+        self.assertIn("older template", why)
 
     def test_none_when_there_are_no_green_shapes(self):
         make_pptx(self.path, slide5(OTHER_SP))
-        self.assertIsNone(cc.read_marker_offsets(self.path))
+        offsets, why = cc.read_marker_offsets(self.path)
+        self.assertIsNone(offsets)
+        self.assertIn("no green", why)
 
     def test_none_when_the_label_is_missing(self):
         make_pptx(self.path, slide5(DOT_SP, OTHER_SP))
-        self.assertIsNone(cc.read_marker_offsets(self.path))
+        offsets, why = cc.read_marker_offsets(self.path)
+        self.assertIsNone(offsets)
+        self.assertIn("no label", why)
 
     def test_none_when_a_marker_is_duplicated(self):
         """Two dots means template drift. Returning either one would let the
         backfill call a deck "already correct" on the strength of a stray shape."""
         make_pptx(self.path, slide5(DOT_SP, DOT_SP, LABEL_SP))
-        self.assertIsNone(cc.read_marker_offsets(self.path))
+        offsets, why = cc.read_marker_offsets(self.path)
+        self.assertIsNone(offsets)
+        # The reason must name template drift: reposition_map_marker() RAISES on
+        # this state, so the sweep must not report it like a benign old deck.
+        self.assertIn("TWO green dots", why)
+        self.assertIn("template drift", why)
+
+    def test_multiline_shape_xml_is_still_matched(self):
+        """SP_RE carries re.S because a PowerPoint re-save can wrap <p:sp>
+        across lines. Without the flag both the read and the write side would
+        see zero markers and the whole estate would report as unreadable."""
+        make_pptx(self.path, slide5(DOT_SP, LABEL_SP).replace("><", ">\n<"))
+        offsets, why = cc.read_marker_offsets(self.path)
+        self.assertIsNone(why)
+        self.assertEqual(offsets, ((4074942, 2650779), (3649553, 2875998)))
 
 
 class TestResolveLatlon(unittest.TestCase):

--- a/skills/aaif-create-chapter/scripts/test_create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/test_create_chapter.py
@@ -231,6 +231,59 @@ class TestReposition(unittest.TestCase):
                 self.assertIn("[Content_Types].xml", z.namelist())
 
 
+class TestReadMarkerOffsets(unittest.TestCase):
+    """read_marker_offsets() is the read-side twin of marker_offsets(): the
+    backfill uses it to tell an already-correct deck from one that still needs
+    moving. It must agree exactly with what reposition_map_marker() writes, and
+    must return None — never a guess — on anything that isn't the template."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.path = os.path.join(self.tmp, "d.pptx")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_reads_the_template_offsets(self):
+        make_pptx(self.path, slide5(DOT_SP, LABEL_SP, OTHER_SP))
+        self.assertEqual(cc.read_marker_offsets(self.path),
+                         ((4074942, 2650779), (3649553, 2875998)))
+
+    def test_round_trips_with_reposition(self):
+        """What reposition writes is exactly what this reads back — the property
+        the backfill's "already correct, skip it" decision rests on."""
+        make_pptx(self.path, slide5(DOT_SP, LABEL_SP, OTHER_SP))
+        cc.reposition_map_marker(self.path, 35.6762, 139.6503)   # Tokyo
+        self.assertEqual(cc.read_marker_offsets(self.path),
+                         cc.marker_offsets(35.6762, 139.6503))
+
+    def test_tolerates_a_re_saved_self_close(self):
+        """PowerPoint re-saves <a:off .../> with a space; OFF_RE allows it."""
+        make_pptx(self.path, slide5(
+            green_sp((10, 20), (cc.DOT_SIZE, cc.DOT_SIZE), text="", off_selfclose=" />"),
+            green_sp((30, 40), (2000000, 300000), text="X", off_selfclose=" />")))
+        self.assertEqual(cc.read_marker_offsets(self.path), ((10, 20), (30, 40)))
+
+    def test_none_when_slide5_is_absent(self):
+        make_pptx(self.path, slide_xml=None)
+        self.assertIsNone(cc.read_marker_offsets(self.path))
+
+    def test_none_when_there_are_no_green_shapes(self):
+        make_pptx(self.path, slide5(OTHER_SP))
+        self.assertIsNone(cc.read_marker_offsets(self.path))
+
+    def test_none_when_the_label_is_missing(self):
+        make_pptx(self.path, slide5(DOT_SP, OTHER_SP))
+        self.assertIsNone(cc.read_marker_offsets(self.path))
+
+    def test_none_when_a_marker_is_duplicated(self):
+        """Two dots means template drift. Returning either one would let the
+        backfill call a deck "already correct" on the strength of a stray shape."""
+        make_pptx(self.path, slide5(DOT_SP, DOT_SP, LABEL_SP))
+        self.assertIsNone(cc.read_marker_offsets(self.path))
+
+
 class TestResolveLatlon(unittest.TestCase):
     def test_override_bypasses_geocoding(self):
         # Both values given -> returned verbatim, no network.


### PR DESCRIPTION
## Summary

Adds `backfill_map_dots.py`, which re-places the slide-5 "you-are-here" dot in chapter decks that already exist, plus the read-side primitive it needs.

Chapters created before 2026-08-12 got their dot from the old hand-rolled projection, which was wrong everywhere — mean 31 px out, worst 60 px, with Shanghai landing on Japan and Tokyo in the Pacific. The current Gall Stereographic fit is accurate to 0.64 px but only ever applied to *new* decks. This closes that gap and leaves behind a maintenance tool for the next refit.

## Changesets

### 1. `refactor(create-chapter): add read_marker_offsets, hoist marker regexes`
**Files:** `create_chapter.py`, `test_create_chapter.py` (+85 -5)

`reposition_map_marker()` could place a dot but nothing could read one back, so a caller sweeping the estate had no way to tell an already-correct deck from one needing a move without rewriting it. Adds `read_marker_offsets()` as the read-side twin of `marker_offsets()` and lifts the two slide-5 regexes to module scope so both sides share one definition.

Returns `None` — never a guess — when slide 5 is absent, has no green markers, or does not hold exactly one dot and one label. Tests pin the round-trip property the skip decision rests on, plus each `None` path.

### 2. `feat(create-chapter): backfill map dots in existing chapter decks`
**Files:** `backfill_map_dots.py`, `test_backfill_map_dots.py`, `SKILL.md` (+655 -3)

Walks the Chapters Drive and brings existing decks up to the current fit, importing the projection, OOXML surgery and Drive plumbing from `create_chapter.py` so there is exactly one definition of where a dot belongs.

- Coordinates come from the **Chapters & Teams** sheet's `Generated Geolocation`, joined to Drive by folder URL — not by geocoding the folder name. That is what the website feed draws, so deck and site agree by construction, and it is the only source that knows the folder still called "Scotland" is the Edinburgh chapter.
- **Read-only by default**; `--write` gates every mutation, pinned by `TestDefaultIsReadOnly`.
- A deck within `--tolerance` (default 1 px) is left alone, so a re-run is a cheap no-op and an interrupted run is safe to repeat.
- Anything unexpected is reported and skipped, never guessed at.
- Columns resolve by header name; the tab is a website feed and has been restructured before.

## Test Plan

- [x] `test_create_chapter.py` — exit 0
- [x] `test_backfill_map_dots.py` — exit 0, 39 tests across 8 classes
- [x] `PYTHONPATH=lib pytest lib/aaif_events/tests` — 210 passed, 5 subtests
- [x] `check_no_secret_args.py`, `check_workflows.py`, `test_check_workflows.py` — all OK
- [x] `pre-commit run` — all hooks pass (gitleaks, codespell, frontmatter, tooling banner)
- [x] `claude plugin validate .` — passed
- [x] **Estate verified read-only:** `backfill_map_dots.py` (plan mode) reports `80 chapter(s) checked: 80 already correct, 0 off` — confirming the claim added to `SKILL.md`

## Notes for the reviewer

Two chapters are skipped by design and both are correct:
- `Tatooine` — a test folder with no sheet row.
- `Stuttgart` — its row was added today and has no `Generated Geolocation` yet, so its dot is genuinely unplaced. Fill the geolocation, then run `--city Stuttgart --write`.

Stuttgart also surfaced a reporting bug fixed in this PR: a folder whose row exists but lacks coordinates was reported as `no row on Chapters & Teams links to this folder`, which is inaccurate. `read_chapter_coords()` now returns a third value keyed by folder id so the two cases are distinguishable, with tests for both.

_Generated using hero-skills._