### PR TITLE
feat(sync-chapters): split CRM Status into decision + "Interested in"

### DIFF
--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -1142,11 +1142,12 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_interested_in.py --write     # apply
 Five parts, per workbook (templates included):
 
 - **The column is APPENDED**, at the first free column past the last header —
-  `L` on the shipped layout — not slotted in beside `Status` where it reads
-  best. Inserting would renumber every cell ref in ~1000 rows, every
-  `dataValidation` sqref, and the Guide tab's cross-sheet formulas. Nothing
-  addresses these sheets by letter. Its `<col>` width is split out of the
-  shipped `L..S` run rather than narrowing all eight.
+  `L` on the shipped layout. Inserting it in place would renumber every cell
+  ref in ~1000 rows, every `dataValidation` sqref, and the Guide tab's
+  cross-sheet formulas; appending got the split shipped without touching any of
+  that. `migrate_column_order.py` (below) then does the insert properly. Its
+  `<col>` width is split out of the shipped `L..S` run rather than narrowing
+  all eight.
 - **Rows are backfilled from their own `Notes (CRM)`** provenance string, which
   has carried both facts all along. Nothing is invented: a row whose `Status`
   holds a role but whose note won't parse has the role **relocated** and its
@@ -1191,3 +1192,49 @@ applies, re-downloads every written workbook and prints a `Verified` line.
 Pre-edit bytes land in `<repo>/backups/crm-split-before-<stamp>/` (gitignored,
 and holding real names and emails) — **delete the directory once the write is
 confirmed good**; nothing prunes it.
+
+
+## One-shot: `Interested in` before `Status` (`migrate_column_order.py`)
+
+`migrate_interested_in.py` appended the new column at `L`. This moves it to `D`,
+immediately before `Status`, so "what they asked for" and "how far the decision
+got" are read together. Run **after** the split migration.
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_column_order.py             # report, writes nothing
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_column_order.py --city Boston
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_column_order.py --write     # apply, then verify
+```
+
+```
+before   A Full name  B Signal  C Trusted  D Status  E Notes … K What…  L Interested in
+after    A Full name  B Signal  C Trusted  D Interested in  E Status  F Notes … L What…
+```
+
+Everything carrying a column position is renumbered: every `<c r="…">` (re-sorted
+into ascending order — a row left out of order reads as a corrupt file), the
+`<cols>` width runs (expanded, mapped and re-collapsed, because they are
+**ranges** and rewriting min/max in place re-widens whatever shared a run),
+`<dimension>`, `<autoFilter>` (which shipped as `$A$1:$K$1` and never covered
+the appended column — it is widened to the real last column), every
+`dataValidation` and `conditionalFormatting` sqref, A1-style column letters
+inside cf **formulas** (the name-turns-red rule tests `$B2="Non-grata"`), and
+the Guide's `Attendees!<col>` references.
+
+- **Only `Attendees!`-prefixed refs move in the Guide.** A Guide-local `B5` is a
+  cell of the dashboard itself; without the prefix scope the Guide rewrites its
+  own layout along with the references it makes.
+- **The verify is a data check, not an "it opens" check.** Every row is
+  snapshotted **by header** before the write and compared after. A workbook whose
+  refs were renumbered inconsistently still opens, still has twelve headers, and
+  quietly shows one person's email against another's name — that fails here.
+- **The mapping is derived by rebuilding the column order as a list**, not by
+  arithmetic on "shift everything between src and dst": the arithmetic version
+  needs a different sign for a left-move than a right-move and gets one boundary
+  wrong. A chapter's own extra columns keep their relative position.
+- `sync_crm.py` is unaffected — it addresses every column by header name, so the
+  move is invisible to it. `migrate_interested_in.py` derives the Guide's target
+  formulas from the live header map for the same reason; hardcoded letters would
+  make it report three unrecognised Guide formulas on all 83 chapters forever.
+
+Idempotent — a workbook already in the target order plans nothing.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -451,15 +451,43 @@ are being onboarded (see the sharing note at the end of this section).
 |---|---|
 | `Full name` | role tab `Name` / `Full name` |
 | `Trusted/Regular` | `Yes` for an **accepted** organizer — they're on the team, not a guest to triage |
-| `Status` | the accepted role (`Organizer` / `Speaker` / `Host`); a pipeline organizer is `Prospect`, a pipeline host/speaker keeps the role status |
+| `Status` | the **decision**, mirrored from the intake: `Prospect` / `In progress` / `Interviewing` / `Tentative` / `Accepted` |
+| `Interested in` | what they **applied for**: `Organizer` / `Speaker` / `Host`, `/`-joined for someone who asked for more than one |
 | `Notes (CRM)` | provenance — `Intake: Organizer · Accepted · 2026-08-07` (every merged role and status, in priority order) |
 | `Email` | role tab `Email` — **also the dedupe key** |
+| `LinkedIn URL` | role tab `LinkedIn` |
+| `Company` | speakers `Affiliation`, hosts `Company` — organizers are not asked |
+| `Role / title` | speakers `Headline` — organizers and hosts are not asked |
+| `Technical expertise` | organizers `Technical expertise`, speakers `Areas of expertise`, hosts `Industry` |
 | `What brings you here?` | the survey answer **verbatim**, plus the role's detail (`Talk title` / `Venue name` / `Chapter / city wanted`) |
 
-**Never written:** `Signal`, `LinkedIn URL`, `Company`, `Role / title`,
-`Technical expertise`. They are absent from the mapping rather than written
-blank, so the automation cannot touch them even on a row it creates. The
-canonical list is `CRM_WRITTEN` in `sync_crm.py`, asserted by the tests.
+### `Status` and `Interested in` are two different questions
+
+Split apart on **2026-08-25**. Before that there was one `Status` column and the
+engine wrote the **role** into it, so a venue host whose intake row still said
+`Prospect` appeared in their chapter's CRM as a flat `Host` — an organizer
+scanning the list saw settled people where triage had settled nothing. Pipeline
+*organizers* were the one role spared (special-cased to `Prospect`), which is
+what made it easy to miss. `Notes (CRM)` had carried both facts correctly all
+along.
+
+- `Interested in` is a fact about the **application** and a decision never
+  changes it. Accepted in **any** role makes `Status` = `Accepted`; otherwise
+  `Status` is the intake's own pipeline value, verbatim.
+- No role word can reach `Status` and none is on its dropdown any more —
+  asserted by the tests, from `CRM_ROLE` / `CRM_LIFECYCLE` in `sync_crm.py`.
+- A workbook last touched before the split has no `Interested in` column, and
+  `sync_crm` **refuses to open it** rather than writing by column letter. Run
+  `migrate_interested_in.py --write` first (see the section at the end).
+
+**Never written:** `Signal` — the chapter's own private judgement of a person,
+which no form answer can supply. It is absent from the mapping rather than
+written blank, so the automation cannot touch it even on a row it creates. The
+canonical list is `CRM_WRITTEN` in `sync_crm.py`, asserted by the tests. (Until
+2026-08-25 the four detail columns above were also withheld, on a rule dating
+from when the Chapters folder was public-link; it is now 92 individual
+per-chapter organizer grants, and the audience for a chapter's CRM is that
+chapter's own organizers.)
 
 `What brings you here?` is the form's routing question, and the role tabs are
 filtered views that drop it — so it is read from `Form Responses` and joined back
@@ -503,11 +531,13 @@ used instead of inventing one.
 - **Never clobber a human.** A CRM cell that already has content is left alone —
   corrected spellings, hand-written notes and manually added companies all
   survive every re-run. Only genuinely blank cells are filled.
-- **`Status` is the one exception**: it is upgraded when it still holds a value
-  the automation itself wrote (`Prospect` — or its legacy spelling `New` —
-  `Organizer`, `Speaker`, `Host`). That is how a person's role is corrected
-  after re-triage — while a human's `Attended`, `Regular`, `Volunteer` or
-  `Declined` is never undone.
+- **`Status` and `Interested in` are the two exceptions**: each is upgraded
+  while it still holds a value the automation itself wrote (`AUTO_OWNED` in
+  `sync_crm.py` — for `Status`, every lifecycle value plus the legacy `New` and
+  the three pre-split role words; for `Interested in`, any `/`-joined
+  combination of the role words). That is how a re-triage reaches a chapter —
+  while a human's `Attended`, `Regular`, `Volunteer`, `Declined`, or a typed
+  `Organizer (co-lead)`, is never undone.
 - **Fixture rows are cleared, and only fixture rows.** A row is wiped **only** if
   its `Email` is at a reserved example domain (`@example.com`, `.org`, `.net`,
   `.edu`) — that is the sole gate, deliberately narrow and anchored on the `@` so
@@ -524,17 +554,18 @@ used instead of inventing one.
   first, copying row 2's per-column cell styles so a synced person looks like a
   hand-entered one. Past row 1000 new `<row>` elements are inserted in ascending
   order.
-- **The `Status` dropdown gains a `Host` value.** It shipped as
-  `New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined` with no
-  value for a venue host, so hosts had nowhere honest to land. Every workbook the
-  script opens is patched — including **TemplateCity**, or every chapter cloned
-  from it would re-inherit the gap. Both quote encodings are handled (the
-  template writes `"…"`, older workbooks write `&quot;…&quot;`), and so are the
-  post-migration lists without the legacy `New` (removed by
-  `migrate_status_prospect.py`; the unrelated `New` on the **Signal** list is
-  untouched by that migration). A workbook with
-  no Status list at all is reported, not guessed at.
-- **TemplateCity never receives people** — only the dropdown patch.
+- **The dropdowns are CHECKED here, never written.** `sync_crm` reports any
+  workbook whose `Status` or `Interested in` list is not `DV_EXPECTED` and tells
+  you to run `migrate_interested_in.py`; that script is the only thing that
+  writes them. Schema in one place, data in the other — before 2026-08-25 this
+  file patched the `Status` list in place, which made the *order* of the
+  dropdown patch and the row serializer load-bearing inside `finalize()`, and
+  getting it wrong silently threw the patch away while reporting it applied.
+  People still sync into a workbook with a stale list; the values written are
+  correct either way. The unrelated `New` on the **Signal** list is not touched
+  by anything.
+- **TemplateCity never receives people**, and is no longer opened for a patch —
+  the migration covers it, so every chapter cloned from it is born split.
 - **Rows are skipped, and reported, when**: `Status` is neither a decided-yes
   (`Accepted` / `Existing (from MLOps)`) nor a recognised pipeline status —
   `Denied` / `Inactive` / `Duplicate` and any dropdown value the allowlists do
@@ -973,7 +1004,8 @@ After any run (and after editing the engine):
   for the whole sync.
 - After a CRM `--write`, open one touched workbook and check the person's row
   reads correctly, the sample row and any hand-written notes are untouched, and
-  the `Status` cell offers `Host` in its dropdown.
+  the `Status` cell offers the decision ladder (no role words) and
+  `Interested in` offers the role list.
 - After an About `--write`, open one rewritten doc and check the Organizers list
   reads as a proper bulleted list (not renumbered off the Luma list below it),
   the rest of the doc is untouched, and the brand fonts still render.
@@ -994,6 +1026,7 @@ After any run (and after editing the engine):
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_prune_organizers.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_nightly.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_status_prospect.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_interested_in.py
   ```
 
 ## One-shot: retiring the status `New` (`migrate_status_prospect.py`)
@@ -1093,3 +1126,51 @@ be deleted — that exit code is the evidence they are waiting on.
   straight from the public form and are copied as-is. Fix them at the source with
   **`aaif-clean-data`**, then re-run — the CRM only fills blanks, so a corrected
   intake value will **not** overwrite the bad one already written. Clean first.
+
+## One-shot: splitting `Status` into decision + role (`migrate_interested_in.py`)
+
+Adds the `Interested in` column to every chapter CRM and moves the role out of
+`Status`. Written 2026-08-25. **`sync_crm.py` refuses to open a workbook that
+has not had this run**, so it goes first.
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_interested_in.py             # report, writes nothing
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_interested_in.py --city Boston
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_interested_in.py --write     # apply, then verify
+```
+
+Four parts, per workbook (templates included):
+
+- **The column is APPENDED**, at the first free column past the last header —
+  `L` on the shipped layout — not slotted in beside `Status` where it reads
+  best. Inserting would renumber every cell ref in ~1000 rows, every
+  `dataValidation` sqref, and the Guide tab's cross-sheet formulas. Nothing
+  addresses these sheets by letter. Its `<col>` width is split out of the
+  shipped `L..S` run rather than narrowing all eight.
+- **Rows are backfilled from their own `Notes (CRM)`** provenance string, which
+  has carried both facts all along. Nothing is invented: a row whose `Status`
+  holds a role but whose note won't parse has the role **relocated** and its
+  `Status` left **blank** — blank is in `AUTO_STATUS`, so the next sync fills it
+  from the live intake, whereas a guess would outrank it. A `Status` that isn't
+  a role word (`Attended`, `Regular`, `Volunteer`, `Declined`, a pipeline value,
+  or blank) is never touched, and an `Interested in` that already has content is
+  never restated.
+- **Both dropdowns are rewritten** to `sync_crm.DV_EXPECTED`. A validation whose
+  `sqref` spans several columns is **refused and reported** — rewriting it would
+  silently re-validate a neighbour (the Signal list's unrelated `New`), and
+  there's no safe way to split a merged sqref without knowing what a human meant.
+- **The Guide tab's formulas are repointed.** Two landmines: the dashboard
+  counted `COUNTIF(Attendees!D2:D1000,"Speaker")` (and `"Organizer"`), which
+  reads **0 in every chapter** the moment roles leave `Status` — moved to the
+  new column with `*…*` wildcards, since a cell can say `Organizer/Speaker`; and
+  the "Live list" `FILTER` already referenced `Attendees!L2:L`, a column that
+  did not exist on the 11-column layout, so it had been returning a blank column
+  since the columns were last renumbered. A Guide someone has edited reports the
+  miss instead of having a regex rewrite a formula it doesn't understand. Cached
+  `<v>` results are left stale; both Sheets and Excel recalculate on open.
+
+Idempotent — a second pass proposes nothing. Report is the default; `--write`
+applies, re-downloads every written workbook and prints a `Verified` line.
+Pre-edit bytes land in `<repo>/backups/crm-split-before-<stamp>/` (gitignored,
+and holding real names and emails) — **delete the directory once the write is
+confirmed good**; nothing prunes it.

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -404,11 +404,10 @@ accepted organizer's address cannot write into that person's CRM row. One gap to
 `Denied` stays in the CRM (the engine never deletes people) and shows up under
 "Already in a CRM and NOT touched" — remove that row by hand.
 
-**Keep it minimal.** Only six of the eleven columns are ever written. `Signal`,
-`LinkedIn URL`, `Company`, `Role / title` and `Technical expertise` still exist
-for an organizer to fill in by hand — the automation just doesn't push a survey's
-worth of personal detail into a folder that is still link-readable while chapters
-are being onboarded (see the sharing note at the end of this section).
+**`Signal` is the one column the automation never writes.** Eleven of the twelve
+are, including the four survey-detail columns — see the column mapping above for
+why that changed on 2026-08-25. `Signal` is the chapter's own private rating of a
+person, which no form answer can supply, so it stays hand-entered.
 
 ## The flow: report → approve → write
 
@@ -592,19 +591,31 @@ script doesn't touch is repacked byte-for-byte, and values are written as
 starting with `=` can never become a formula, so there is no RAW-vs-`USER_ENTERED`
 hazard here.
 
-**Write order is load-bearing.** `Attendees.serialize()` rewrites the sheet part
-wholesale from the element tree, so a bytes-level dropdown patch applied *before*
-it is silently discarded — and the run still reports the patch as applied. That
-is why row writes, serialization and the dropdown patch all live inside
-`finalize()`, in that order; call it, don't re-implement it.
+**Write order used to be load-bearing, and is not any more.**
+`Attendees.serialize()` rewrites the sheet part wholesale from the element tree,
+so a bytes-level edit applied *before* it is silently discarded — and the run
+still reports it as applied, which is what once shipped to a probe workbook.
+`sync_crm` no longer makes any bytes-level edit: schema belongs to
+`migrate_interested_in.py`, and `finalize()` only writes rows and serializes.
+The hazard still applies to **the migrations**, which do both — each does every
+structural edit on the element tree and only then touches the Guide part, which
+`serialize()` does not rewrite.
 
 ## Sharing: minimal by design
 
-`CRM_WRITTEN` (six columns) plus the status allowlists (`SYNC_STATUSES`,
-`PIPELINE_STATUSES` and the `SELF_SERVE_MIN` gate on pipeline organizers) are
-what keep declined applicants and everyone's survey detail out of a folder
-shared more widely than intended — and since 2026-08 a *vetting-in-progress*
-person can legitimately appear in a self-serve chapter's CRM as a `Prospect`.
+The status allowlists (`SYNC_STATUSES`, `PIPELINE_STATUSES` and the
+`SELF_SERVE_MIN` gate on pipeline organizers) are what keep **declined
+applicants** out of a folder shared more widely than intended — and since
+2026-08 a *vetting-in-progress* person can legitimately appear in a self-serve
+chapter's CRM as a `Prospect`.
+
+`CRM_WRITTEN` is **no longer part of that mitigation.** It was six columns, on
+the reasoning that the Chapters folder was link-readable; it is not — it is 92
+individual per-chapter organizer grants — and since 2026-08-25 it is eleven
+columns including LinkedIn, employer, job title and expertise. The audience for
+a chapter's CRM is that chapter's own organizers. If the folder's sharing is
+ever widened, that is now a decision about **everyone's survey detail**, not
+just about which people appear.
 **Re-check the folder's sharing before widening any of them** — they
 are the whole mitigation, and the CRM is written *before* access is narrowed
 (feed → CRM → access), so the write lands under whatever sharing exists at the
@@ -1005,7 +1016,8 @@ After any run (and after editing the engine):
 - After a CRM `--write`, open one touched workbook and check the person's row
   reads correctly, the sample row and any hand-written notes are untouched, and
   the `Status` cell offers the decision ladder (no role words), is coloured to
-  match its value, and `Interested in` offers the role list.
+  match its value, and `Interested in` sits immediately to its left and offers
+  the role list.
 - After an About `--write`, open one rewritten doc and check the Organizers list
   reads as a proper bulleted list (not renumbered off the Luma list below it),
   the rest of the doc is untouched, and the brand fonts still render.
@@ -1027,6 +1039,7 @@ After any run (and after editing the engine):
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_nightly.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_status_prospect.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_interested_in.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_column_order.py
   ```
 
 ## One-shot: retiring the status `New` (`migrate_status_prospect.py`)

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -1004,8 +1004,8 @@ After any run (and after editing the engine):
   for the whole sync.
 - After a CRM `--write`, open one touched workbook and check the person's row
   reads correctly, the sample row and any hand-written notes are untouched, and
-  the `Status` cell offers the decision ladder (no role words) and
-  `Interested in` offers the role list.
+  the `Status` cell offers the decision ladder (no role words), is coloured to
+  match its value, and `Interested in` offers the role list.
 - After an About `--write`, open one rewritten doc and check the Organizers list
   reads as a proper bulleted list (not renumbered off the Luma list below it),
   the rest of the doc is untouched, and the brand fonts still render.
@@ -1139,7 +1139,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_interested_in.py --city Boston
 python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_interested_in.py --write     # apply, then verify
 ```
 
-Four parts, per workbook (templates included):
+Five parts, per workbook (templates included):
 
 - **The column is APPENDED**, at the first free column past the last header —
   `L` on the shipped layout — not slotted in beside `Status` where it reads
@@ -1159,6 +1159,23 @@ Four parts, per workbook (templates included):
   `sqref` spans several columns is **refused and reported** — rewriting it would
   silently re-validate a neighbour (the Signal list's unrelated `New`), and
   there's no safe way to split a merged sqref without knowing what a human meant.
+- **The `Status` column gets colour rules**, so the decision reads at a glance:
+  green for `Accepted` / `Regular` / `Volunteer`, amber for `In progress` /
+  `Interviewing` / `Tentative`, red for `Declined`. `Prospect` (the commonest
+  value) and `Attended` are deliberately **left unpainted** — colouring every
+  value colours nothing. A blank `Status` is not painted either: the range is
+  `D2:D1000` and the template pre-creates 1000 empty rows, so a blank rule
+  would light up the whole column in every chapter.
+  The three `dxf` styles already in every workbook are **referenced, not
+  added** — `dxfId` is a positional index into `<dxfs>`, so appending a style
+  to some workbooks and not others silently paints the wrong colour in
+  whichever drifted. A workbook with fewer than three is refused and reported,
+  and a `Status` column someone has **already** painted is reported and left
+  alone. The block is inserted after `sheetData` and before `dataValidations`,
+  because `CT_Worksheet` fixes that order and appending to the end of the
+  worksheet makes Excel call the file corrupt.
+  (Nothing tested `Status` before this — the existing rules cover **Signal**
+  and **Trusted/Regular** only, which is why the split broke none of them.)
 - **The Guide tab's formulas are repointed.** Two landmines: the dashboard
   counted `COUNTIF(Attendees!D2:D1000,"Speaker")` (and `"Organizer"`), which
   reads **0 in every chapter** the moment roles leave `Status` — moved to the

--- a/skills/aaif-sync-chapters/scripts/migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_column_order.py
@@ -42,8 +42,9 @@ then re-downloads and re-reads every workbook and prints a Verified line.
 Pre-edit bytes are kept under <repo>/backups/ (gitignored). No member names or
 emails on stdout — counts, chapter names and column names only.
 
-Exit codes: 0 everything already ordered; 2 changes proposed (or applied);
-1 failure (including a failed verify or a skipped workbook).
+Exit codes: 0 nothing due (or a --write that applied and verified cleanly);
+2 changes proposed in report mode; 1 failure — a skipped workbook or a failed
+verify.
 
 Usage:
   python3 migrate_column_order.py                 # report only, zero writes
@@ -81,8 +82,10 @@ def move_mapping(headers, move=MOVE, before=BEFORE):
     right, and gets the boundary wrong in one of the two directions; this cannot,
     and it extends unchanged to any future move.
 
-    Columns past the last header (a chapter that added its own) keep their
-    positions relative to everything else, because they are in the list too.
+    The domain is `0 .. last header column` — a column past the last HEADER is
+    NOT in the mapping, and survives only because every consumer treats the
+    mapping as partial (`mapping.get(old, old)`). move_ranges takes the sheet's
+    new extent from the rows, not from this mapping, for exactly that reason.
     """
     src, dst = headers[move], headers[before]
     order = list(range(max(headers.values()) + 1))
@@ -127,8 +130,15 @@ def remap_formula(text, mapping, prefix=""):
     def one(m):
         body = m.group(2)
         body = _REF_RE.sub(lambda r: remap_ref(r.group(0), mapping), body)
-        # `A2:A` — the half with no row number.
-        body = re.sub(r"(:)(\$?)([A-Z]{1,3})(?![A-Z0-9])",
+        # `A2:A` — the half with no row number. The lookahead MUST exclude
+        # `$`: without it, `$L$2:$L$1000` — which the pass above has already
+        # correctly rewritten to `$D$2:$D$1000` — matches again on `:$D` (the
+        # `$` before the row number is not [A-Z0-9]) and shifts the tail a
+        # second time, yielding `$D$2:$E$1000`: a range spanning TWO columns,
+        # in a dashboard formula, with no error anywhere. Sheets writes
+        # absolute ranges routinely; the shipped template happens to use
+        # relative ones, which is the only reason the tests missed this.
+        body = re.sub(r"(:)(\$?)([A-Z]{1,3})(?![A-Z0-9$])",
                       lambda r: "%s%s%s" % (
                           r.group(1), r.group(2),
                           re.sub(r"\d+$", "",
@@ -206,7 +216,15 @@ def _collapse_cols(block):
 
 def move_ranges(att, mapping):
     """Renumber dimension, autoFilter, and every sqref + cf formula."""
-    last = max(mapping.values())
+    # The last column the SHEET actually uses, not the last one the mapping
+    # covers. move_mapping is built from the headers only, so a column holding
+    # data under a blank header cell is outside it — and taking `last` from the
+    # mapping then NARROWED <dimension> and <autoFilter> past that data.
+    # Attendees.serialize()'s explicit "never NARROW the sheet" guard cannot
+    # help: it recomputes the width from the ref this function just shrank.
+    last = max([max(mapping.values())]
+               + [col_of(c.get("r") or "") for row in att.data.iter(X + "row")
+                  for c in row.iter(X + "c")])
     dim = att.root.find(X + "dimension")
     if dim is not None and dim.get("ref"):
         ref = dim.get("ref")
@@ -221,6 +239,15 @@ def move_ranges(att, mapping):
         # rather than remapping a range that was already wrong.
         af.set("ref", "$A$1:$%s$1" % re.sub(r"\d+$", "", cell_ref(last, 1)))
     for el in att.root.iter():
+        if el.tag == X + "hyperlink" and el.get("ref"):
+            # Hyperlinks carry a position like everything else, and missing
+            # them is silent in the worst way: the link stays on the cell
+            # ADDRESS while the column that owned it slides out from under it,
+            # so a LinkedIn URL ends up attached to the Email cell. Clicking a
+            # person's email opens someone's profile. snapshot() compares cell
+            # VALUES, so the verify cannot see it. Found in review after this
+            # had already run: Dallas and Kampala had 6 such links between them.
+            el.set("ref", remap_ref(el.get("ref"), mapping))
         if el.tag == X + "conditionalFormatting" or el.tag == X + "dataValidation":
             if el.get("sqref"):
                 el.set("sqref", " ".join(remap_ref(p, mapping)
@@ -230,6 +257,33 @@ def move_ranges(att, mapping):
             # whose formula is a bare quoted literal is a cellIs value, not a
             # reference, and must be left exactly alone.
             el.text = remap_formula(el.text, mapping)
+
+
+def unmovable(att):
+    """[description] for anything on the sheet this move cannot safely renumber.
+
+    None of the 83 chapters carried any of these (verified 2026-08-26), which
+    is exactly why they must be REFUSED rather than ignored: the day one
+    appears, moving the columns out from under it is silent. `snapshot()`
+    compares cell VALUES — and a cell formula's cached <v> still holds its
+    pre-move result — so a mis-anchored merge, filter or formula sails through
+    the verify and only goes wrong when Sheets recalculates, long after the
+    backup is gone. Hyperlinks were on this list until they were handled
+    properly in move_ranges; they are what proved the class was real.
+    """
+    out = []
+    merges = sum(1 for el in att.root.iter() if el.tag == X + "mergeCell")
+    filters = sum(1 for el in att.root.iter() if el.tag == X + "filterColumn")
+    # A <f> anywhere in the grid: a chapter's own helper formula, whose column
+    # references this script does not rewrite.
+    formulas = sum(1 for row in att.data.iter(X + "row")
+                   for c in row.iter(X + "c")
+                   if c.find(X + "f") is not None)
+    for n, label in ((merges, "merged cell(s)"), (formulas, "cell formula(s)"),
+                     (filters, "autoFilter column filter(s)")):
+        if n:
+            out.append("%d %s" % (n, label))
+    return out
 
 
 def move_guide(parts, mapping):
@@ -328,6 +382,14 @@ def _run(args, workdir):
         if book is None:
             skipped.append((folder["name"], why))
             print("  %-18s SKIPPED — %s" % (folder["name"], why))
+            continue
+        blockers = unmovable(book["att"])
+        if blockers:
+            skipped.append((folder["name"],
+                            "carries %s, whose position this move cannot "
+                            "renumber — reorder by hand or extend the script"
+                            % " and ".join(blockers)))
+            print("  %-18s SKIPPED — %s" % (folder["name"], skipped[-1][1]))
             continue
         mapping = move_mapping(book["att"].headers)
         if mapping is None:

--- a/skills/aaif-sync-chapters/scripts/migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_column_order.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""One-shot: move `Interested in` to sit immediately before `Status`.
+
+migrate_interested_in.py APPENDED the new column at L, because appending is
+free and inserting is not: every cell ref in ~1000 rows, every dataValidation
+and conditionalFormatting sqref, the autoFilter, the dimension and the Guide
+tab's cross-sheet formulas all carry a column position. That was the right
+trade for getting the split shipped; it is the wrong place for the column to
+live. "What they asked for" and "how far the decision got" are read together,
+so they belong side by side.
+
+This script does the insert properly. It moves ONE column and renumbers
+everything that refers to a position:
+
+    before   A Full name  B Signal  C Trusted  D Status  E Notes … K What…  L Interested in
+    after    A Full name  B Signal  C Trusted  D Interested in  E Status  F Notes … L What…
+
+  * every <c r="…"> in every row, re-sorted into the new column order;
+  * <cols> width runs, split and renumbered (the runs are RANGES, so a naive
+    per-column rewrite silently re-widens a neighbour);
+  * <dimension>, and <autoFilter> — which shipped as $A$1:$K$1 and so never
+    covered the appended column at all; it is widened to the real last column,
+    or the filter arrows stop one short of the data;
+  * every dataValidation and conditionalFormatting sqref;
+  * A1-style column letters inside conditionalFormatting formulas (the
+    name-turns-red rule tests `$B2="Non-grata"`);
+  * the Guide tab's `Attendees!<col>` references — and ONLY those: a
+    Guide-local ref like `B5` must not move.
+
+Nothing about the DATA changes. Every value stays with its header, which is
+what the verify actually checks: the workbook is re-read after the write and
+every row is compared header-by-header against what it held before. A column
+move that quietly transposed two people's cells would pass a "does it open"
+check and fail this one.
+
+Safe to run against a workbook that is already in the target order — it plans
+nothing. Safe to run against one that never had the split: it is reported and
+skipped, since there is no column to move.
+
+House rules: the report is the default and writes nothing; --write applies,
+then re-downloads and re-reads every workbook and prints a Verified line.
+Pre-edit bytes are kept under <repo>/backups/ (gitignored). No member names or
+emails on stdout — counts, chapter names and column names only.
+
+Exit codes: 0 everything already ordered; 2 changes proposed (or applied);
+1 failure (including a failed verify or a skipped workbook).
+
+Usage:
+  python3 migrate_column_order.py                 # report only, zero writes
+  python3 migrate_column_order.py --city Boston   # scope to one chapter
+  python3 migrate_column_order.py --write         # apply, then verify
+"""
+import argparse
+import os
+import re
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sync_chapters import download, fold_city, fresh_if_unchanged, upload  # noqa: E402
+from sync_crm import (CRM_SHEET, NEW_COLUMN, X, XLSX,  # noqa: E402
+                      Attendees, backup_root, cell_ref, cleanup_workdir,
+                      col_of, find_crm, list_chapter_folders, load_parts,
+                      save_parts, sheet_part)
+
+#: The column being moved, and the one it must sit immediately before.
+MOVE, BEFORE = NEW_COLUMN, "Status"
+
+GUIDE_SHEET = "Guide"
+
+
+# ---------------------------------------------------------------------------
+# The mapping
+# ---------------------------------------------------------------------------
+def move_mapping(headers, move=MOVE, before=BEFORE):
+    """{old column index: new column index} for the move, or None if already done.
+
+    Derived by rebuilding the column ORDER as a list and re-indexing it, rather
+    than by arithmetic on "shift everything between src and dst". The arithmetic
+    version has a different sign depending on whether the column moves left or
+    right, and gets the boundary wrong in one of the two directions; this cannot,
+    and it extends unchanged to any future move.
+
+    Columns past the last header (a chapter that added its own) keep their
+    positions relative to everything else, because they are in the list too.
+    """
+    src, dst = headers[move], headers[before]
+    order = list(range(max(headers.values()) + 1))
+    order.remove(src)
+    order.insert(order.index(dst), src)
+    mapping = {old: new for new, old in enumerate(order)}
+    return None if all(o == n for o, n in mapping.items()) else mapping
+
+
+# ---------------------------------------------------------------------------
+# Reference rewriting
+# ---------------------------------------------------------------------------
+_REF_RE = re.compile(r"(\$?)([A-Z]{1,3})(\$?)(\d+)")
+
+
+def remap_ref(ref, mapping):
+    """'D2:D1000' -> 'E2:E1000'. Preserves $ anchors and the row numbers."""
+    def one(m):
+        c1, letters, c2, row = m.groups()
+        col = mapping.get(col_of(letters))
+        if col is None:
+            return m.group(0)
+        return "%s%s%s%s" % (c1, re.sub(r"\d+$", "", cell_ref(col, 1)), c2, row)
+    return _REF_RE.sub(one, ref)
+
+
+def remap_formula(text, mapping, prefix=""):
+    """Rewrite A1-style column letters in a formula.
+
+    `prefix` scopes the rewrite to cross-sheet references ("Attendees!"): on the
+    Guide tab a bare `B5` is a cell of the GUIDE and must not move, while
+    `Attendees!B2:B` must. Without the scope the dashboard's own layout would be
+    rewritten along with the references it makes.
+
+    Open-ended ranges (`Attendees!L2:L`, which the live-list FILTER uses) are
+    handled too — the trailing bare column has no row number, so it needs its
+    own pass.
+    """
+    if not prefix:
+        return _REF_RE.sub(lambda m: remap_ref(m.group(0), mapping), text)
+
+    def one(m):
+        body = m.group(2)
+        body = _REF_RE.sub(lambda r: remap_ref(r.group(0), mapping), body)
+        # `A2:A` — the half with no row number.
+        body = re.sub(r"(:)(\$?)([A-Z]{1,3})(?![A-Z0-9])",
+                      lambda r: "%s%s%s" % (
+                          r.group(1), r.group(2),
+                          re.sub(r"\d+$", "",
+                                 cell_ref(mapping.get(col_of(r.group(3)),
+                                                      col_of(r.group(3))), 1))),
+                      body)
+        return m.group(1) + body
+
+    # One reference at a time, each still carrying its sheet prefix.
+    return re.sub(r"(%s)((?:\$?[A-Z]{1,3}\$?\d+)(?::\$?[A-Z]{1,3}(?:\$?\d+)?)?)"
+                  % re.escape(prefix), one, text)
+
+
+# ---------------------------------------------------------------------------
+# Sheet surgery
+# ---------------------------------------------------------------------------
+def move_cells(att, mapping):
+    """Re-letter every <c> and re-sort each row into the new column order."""
+    for row in att.rows.values():
+        rownum = int(row.get("r"))
+        cells = list(row)
+        placed = []
+        for c in cells:
+            old = col_of(c.get("r") or "")
+            new = mapping.get(old, old)
+            c.set("r", cell_ref(new, rownum))
+            placed.append((new, c))
+            row.remove(c)
+        # Excel requires <c> in ascending column order within a <row>; a row
+        # left out of order reads as a corrupt file, not as a reordered one.
+        for _, c in sorted(placed, key=lambda p: p[0]):
+            row.append(c)
+
+
+def move_cols(att, mapping):
+    """Renumber the <cols> width runs.
+
+    Each <col> is a RANGE (min..max). A run is expanded to its individual
+    columns, mapped, then re-collapsed into contiguous runs — rewriting min/max
+    in place would be wrong the moment a moved column starts or ends a run.
+    """
+    block = att.root.find(X + "cols")
+    if block is None:
+        return
+    widths = {}                       # new index -> the <col> attrs it inherits
+    for c in list(block):
+        lo, hi = int(c.get("min")) - 1, int(c.get("max")) - 1
+        for old in range(lo, hi + 1):
+            widths[mapping.get(old, old)] = dict(c.attrib)
+        block.remove(c)
+    for new in sorted(widths):
+        attrs = widths[new]
+        attrs["min"] = attrs["max"] = str(new + 1)
+        el = block.makeelement(X + "col", attrs)
+        block.append(el)
+    _collapse_cols(block)
+
+
+def _collapse_cols(block):
+    """Merge adjacent <col> entries that carry identical formatting."""
+    kids = list(block)
+    for c in kids:
+        block.remove(c)
+    for c in kids:
+        prev = list(block)[-1] if len(block) else None
+        same = (prev is not None
+                and int(prev.get("max")) + 1 == int(c.get("min"))
+                and {k: v for k, v in prev.attrib.items() if k not in ("min", "max")}
+                == {k: v for k, v in c.attrib.items() if k not in ("min", "max")})
+        if same:
+            prev.set("max", c.get("max"))
+        else:
+            block.append(c)
+
+
+def move_ranges(att, mapping):
+    """Renumber dimension, autoFilter, and every sqref + cf formula."""
+    last = max(mapping.values())
+    dim = att.root.find(X + "dimension")
+    if dim is not None and dim.get("ref"):
+        ref = dim.get("ref")
+        start = ref.split(":")[0]
+        end = ref.split(":")[-1] if ":" in ref else ref
+        rows = re.sub(r"^\D+", "", end) or "1"
+        dim.set("ref", "%s:%s" % (start, cell_ref(last, int(rows))))
+    af = att.root.find(X + "autoFilter")
+    if af is not None and af.get("ref"):
+        # Shipped as $A$1:$K$1 — it never covered the appended column, so the
+        # filter arrows stopped one short of the data. Widen to the real end
+        # rather than remapping a range that was already wrong.
+        af.set("ref", "$A$1:$%s$1" % re.sub(r"\d+$", "", cell_ref(last, 1)))
+    for el in att.root.iter():
+        if el.tag == X + "conditionalFormatting" or el.tag == X + "dataValidation":
+            if el.get("sqref"):
+                el.set("sqref", " ".join(remap_ref(p, mapping)
+                                         for p in el.get("sqref").split()))
+        if el.tag == X + "formula" and el.text and not el.text.strip().startswith('"'):
+            # A cf rule that TESTS another column — `$B2="Non-grata"`. A rule
+            # whose formula is a bare quoted literal is a cellIs value, not a
+            # reference, and must be left exactly alone.
+            el.text = remap_formula(el.text, mapping)
+
+
+def move_guide(parts, mapping):
+    """Rewrite `Attendees!<col>` references wherever the Guide keeps them.
+
+    Both storage forms again: the sheet part for inline strings and formulas,
+    and the shared string table for the workbooks that use one.
+    """
+    changed = []
+    targets = [p for p in (sheet_part(parts, GUIDE_SHEET), "xl/sharedStrings.xml")
+               if p and p in parts]
+    for part in targets:
+        raw = parts[part].decode("utf-8", "replace")
+        out = remap_formula(raw, mapping, prefix="%s!" % CRM_SHEET)
+        if out != raw:
+            parts[part] = out.encode()
+            changed.append(part)
+    return changed
+
+
+def snapshot(att):
+    """{rownum: {header: value}} — what the workbook says, independent of layout.
+
+    This is what the move must preserve exactly. Comparing the two snapshots is
+    the only check that catches a transposition: a workbook whose columns were
+    renumbered inconsistently still opens, still has twelve headers, and quietly
+    shows one person's email against another's name.
+    """
+    return {r: {h: att.value(r, h) for h in att.headers}
+            for r in att.rows if r > 1 and att.occupied(r)}
+
+
+# ---------------------------------------------------------------------------
+# Per-workbook driver
+# ---------------------------------------------------------------------------
+def open_crm(folder, workdir):
+    crm, why = find_crm(folder["id"])
+    if crm is None:
+        return None, why
+    path = os.path.join(workdir, "%s.xlsx" % re.sub(r"[^\w.-]", "_", folder["name"]))
+    try:
+        names, parts = load_parts(download(crm["id"], path))
+        part = sheet_part(parts, CRM_SHEET)
+        if part is None:
+            return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
+        att = Attendees(parts, part)
+    except Exception as e:
+        return None, "%s: %s: %s" % (crm["name"], type(e).__name__, e)
+    return {"folder": folder, "crm": crm, "names": names, "parts": parts,
+            "part": part, "att": att, "path": path}, None
+
+
+def apply_move(book, mapping):
+    """Apply the move; return (new bytes, pre-move snapshot)."""
+    att = book["att"]
+    before = snapshot(att)
+    move_cells(att, mapping)
+    move_cols(att, mapping)
+    move_ranges(att, mapping)
+    # headers must be re-derived before serialize() sizes the dimension.
+    att.headers = {h: mapping.get(c, c) for h, c in att.headers.items()}
+    att.serialize()
+    move_guide(book["parts"], mapping)
+    return save_parts(book["names"], book["parts"]), before
+
+
+def target_order(headers):
+    """The header names in their intended left-to-right order, for the report."""
+    return [h for h, _ in sorted(headers.items(), key=lambda kv: kv[1])]
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+def run(args):
+    workdir = tempfile.mkdtemp(prefix="aaif-order-")
+    try:
+        code = _run(args, workdir)
+    finally:
+        stranded = cleanup_workdir(workdir, keep_backups=False)
+    return 1 if stranded else code
+
+
+def _run(args, workdir):
+    folders = list_chapter_folders()
+    if args.city:
+        want = fold_city(args.city)
+        folders = [f for f in folders if fold_city(f["name"]) == want]
+        if not folders:
+            sys.exit("ABORT: no chapter folder matches %r." % args.city)
+    print("Chapters: %d folder(s) in scope.\n" % len(folders))
+
+    touched, skipped = [], []
+    for folder in folders:
+        book, why = open_crm(folder, workdir)
+        if book is None:
+            skipped.append((folder["name"], why))
+            print("  %-18s SKIPPED — %s" % (folder["name"], why))
+            continue
+        mapping = move_mapping(book["att"].headers)
+        if mapping is None:
+            continue
+        print("  %-18s %s -> column %s"
+              % (folder["name"], MOVE,
+                 re.sub(r"\d+$", "", cell_ref(mapping[book["att"].headers[MOVE]], 1))))
+        touched.append({"book": book, "mapping": mapping})
+
+    if skipped:
+        print("\nChapters SKIPPED — not reordered, fix the workbook and re-run:")
+        for name, why in skipped:
+            print("  %-28s %s" % (name, why))
+    if not touched:
+        if skipped:
+            print("\nNothing due for the chapters that could be opened — but %d "
+                  "was/were SKIPPED above." % len(skipped))
+            return 1
+        print("\nNothing to do — %r already sits before %r everywhere."
+              % (MOVE, BEFORE))
+        return 0
+    if not args.write:
+        print("\n%d workbook(s) would change. Re-run with --write to apply."
+              % len(touched))
+        return 2
+
+    print("\nWriting %d workbook(s)..." % len(touched))
+    backup_dir = backup_root("crm-order-before")
+    written, changed, failed = [], [], []
+    snapshots = {}
+    for t in touched:
+        book, name = t["book"], t["book"]["folder"]["name"]
+        try:
+            with open(book["path"], "rb") as fh:
+                planned = fh.read()
+            current, drifted = fresh_if_unchanged(
+                book["crm"]["id"], os.path.join(workdir, "reread.xlsx"), planned)
+            with open(os.path.join(backup_dir, os.path.basename(book["path"])),
+                      "wb") as fh:
+                fh.write(current)
+            if drifted:
+                changed.append(name)
+                print("  SKIPPED %s — workbook changed since the plan was built; "
+                      "NOT written, re-run" % name, file=sys.stderr)
+                continue
+            raw, before = apply_move(book, t["mapping"])
+            snapshots[name] = before
+            upload(book["crm"]["id"], book["path"], raw, XLSX)
+            written.append(name)
+            print("  wrote %s (%s)" % (name, book["crm"]["name"]))
+        except Exception as e:
+            failed.append((name, str(e)))
+            print("  FAILED %s — %s" % (name, e), file=sys.stderr)
+    print("Wrote %d workbook(s); pre-edit copies kept in %s (gitignored; delete "
+          "once the write is confirmed good)" % (len(written), backup_dir))
+    if changed:
+        print("\n%d workbook(s) changed since the plan was built and were NOT "
+              "written — re-run:\n  %s" % (len(changed), ", ".join(changed)))
+
+    print("\nRe-verifying (every row compared header-by-header)...")
+    stale = []
+    for t in touched:
+        folder = t["book"]["folder"]
+        if folder["name"] not in written:
+            continue
+        book, why = open_crm(folder, os.path.join(workdir, "verify"))
+        if book is None:
+            stale.append((folder["name"], "could not re-open: %s" % why))
+            continue
+        att = book["att"]
+        order = target_order(att.headers)
+        if order.index(MOVE) + 1 != order.index(BEFORE):
+            stale.append((folder["name"], "%r is not immediately before %r (%s)"
+                          % (MOVE, BEFORE, ", ".join(order))))
+            continue
+        # The transposition check. Values are compared BY HEADER, so a workbook
+        # whose refs were renumbered inconsistently fails here even though it
+        # opens cleanly and still has twelve columns.
+        after, before = snapshot(att), snapshots.get(folder["name"], {})
+        if after != before:
+            rows = sorted(set(before) ^ set(after)) or [
+                r for r in before if before[r] != after.get(r)]
+            stale.append((folder["name"], "%d row(s) changed value across the "
+                          "move — DATA MOVED, restore from the backup" % len(rows)))
+    if failed or stale or changed:
+        if failed or stale:
+            print("VERIFY FAILED:")
+            for name, why in failed + stale:
+                print("  %s — %s" % (name, why))
+        return 1
+    print("Verified: every written workbook has %r before %r, and every row "
+          "holds exactly the values it held before." % (MOVE, BEFORE))
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Move %r to sit immediately before %r on every chapter CRM."
+                    % (MOVE, BEFORE))
+    ap.add_argument("--write", action="store_true",
+                    help="apply the move (default: report only)")
+    ap.add_argument("--city", help="limit to one chapter folder")
+    args = ap.parse_args()
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
@@ -10,7 +10,7 @@ settled nothing. Pipeline ORGANIZERS were the one role spared, because they
 were special-cased to "Prospect", which is what made the bug easy to miss.
 
 This script performs the split across every "<City> CRM.xlsx" under the
-Chapters Drive folder (the templates included), in four parts:
+Chapters Drive folder (the templates included), in five parts:
 
   1. A new `Interested in` column is APPENDED — at the first free column past
      the last header, which is L on the shipped layout. Appended, not slotted
@@ -58,8 +58,9 @@ then re-downloads and re-reads every workbook and prints a Verified line.
 Pre-edit bytes are kept under <repo>/backups/ (gitignored). No member names or
 emails on stdout — counts, chapter names and column names only.
 
-Exit codes: 0 everything already split; 2 changes proposed (or applied);
-1 failure (including a failed verify or a skipped workbook).
+Exit codes: 0 nothing due (or a --write that applied and verified cleanly);
+2 changes proposed in report mode; 1 failure — a skipped workbook, a failed
+verify, or a gap this script cannot close.
 
 Usage:
   python3 migrate_interested_in.py                 # report only, zero writes
@@ -90,8 +91,10 @@ PRE_SPLIT_HEADERS = tuple(h for h in CRM_HEADERS if h != NEW_COLUMN)
 #: Matched case-insensitively — these were typed by hand as often as written.
 ROLE_WORDS = {r.casefold(): r for r in CRM_ROLE.values()}
 
-#: Width for the new column. The shipped `<cols>` run covers L..S at 8.71,
-#: which truncates "Organizer/Speaker" to about "Organiz".
+#: Width for the new column. The shipped `<cols>` runs leave the appended
+#: column at the sheet default (8.71), which truncates "Organizer/Speaker" to
+#: about "Organiz". widen_column splits whatever run it lands in, so no column
+#: letter is assumed here.
 NEW_COL_WIDTH = "20"
 
 # The Notes (CRM) provenance string sync_crm writes:
@@ -139,9 +142,11 @@ def plan_row(interested, status, note):
         Every other value — blank, a pipeline status, or a human's "Declined" —
         is left alone, because only a role in that column is unambiguously the
         bug this script exists to undo.
-      * The note is the ONLY source for both. Where it cannot be parsed the
-        role still moves to its proper column and the status goes blank; a
-        blank invites the next sync to decide, a guess would outrank it.
+      * The note is the only source for `Status`. `Interested in` falls back
+        to the role word already sitting in `Status` when the note will not
+        parse — the role still moves to its proper column, and the status goes
+        blank rather than being guessed at; a blank invites the next sync to
+        decide, a guess would outrank it.
     """
     note_role, note_status = parse_note(note)
     status_role = ROLE_WORDS.get(clean_text(status).casefold())
@@ -229,18 +234,35 @@ def widen_column(att, col):
 
 
 def dv_plan(att):
-    """[(header, current list or None)] for each dropdown that is not right yet."""
-    out = []
+    """([(header, current)] due, [header] blocked) for the two dropdowns.
+
+    `blocked` is a column whose validation spans several columns — rewriting it
+    would silently re-validate a neighbour (the Signal list's unrelated "New"),
+    and there is no safe way to split a merged sqref without knowing what a
+    human meant. apply_dropdowns refuses those.
+
+    Splitting the two is not cosmetic. `blocked` used to come back in the same
+    list as `due`, so `plan()["any"]` stayed true for a workbook that had
+    already received everything it was ever going to: the verify reported
+    "1 op still pending", the run exited 1, and every later run re-downloaded,
+    re-backed-up and re-uploaded it to change nothing — for ever. The comment
+    beside the refusal already said counting one "would pin every later run to
+    a permanent failure"; this is what makes that true.
+    """
+    due, blocked = [], []
     for header, want in DV_EXPECTED.items():
         col = att.headers.get(header)
-        got = None
-        for dv in _dv_elements(att):
-            if _dv_column(dv) == col:
-                got = _dv_formula(dv)
-                break
+        if col is None:
+            due.append((header, None))
+            continue
+        if any(_dv_column(dv) is None and _covers(dv, col) for dv in _dv_elements(att)):
+            blocked.append(header)
+            continue
+        got = next((_dv_formula(dv) for dv in _dv_elements(att)
+                    if _dv_column(dv) == col), None)
         if got != want:
-            out.append((header, got))
-    return out
+            due.append((header, got))
+    return due, blocked
 
 
 def _dv_elements(att):
@@ -254,7 +276,9 @@ def _dv_column(dv):
     if not sqref or " " in sqref:
         return None
     cols = {col_of(end) for end in sqref.split(":")}
-    return cols.pop() if len(cols) == 1 else None
+    # -1 is col_of's "no column letter here". Returning it would let an
+    # unparsable sqref match a real column index and be rewritten.
+    return cols.pop() if len(cols) == 1 and -1 not in cols else None
 
 
 def _dv_formula(dv):
@@ -274,7 +298,14 @@ def apply_dropdowns(att, last_row=1000):
     """
     block = att.root.find(X + "dataValidations")
     if block is None:
-        block = ET.SubElement(att.root, X + "dataValidations")
+        # NOT ET.SubElement: that appends to the end of <worksheet>, which puts
+        # dataValidations after pageMargins/pageSetup. CT_Worksheet is a fixed
+        # sequence and Excel calls such a file corrupt — the same trap apply_cf
+        # computes an insertion point to avoid. Worse, apply_dropdowns runs
+        # FIRST, so a block appended here then becomes the anchor apply_cf
+        # searches for and drags the colour rules after pageMargins too.
+        block = ET.Element(X + "dataValidations")
+        att.root.insert(_insert_at(att, AFTER_DATA_VALIDATIONS), block)
     refused = []
     for header, want in DV_EXPECTED.items():
         col = att.headers[header]
@@ -298,9 +329,19 @@ def apply_dropdowns(att, last_row=1000):
 
 
 def _covers(dv, col):
+    """Whether a validation's range includes `col`, for the refusal check.
+
+    Deliberately INCLUSIVE of what it cannot parse: an unreadable end (-1 from
+    col_of) makes this return True, so the column is refused and reported
+    rather than rewritten under a rule nobody understood.
+    """
     sqref = (dv.get("sqref") or "").strip()
     ends = [col_of(e) for e in re.split(r"[\s:]+", sqref) if e]
-    return bool(ends) and min(ends) <= col <= max(ends)
+    if not ends:
+        return False
+    if -1 in ends:
+        return True
+    return min(ends) <= col <= max(ends)
 
 
 # ---------------------------------------------------------------------------
@@ -334,10 +375,11 @@ STATUS_DXF = {
 #: which renders as arbitrary formatting rather than as an error.
 MIN_DXFS = 3
 
-# A blank Status is deliberately NOT painted. The sqref covers D2:D1000 and the
-# template pre-creates 1000 empty rows, so a blank rule lights up the entire
-# column on every chapter that has fewer than a thousand people — i.e. all of
-# them.
+# A blank Status is deliberately NOT painted: the rule covers the whole Status
+# column and the template pre-creates 1000 empty rows, so a blank rule lights up
+# the entire column on every chapter with fewer than a thousand people — i.e.
+# all of them. (_build_cf derives the column from att.headers, so no letter is
+# assumed; migrate_column_order.py has since moved Status to E.)
 _DXF_COUNT_RE = re.compile(rb'<dxfs\b[^>]*\bcount="(\d+)"')
 
 
@@ -372,15 +414,24 @@ def _cf_signature(el):
     return (el.get("sqref"), tuple(rules))
 
 
+#: The states cf_plan can return. Named, because a magic string that is not
+#: "due" is silently skipped by `any` AND silently absent from the gap report —
+#: a fifth state added later would make a whole chapter vanish from both.
+CF_OK, CF_DUE, CF_FOREIGN, CF_NO_DXFS = "ok", "due", "foreign", "no-dxfs"
+CF_STATES = (CF_OK, CF_DUE, CF_FOREIGN, CF_NO_DXFS)
+#: Terminal states: reported, never counted as pending work.
+CF_BLOCKED = (CF_FOREIGN, CF_NO_DXFS)
+
+
 def cf_plan(att, parts):
-    """"ok" | "due" | "foreign" | "no-dxfs" for the Status colour rules.
+    """One of CF_STATES for the Status colour rules.
 
     "foreign" means a conditionalFormatting block already covers the Status
     column and is not the one this script writes — a human painted that column,
     and their rules are not ours to replace. Reported, never overwritten.
     """
     if dxf_count(parts) < MIN_DXFS:
-        return "no-dxfs"
+        return CF_NO_DXFS
     col = att.headers["Status"]
     want = _cf_signature(_build_cf(att, priority=1))
     for el in _cf_blocks(att):
@@ -389,8 +440,8 @@ def cf_plan(att, parts):
             continue
         # Compare the rules, not the priority — a later block insertion may
         # renumber priorities without changing what the rules mean.
-        return "ok" if _cf_signature(el)[1] == want[1] else "foreign"
-    return "due"
+        return CF_OK if _cf_signature(el)[1] == want[1] else CF_FOREIGN
+    return CF_DUE
 
 
 def _build_cf(att, priority, last_row=1000):
@@ -406,6 +457,23 @@ def _build_cf(att, priority, last_row=1000):
     return el
 
 
+#: Elements that must follow <dataValidations>, per the CT_Worksheet sequence.
+#: A new block is inserted before the first of these that the sheet actually
+#: has; if it has none, appending at the end is correct.
+AFTER_DATA_VALIDATIONS = ("hyperlinks", "printOptions", "pageMargins", "pageSetup",
+                          "headerFooter", "rowBreaks", "colBreaks", "drawing",
+                          "legacyDrawing", "tableParts", "extLst")
+#: ...and the same for <conditionalFormatting>, which precedes dataValidations.
+AFTER_CONDITIONAL_FORMATTING = ("dataValidations",) + AFTER_DATA_VALIDATIONS
+
+
+def _insert_at(att, after_tags):
+    """Index of the first child in `after_tags`, else the end of the element."""
+    kids = list(att.root)
+    tags = {X + t for t in after_tags}
+    return next((i for i, k in enumerate(kids) if k.tag in tags), len(kids))
+
+
 def apply_cf(att):
     """Insert the Status colour block at a schema-legal position.
 
@@ -419,12 +487,8 @@ def apply_cf(att):
     priority = max([int(r.get("priority", 0)) for el in existing for r in el]
                    + [0]) + 1
     el = _build_cf(att, priority)
-    if existing:
-        at = kids.index(existing[-1]) + 1
-    else:
-        after = [X + "dataValidations", X + "hyperlinks", X + "printOptions",
-                 X + "pageMargins", X + "pageSetup"]
-        at = next((i for i, k in enumerate(kids) if k.tag in after), len(kids))
+    at = (kids.index(existing[-1]) + 1 if existing
+          else _insert_at(att, AFTER_CONDITIONAL_FORMATTING))
     att.root.insert(at, el)
 
 
@@ -565,9 +629,10 @@ def open_crm(folder, workdir):
 def plan(book):
     """Everything due on one workbook, or None when it is already split."""
     att = book["att"]
+    dv_due, dv_blocked = dv_plan(att)
     p = {"add_column": NEW_COLUMN not in att.headers,
          "rows": plan_workbook(att),
-         "dv": dv_plan(att)}
+         "dv": dv_due, "dv_blocked": dv_blocked}
     # The new column's index is only known after add_column would run, and the
     # Guide formulas name it — so predict it the same way add_column picks it.
     p["role_col"] = (att.headers[NEW_COLUMN] if not p["add_column"]
@@ -577,8 +642,13 @@ def plan(book):
     p["guide"], p["guide_missing"] = plan_guide(
         book["parts"], dict(att.headers, **{NEW_COLUMN: p["role_col"]}))
     p["cf"] = cf_plan(att, book["parts"])
+    if p["cf"] not in CF_STATES:
+        raise ValueError("cf_plan returned %r, which is not one of %s — a new "
+                         "state must be classified as pending or terminal, or "
+                         "the chapter is silently skipped by BOTH the work "
+                         "gate and the gap report." % (p["cf"], sorted(CF_STATES)))
     p["any"] = bool(p["add_column"] or p["rows"] or p["dv"] or p["guide"]
-                    or p["cf"] == "due")
+                    or p["cf"] == CF_DUE)
     return p
 
 
@@ -591,7 +661,7 @@ def apply_plan(book, p):
         for header, value in op["sets"].items():
             att.write(op["rownum"], header, value)
     refused = apply_dropdowns(att)
-    if p["cf"] == "due":
+    if p["cf"] == CF_DUE:
         apply_cf(att)
     att.serialize()
     if p["guide"]:
@@ -605,14 +675,25 @@ def describe(p):
     if p["add_column"]:
         bits.append("+%r column" % NEW_COLUMN)
     if p["rows"]:
-        moved = sum(1 for o in p["rows"] if "Status" in o["sets"])
+        # A relocated status and a BLANKED one are different events and used to
+        # share one count. Blanking happens when a row's Status held a role but
+        # its note could not be parsed: the role moves to its proper column and
+        # no decision is invented. That is the documented policy, but an
+        # operator approving a fleet-wide write deserves to know how many
+        # people's decision state is being cleared.
+        moved = sum(1 for o in p["rows"] if o["sets"].get("Status"))
+        blanked = sum(1 for o in p["rows"]
+                      if "Status" in o["sets"] and not o["sets"]["Status"])
         bits.append("%d row(s) backfilled (%d role(s) moved out of Status)"
-                    % (len(p["rows"]), moved))
+                    % (len(p["rows"]), moved + blanked))
+        if blanked:
+            bits.append("%d Status(es) BLANKED — note unparsable, next sync decides"
+                        % blanked)
     if p["dv"]:
         bits.append("dropdown(s): %s" % ", ".join(h for h, _ in p["dv"]))
     if p["guide"]:
         bits.append("%d Guide formula(s)" % len(p["guide"]))
-    if p["cf"] == "due":
+    if p["cf"] == CF_DUE:
         bits.append("Status colour rules")
     return ", ".join(bits)
 
@@ -638,7 +719,7 @@ def _run(args, workdir):
             sys.exit("ABORT: no chapter folder matches %r." % args.city)
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
-    touched, skipped, guide_gaps, cf_gaps = [], [], [], []
+    touched, skipped, guide_gaps, cf_gaps, dv_gaps = [], [], [], [], []
     for folder in folders:
         book, why = open_crm(folder, workdir)
         if book is None:
@@ -648,22 +729,34 @@ def _run(args, workdir):
         p = plan(book)
         if p["guide_missing"]:
             guide_gaps.append((folder["name"], len(p["guide_missing"])))
-        if p["cf"] in ("foreign", "no-dxfs"):
+        if p["cf"] in CF_BLOCKED:
             cf_gaps.append((folder["name"], p["cf"]))
+        if p["dv_blocked"]:
+            dv_gaps.append((folder["name"], p["dv_blocked"]))
         if not p["any"]:
             continue
         print("  %-18s %s" % (folder["name"], describe(p)))
         touched.append({"book": book, "plan": p})
 
+    if dv_gaps:
+        print("\nDropdown(s) left alone — one validation spans several columns, so "
+              "rewriting it would re-validate a neighbour. Split the range by hand:")
+        for name, cols in dv_gaps:
+            print("  %-28s %s" % (name, ", ".join(cols)))
     if cf_gaps:
         print("\nStatus colour rules NOT written:")
         for name, why in cf_gaps:
+            # .get, not [why]: an unclassified state must not crash the report
+            # halfway through a fleet sweep, after other chapters have printed.
             print("  %-28s %s" % (name, {
-                "foreign": "the Status column already has conditional formatting "
-                           "someone else wrote — left alone",
-                "no-dxfs": "fewer than %d <dxf> styles, so the rules would "
-                           "reference a style that does not exist" % MIN_DXFS,
-            }[why]))
+                CF_FOREIGN: "the Status column already carries conditional "
+                            "formatting that does not match the rules this "
+                            "script writes — left alone (if an earlier version "
+                            "of this script painted it, the rule set has since "
+                            "changed)",
+                CF_NO_DXFS: "fewer than %d <dxf> styles, so the rules would "
+                            "reference a style that does not exist" % MIN_DXFS,
+            }.get(why, why)))
     if guide_gaps:
         print("\nGuide tab not in the shipped shape — the formula(s) below were "
               "not found and are NOT rewritten; fix by hand or they keep counting "
@@ -675,10 +768,18 @@ def _run(args, workdir):
         for name, why in skipped:
             print("  %-28s %s" % (name, why))
 
+    # The gap lists are NOT pending work — nothing this script can do will
+    # clear them — but they are also not nothing, and the last line printed is
+    # what an operator and a CI log actually read. Saying "every chapter CRM
+    # already has the split" directly under a list of chapters whose dashboards
+    # still count the wrong column is how a known problem becomes an unknown one.
+    gaps = len(guide_gaps) + len(cf_gaps) + len(dv_gaps)
     if not touched:
-        if skipped:
-            print("\nNothing due for the chapters that could be opened — but %d "
-                  "was/were SKIPPED above and are NOT split." % len(skipped))
+        if skipped or gaps:
+            print("\nNo column, row, dropdown or colour work is due — but %d "
+                  "chapter(s) above are NOT fully migrated (%d skipped, %d with "
+                  "a gap this script cannot close). Nothing here will fix them."
+                  % (len(skipped) + gaps, len(skipped), gaps))
             return 1
         print("\nNothing to do — every chapter CRM already has the split.")
         return 0
@@ -747,7 +848,12 @@ def _run(args, workdir):
             for name, why in failed + stale:
                 print("  %s — %s" % (name, why))
         return 1
-    print("Verified: a fresh read of every written workbook proposes zero changes.")
+    if gaps:
+        print("Verified: a fresh read of every written workbook proposes zero "
+              "changes — but %d chapter(s) carry a gap listed above that was "
+              "NOT written and is therefore UNVERIFIED." % gaps)
+    else:
+        print("Verified: a fresh read of every written workbook proposes zero changes.")
     return 0
 
 

--- a/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
@@ -461,10 +461,30 @@ def _both_quotings(old, new):
             (old.replace('"', "&quot;"), new.replace('"', "&quot;"))]
 
 
-def guide_edits(role_col):
+def _letter(headers, header):
+    """The column letter `header` currently occupies."""
+    return re.sub(r"\d+$", "", cell_ref(headers[header], 1))
+
+
+def guide_edits(headers):
     """[[(old, new), ...]] — one inner list of interchangeable spellings per
-    edit, given the new column's index."""
-    L = re.sub(r"\d+$", "", cell_ref(role_col, 1))
+    edit, for the layout `headers` describes.
+
+    Every letter in the REPLACEMENT is derived from the live header map, never
+    hardcoded. migrate_column_order.py moves `Interested in` from L to D and
+    shifts six other columns, so a hardcoded target would stop matching the
+    moment that ran — this script would then report three unrecognised Guide
+    formulas on all 83 chapters, forever, about a Guide that is perfectly fine.
+    The OLD text stays hardcoded because it is history: it is the one spelling
+    the shipped template ever had.
+    """
+    L = _letter(headers, NEW_COLUMN)
+    company = _letter(headers, "Company")
+    title = _letter(headers, "Role / title")
+    what = _letter(headers, "What brings you here?")
+    name = _letter(headers, "Full name")
+    signal = _letter(headers, "Signal")
+    notes = _letter(headers, "Notes (CRM)")
     return [
         # The dashboard counted the Status column, so both tiles read 0 for
         # every chapter the moment roles left it. Wildcards because a cell can
@@ -480,13 +500,14 @@ def guide_edits(role_col):
         # quote spelling to vary: the match stops before the conditions.
         [("=FILTER({Attendees!A2:A, Attendees!I2:I, Attendees!K2:K, Attendees!L2:L, "
           "Attendees!B2:B, Attendees!E2:E}",
-          "=FILTER({Attendees!A2:A, Attendees!%s2:%s, Attendees!H2:H, "
-          "Attendees!I2:I, Attendees!K2:K, Attendees!B2:B, Attendees!E2:E}"
-          % (L, L))],
+          "=FILTER({Attendees!%s2:%s, Attendees!%s2:%s, Attendees!%s2:%s, "
+          "Attendees!%s2:%s, Attendees!%s2:%s, Attendees!%s2:%s, Attendees!%s2:%s}"
+          % (name, name, L, L, company, company, title, title, what, what,
+             signal, signal, notes, notes))],
     ]
 
 
-def plan_guide(parts, role_col):
+def plan_guide(parts, headers):
     """([(part, old, new)] still to apply, [the old text of each edit not found]).
 
     Exact-match replacement, not a regex: the Guide is prose and seven
@@ -496,7 +517,7 @@ def plan_guide(parts, role_col):
     """
     raws = {p: parts[p].decode("utf-8", "replace") for p in guide_parts(parts)}
     todo, missing = [], []
-    for variants in guide_edits(role_col):
+    for variants in guide_edits(headers):
         if any(new in raw for _, new in variants for raw in raws.values()):
             continue                                   # already migrated
         hit = next(((p, old, new) for old, new in variants
@@ -551,7 +572,10 @@ def plan(book):
     # Guide formulas name it — so predict it the same way add_column picks it.
     p["role_col"] = (att.headers[NEW_COLUMN] if not p["add_column"]
                      else max(att.headers.values()) + 1)
-    p["guide"], p["guide_missing"] = plan_guide(book["parts"], p["role_col"])
+    # The header map AS IT WILL BE once add_column has run — the Guide formulas
+    # name the new column, and its index is only known after that.
+    p["guide"], p["guide_missing"] = plan_guide(
+        book["parts"], dict(att.headers, **{NEW_COLUMN: p["role_col"]}))
     p["cf"] = cf_plan(att, book["parts"])
     p["any"] = bool(p["add_column"] or p["rows"] or p["dv"] or p["guide"]
                     or p["cf"] == "due")

--- a/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""One-shot: split the chapter CRMs' `Status` column into a decision and a role.
+
+Until 2026-08-25 the Attendees tab had ONE `Status` column and sync_crm wrote
+the person's ROLE into it, taken from whichever intake role tab they came from.
+So a venue host whose intake row still read "Prospect" appeared in their
+chapter's CRM as a flat `Host`, and a speaker awaiting triage as `Speaker` — a
+chapter organizer scanning the list saw settled people where central triage had
+settled nothing. Pipeline ORGANIZERS were the one role spared, because they
+were special-cased to "Prospect", which is what made the bug easy to miss.
+
+This script performs the split across every "<City> CRM.xlsx" under the
+Chapters Drive folder (the templates included), in four parts:
+
+  1. A new `Interested in` column is APPENDED — at the first free column past
+     the last header, which is L on the shipped layout. Appended, not slotted
+     in beside Status where it reads best: inserting a column would renumber
+     every cell ref in ~1000 rows, every dataValidation sqref, and the Guide
+     tab's cross-sheet formulas. Nothing addresses these sheets by letter.
+
+  2. Every occupied row is backfilled from its own `Notes (CRM)` provenance
+     string — "Intake: Organizer/Speaker · Accepted · 2026-08-07" — which has
+     carried BOTH facts correctly all along. The role half becomes
+     `Interested in`; the status half becomes `Status`. Nothing is invented:
+     a row whose Status holds a role but whose note cannot be parsed has the
+     role RELOCATED and its Status left BLANK, because a role was never a
+     decision and this script is not entitled to guess one. Blank is in
+     sync_crm.AUTO_STATUS, so the next sync fills it from the live intake.
+
+  3. Both dropdowns are rewritten to sync_crm.DV_EXPECTED: `Status` loses
+     "Speaker" / "Organizer" / "Host" (offering them is what let the column
+     mean two things at once) and gains the pipeline ladder; the new column
+     gets the role list. sync_crm CHECKS these and reports drift; only this
+     script writes them.
+
+  4. The Guide tab's formulas are repointed. Two of them are landmines:
+       * the dashboard counts `COUNTIF(Attendees!D2:D1000,"Speaker")` and the
+         same for "Organizer" — after the split those read ZERO in every
+         chapter unless they move to the new column (with wildcards, since a
+         cell can say "Organizer/Speaker");
+       * the "Live list" FILTER formula already references `Attendees!L2:L`,
+         a column that does not exist on the 11-column layout. It has been
+         returning a blank column since the last renumbering. It is repointed
+         at the columns it plainly meant.
+     Cached <v> results next to a rewritten <f> are left stale; Sheets and
+     Excel both recalculate on open.
+
+A row a human curated is never touched: only a `Status` holding one of the
+three role words is rewritten, and an `Interested in` that already has content
+is left exactly as it is. "Attended", "Regular", "Volunteer" and "Declined" say
+something the intake does not know and are outside this script's reach.
+
+Idempotent: a workbook that already has the column, the lists and the Guide
+formulas plans zero changes.
+
+House rules: the report is the default and writes nothing; --write applies,
+then re-downloads and re-reads every workbook and prints a Verified line.
+Pre-edit bytes are kept under <repo>/backups/ (gitignored). No member names or
+emails on stdout — counts, chapter names and column names only.
+
+Exit codes: 0 everything already split; 2 changes proposed (or applied);
+1 failure (including a failed verify or a skipped workbook).
+
+Usage:
+  python3 migrate_interested_in.py                 # report only, zero writes
+  python3 migrate_interested_in.py --city Boston   # scope to one chapter
+  python3 migrate_interested_in.py --write         # apply, then verify
+"""
+import argparse
+import os
+import re
+import sys
+import tempfile
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sync_chapters import download, fold_city, fresh_if_unchanged, upload  # noqa: E402
+from sync_crm import (CRM_HEADERS, CRM_LIFECYCLE, CRM_ROLE, CRM_SHEET,  # noqa: E402
+                      DV_EXPECTED, NEW_COLUMN, SYNC_STATUSES, X, XLSX,
+                      Attendees, backup_root, cell_ref, cleanup_workdir,
+                      clean_text, col_of, find_crm, list_chapter_folders,
+                      load_parts, save_parts, set_cell, sheet_part)
+
+#: The header set a PRE-split workbook has — everything except the column this
+#: script adds. Attendees() would otherwise refuse to open one, which is
+#: correct for the sync and useless for the migration that fixes it.
+PRE_SPLIT_HEADERS = tuple(h for h in CRM_HEADERS if h != NEW_COLUMN)
+
+#: The three values that used to live in `Status` and are being relocated.
+#: Matched case-insensitively — these were typed by hand as often as written.
+ROLE_WORDS = {r.casefold(): r for r in CRM_ROLE.values()}
+
+#: Width for the new column. The shipped `<cols>` run covers L..S at 8.71,
+#: which truncates "Organizer/Speaker" to about "Organiz".
+NEW_COL_WIDTH = "20"
+
+# The Notes (CRM) provenance string sync_crm writes:
+#   "Intake: Organizer/Speaker · Accepted · 2026-08-07"
+# Anchored at the start and tolerant of the separator's surrounding spaces. The
+# date is matched but unused — it is what makes the third group unambiguous.
+NOTE_RE = re.compile(
+    r"^\s*Intake:\s*(?P<roles>[^·]+?)\s*·\s*(?P<statuses>[^·]+?)\s*·\s*(?P<date>\S+)")
+
+
+def parse_note(note):
+    """(interested, status) from a Notes (CRM) provenance string, or ("", "").
+
+    Both halves may be "/"-joined for someone who applied in several roles.
+    The status follows crm_fields()'s own rule — accepted in ANY role means
+    Accepted — so a backfilled row is byte-identical to what the sync would
+    write today, and the very next run therefore proposes nothing.
+    """
+    m = NOTE_RE.match(clean_text(note))
+    if not m:
+        return "", ""
+    roles = [ROLE_WORDS.get(r.strip().casefold())
+             for r in m.group("roles").split("/")]
+    if not all(roles):
+        return "", ""            # a role word we do not recognise: do not guess
+    raw = [s.strip() for s in m.group("statuses").split("/") if s.strip()]
+    if any(s in SYNC_STATUSES for s in raw):
+        status = "Accepted"
+    else:
+        # CRM_LIFECYCLE covers every value the intake can hold; anything else
+        # is a note a human rewrote, and yields no status rather than a wrong one.
+        mapped = [CRM_LIFECYCLE[s] for s in raw if s in CRM_LIFECYCLE]
+        status = mapped[0] if mapped else ""
+    return "/".join(roles), status
+
+
+def plan_row(interested, status, note):
+    """{header: new value} for one Attendees row — empty when nothing is due.
+
+    The three rules, in order:
+      * `Interested in` is filled only when EMPTY. Content already there is
+        either this migration's own earlier pass or a human's, and either way
+        it is not ours to restate.
+      * `Status` is rewritten only when it holds one of the three ROLE words.
+        Every other value — blank, a pipeline status, or a human's "Declined" —
+        is left alone, because only a role in that column is unambiguously the
+        bug this script exists to undo.
+      * The note is the ONLY source for both. Where it cannot be parsed the
+        role still moves to its proper column and the status goes blank; a
+        blank invites the next sync to decide, a guess would outrank it.
+    """
+    note_role, note_status = parse_note(note)
+    status_role = ROLE_WORDS.get(clean_text(status).casefold())
+    sets = {}
+    if not clean_text(interested):
+        want = note_role or status_role
+        if want:
+            sets[NEW_COLUMN] = want
+    if status_role:
+        sets["Status"] = note_status
+    return sets
+
+
+def plan_workbook(att):
+    """[{rownum, sets}] for every occupied row that needs the split applied."""
+    ops = []
+    for rownum in sorted(att.rows):
+        if rownum == 1 or not att.occupied(rownum):
+            continue
+        sets = plan_row(att.value(rownum, NEW_COLUMN) if NEW_COLUMN in att.headers
+                        else "",
+                        att.value(rownum, "Status"),
+                        att.value(rownum, "Notes (CRM)"))
+        if sets:
+            ops.append({"rownum": rownum, "sets": sets})
+    return ops
+
+
+# ---------------------------------------------------------------------------
+# Sheet surgery — all of it on the ElementTree, none of it on bytes
+# ---------------------------------------------------------------------------
+# Attendees.serialize() rewrites the sheet part wholesale from the tree, so a
+# bytes-level edit made beforehand is silently discarded. That trap cost a
+# probe workbook once already (see sync_crm.finalize); doing every edit on the
+# tree removes the ordering question instead of documenting it.
+def add_column(att):
+    """Append the new header, returning its 0-based column index.
+
+    Idempotent: a workbook that already has the column keeps its position,
+    wherever a previous pass or a human put it.
+    """
+    if NEW_COLUMN in att.headers:
+        return att.headers[NEW_COLUMN]
+    col = max(att.headers.values()) + 1
+    head = att.rows[1]
+    # Match the header row's own style rather than the sheet default, or the
+    # new column renders as plain text beside ten dark-blue banner cells.
+    style = next((c.get("s") for c in head.findall(X + "c") if c.get("s")), None)
+    set_cell(head, col, NEW_COLUMN, style)
+    att.headers[NEW_COLUMN] = col
+    return col
+
+
+def widen_column(att, col):
+    """Give the new column a readable width, splitting the shipped <cols> run.
+
+    The template declares one <col min="12" max="19" width="8.71">; narrowing
+    a shared run to a single column would silently re-width seven others, so
+    the run is split rather than edited in place.
+    """
+    cols = att.root.find(X + "cols")
+    if cols is None:
+        return
+    one = col + 1                                    # <col> is 1-based
+    for c in list(cols):
+        lo, hi = int(c.get("min")), int(c.get("max"))
+        if not lo <= one <= hi:
+            continue
+        if c.get("width") == NEW_COL_WIDTH and lo == hi == one:
+            return                                   # already split out
+        at = list(cols).index(c)
+        for new_lo, new_hi in ((lo, one - 1), (one, one), (one + 1, hi)):
+            if new_lo > new_hi:
+                continue
+            el = ET.Element(X + "col", dict(c.attrib))
+            el.set("min", str(new_lo))
+            el.set("max", str(new_hi))
+            if new_lo == one:
+                el.set("width", NEW_COL_WIDTH)
+                el.set("customWidth", "1")
+            cols.insert(at, el)
+            at += 1
+        cols.remove(c)
+        return
+
+
+def dv_plan(att):
+    """[(header, current list or None)] for each dropdown that is not right yet."""
+    out = []
+    for header, want in DV_EXPECTED.items():
+        col = att.headers.get(header)
+        got = None
+        for dv in _dv_elements(att):
+            if _dv_column(dv) == col:
+                got = _dv_formula(dv)
+                break
+        if got != want:
+            out.append((header, got))
+    return out
+
+
+def _dv_elements(att):
+    block = att.root.find(X + "dataValidations")
+    return list(block) if block is not None else []
+
+
+def _dv_column(dv):
+    """The single column a dataValidation covers, or None if it spans several."""
+    sqref = (dv.get("sqref") or "").strip()
+    if not sqref or " " in sqref:
+        return None
+    cols = {col_of(end) for end in sqref.split(":")}
+    return cols.pop() if len(cols) == 1 else None
+
+
+def _dv_formula(dv):
+    f = dv.find(X + "formula1")
+    if f is None or not f.text:
+        return None
+    return f.text.strip().strip('"')
+
+
+def apply_dropdowns(att, last_row=1000):
+    """Set both columns' lists to DV_EXPECTED, creating the block if needed.
+
+    A validation spanning several columns is left alone and reported by the
+    caller: rewriting one would silently re-validate a neighbour (the Signal
+    column's list contains an unrelated "New" that must survive), and there is
+    no safe way to split a merged sqref without knowing what a human meant.
+    """
+    block = att.root.find(X + "dataValidations")
+    if block is None:
+        block = ET.SubElement(att.root, X + "dataValidations")
+    refused = []
+    for header, want in DV_EXPECTED.items():
+        col = att.headers[header]
+        existing = [dv for dv in list(block) if _dv_column(dv) == col]
+        if any(_dv_column(dv) is None and _covers(dv, col) for dv in list(block)):
+            refused.append(header)
+            continue
+        if existing:
+            dv = existing[0]
+        else:
+            dv = ET.SubElement(block, X + "dataValidation", {
+                "sqref": "%s:%s" % (cell_ref(col, 2), cell_ref(col, last_row)),
+                "type": "list", "allowBlank": "1", "showDropDown": "0",
+                "showInputMessage": "0", "showErrorMessage": "0"})
+        f = dv.find(X + "formula1")
+        if f is None:
+            f = ET.SubElement(dv, X + "formula1")
+        f.text = '"%s"' % want
+    block.set("count", str(len(list(block))))
+    return refused
+
+
+def _covers(dv, col):
+    sqref = (dv.get("sqref") or "").strip()
+    ends = [col_of(e) for e in re.split(r"[\s:]+", sqref) if e]
+    return bool(ends) and min(ends) <= col <= max(ends)
+
+
+# ---------------------------------------------------------------------------
+# The Guide tab
+# ---------------------------------------------------------------------------
+def guide_parts(parts):
+    """The zip parts that can hold Guide content, in search order.
+
+    Two storage forms are in the estate, and only one of them is the sheet:
+    most workbooks write the Guide's prose as INLINE strings in its own part,
+    but the older ones (Austin, Dallas, Kampala, London, Tatooine as of
+    2026-08-25) put every string in the shared table. Searching only the sheet
+    part found their `<f>` formulas and none of their text.
+    """
+    out = []
+    part = sheet_part(parts, "Guide")
+    if part:
+        out.append(part)
+    if "xl/sharedStrings.xml" in parts:
+        out.append("xl/sharedStrings.xml")
+    return out
+
+
+def _both_quotings(old, new):
+    """One replacement in both spellings a workbook may use for `"`.
+
+    The same trap the dataValidation reader documents: the template writes
+    `"…"` and the older workbooks write `&quot;…&quot;`. Matching only the
+    first reported five chapters' dashboards as unrecognised while they sat
+    there still counting the Status column.
+    """
+    return [(old, new),
+            (old.replace('"', "&quot;"), new.replace('"', "&quot;"))]
+
+
+def guide_edits(role_col):
+    """[[(old, new), ...]] — one inner list of interchangeable spellings per
+    edit, given the new column's index."""
+    L = re.sub(r"\d+$", "", cell_ref(role_col, 1))
+    return [
+        # The dashboard counted the Status column, so both tiles read 0 for
+        # every chapter the moment roles left it. Wildcards because a cell can
+        # hold "Organizer/Speaker".
+        _both_quotings('<f>COUNTIF(Attendees!D2:D1000,"Speaker")</f>',
+                       '<f>COUNTIF(Attendees!%s2:%s1000,"*Speaker*")</f>' % (L, L)),
+        _both_quotings('<f>COUNTIF(Attendees!D2:D1000,"Organizer")</f>',
+                       '<f>COUNTIF(Attendees!%s2:%s1000,"*Organizer*")</f>' % (L, L)),
+        # The live-list FILTER already pointed at L, which held nothing on the
+        # 11-column layout: it has been returning one blank column since the
+        # columns were last renumbered. Repointed at what it plainly meant —
+        # who they are, what they want, where they work, why they came. No
+        # quote spelling to vary: the match stops before the conditions.
+        [("=FILTER({Attendees!A2:A, Attendees!I2:I, Attendees!K2:K, Attendees!L2:L, "
+          "Attendees!B2:B, Attendees!E2:E}",
+          "=FILTER({Attendees!A2:A, Attendees!%s2:%s, Attendees!H2:H, "
+          "Attendees!I2:I, Attendees!K2:K, Attendees!B2:B, Attendees!E2:E}"
+          % (L, L))],
+    ]
+
+
+def plan_guide(parts, role_col):
+    """([(part, old, new)] still to apply, [the old text of each edit not found]).
+
+    Exact-match replacement, not a regex: the Guide is prose and seven
+    formulas, parsed nowhere, so a workbook whose Guide someone edited reports
+    the miss instead of having a pattern rewrite something it did not
+    understand.
+    """
+    raws = {p: parts[p].decode("utf-8", "replace") for p in guide_parts(parts)}
+    todo, missing = [], []
+    for variants in guide_edits(role_col):
+        if any(new in raw for _, new in variants for raw in raws.values()):
+            continue                                   # already migrated
+        hit = next(((p, old, new) for old, new in variants
+                    for p, raw in raws.items() if old in raw), None)
+        if hit:
+            todo.append(hit)
+        else:
+            missing.append(variants[0][0])
+    return todo, missing
+
+
+def apply_guide(parts, todo):
+    for part, old, new in todo:
+        parts[part] = parts[part].decode("utf-8", "replace").replace(old, new).encode()
+
+
+# ---------------------------------------------------------------------------
+# Per-workbook driver
+# ---------------------------------------------------------------------------
+def open_crm(folder, workdir):
+    """Download a chapter's CRM and parse its Attendees tab, PRE-split-tolerant.
+
+    Mirrors sync_crm.open_crm, including its everything-is-guarded rule: a
+    truncated download raises zipfile.BadZipFile, a missing rels part KeyError,
+    and ET.ParseError is a SyntaxError, not a ValueError — catching only
+    ValueError once turned one bad workbook into a traceback that replaced the
+    whole run's summary.
+    """
+    crm, why = find_crm(folder["id"])
+    if crm is None:
+        return None, why
+    path = os.path.join(workdir, "%s.xlsx" % re.sub(r"[^\w.-]", "_", folder["name"]))
+    try:
+        names, parts = load_parts(download(crm["id"], path))
+        part = sheet_part(parts, CRM_SHEET)
+        if part is None:
+            return None, "%s has no %r sheet" % (crm["name"], CRM_SHEET)
+        att = Attendees(parts, part, require=PRE_SPLIT_HEADERS)
+    except Exception as e:
+        return None, "%s: %s: %s" % (crm["name"], type(e).__name__, e)
+    return {"folder": folder, "crm": crm, "names": names, "parts": parts,
+            "part": part, "att": att, "path": path}, None
+
+
+def plan(book):
+    """Everything due on one workbook, or None when it is already split."""
+    att = book["att"]
+    p = {"add_column": NEW_COLUMN not in att.headers,
+         "rows": plan_workbook(att),
+         "dv": dv_plan(att)}
+    # The new column's index is only known after add_column would run, and the
+    # Guide formulas name it — so predict it the same way add_column picks it.
+    p["role_col"] = (att.headers[NEW_COLUMN] if not p["add_column"]
+                     else max(att.headers.values()) + 1)
+    p["guide"], p["guide_missing"] = plan_guide(book["parts"], p["role_col"])
+    p["any"] = bool(p["add_column"] or p["rows"] or p["dv"] or p["guide"])
+    return p
+
+
+def apply_plan(book, p):
+    """Apply `plan` to the workbook and return its new bytes."""
+    att = book["att"]
+    col = add_column(att)
+    widen_column(att, col)
+    for op in p["rows"]:
+        for header, value in op["sets"].items():
+            att.write(op["rownum"], header, value)
+    refused = apply_dropdowns(att)
+    att.serialize()
+    if p["guide"]:
+        apply_guide(book["parts"], p["guide"])
+    return save_parts(book["names"], book["parts"]), refused
+
+
+def describe(p):
+    """The one-line summary of a plan, for the report."""
+    bits = []
+    if p["add_column"]:
+        bits.append("+%r column" % NEW_COLUMN)
+    if p["rows"]:
+        moved = sum(1 for o in p["rows"] if "Status" in o["sets"])
+        bits.append("%d row(s) backfilled (%d role(s) moved out of Status)"
+                    % (len(p["rows"]), moved))
+    if p["dv"]:
+        bits.append("dropdown(s): %s" % ", ".join(h for h, _ in p["dv"]))
+    if p["guide"]:
+        bits.append("%d Guide formula(s)" % len(p["guide"]))
+    return ", ".join(bits)
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+def run(args):
+    workdir = tempfile.mkdtemp(prefix="aaif-split-")
+    try:
+        code = _run(args, workdir)
+    finally:
+        stranded = cleanup_workdir(workdir, keep_backups=False)
+    return 1 if stranded else code
+
+
+def _run(args, workdir):
+    folders = list_chapter_folders()
+    if args.city:
+        want = fold_city(args.city)
+        folders = [f for f in folders if fold_city(f["name"]) == want]
+        if not folders:
+            sys.exit("ABORT: no chapter folder matches %r." % args.city)
+    print("Chapters: %d folder(s) in scope.\n" % len(folders))
+
+    touched, skipped, guide_gaps = [], [], []
+    for folder in folders:
+        book, why = open_crm(folder, workdir)
+        if book is None:
+            skipped.append((folder["name"], why))
+            print("  %-18s SKIPPED — %s" % (folder["name"], why))
+            continue
+        p = plan(book)
+        if p["guide_missing"]:
+            guide_gaps.append((folder["name"], len(p["guide_missing"])))
+        if not p["any"]:
+            continue
+        print("  %-18s %s" % (folder["name"], describe(p)))
+        touched.append({"book": book, "plan": p})
+
+    if guide_gaps:
+        print("\nGuide tab not in the shipped shape — the formula(s) below were "
+              "not found and are NOT rewritten; fix by hand or they keep counting "
+              "the old column:")
+        for name, n in guide_gaps:
+            print("  %-28s %d formula(s) unrecognised" % (name, n))
+    if skipped:
+        print("\nChapters SKIPPED — not split, fix the workbook and re-run:")
+        for name, why in skipped:
+            print("  %-28s %s" % (name, why))
+
+    if not touched:
+        if skipped:
+            print("\nNothing due for the chapters that could be opened — but %d "
+                  "was/were SKIPPED above and are NOT split." % len(skipped))
+            return 1
+        print("\nNothing to do — every chapter CRM already has the split.")
+        return 0
+    if not args.write:
+        print("\n%d workbook(s) would change. Re-run with --write to apply."
+              % len(touched))
+        return 2
+
+    print("\nWriting %d workbook(s)..." % len(touched))
+    backup_dir = backup_root("crm-split-before")
+    written, changed, failed, refusals = [], [], [], []
+    for t in touched:
+        book, name = t["book"], t["book"]["folder"]["name"]
+        try:
+            with open(book["path"], "rb") as fh:
+                planned = fh.read()
+            current, drifted = fresh_if_unchanged(
+                book["crm"]["id"], os.path.join(workdir, "reread.xlsx"), planned)
+            with open(os.path.join(backup_dir, os.path.basename(book["path"])),
+                      "wb") as fh:
+                fh.write(current)
+            if drifted:
+                changed.append(name)
+                print("  SKIPPED %s — workbook changed since the plan was built; "
+                      "NOT written, re-run" % name, file=sys.stderr)
+                continue
+            raw, refused = apply_plan(book, t["plan"])
+            if refused:
+                refusals.append((name, refused))
+            upload(book["crm"]["id"], book["path"], raw, XLSX)
+            written.append(name)
+            print("  wrote %s (%s)" % (name, book["crm"]["name"]))
+        except Exception as e:            # one bad workbook must not abandon
+            failed.append((name, str(e)))  # the other eighty
+            print("  FAILED %s — %s" % (name, e), file=sys.stderr)
+    print("Wrote %d workbook(s); pre-edit copies kept in %s (gitignored; delete "
+          "once the write is confirmed good)" % (len(written), backup_dir))
+    if refusals:
+        # A REFUSAL is still true after a perfectly successful write, so it is
+        # reported beside the verdict and never folded into it — counting it
+        # would pin every later run to a permanent failure.
+        print("\nDropdown(s) left alone — one validation spans several columns, "
+              "so rewriting it would re-validate a neighbour. Fix by hand:")
+        for name, cols in refusals:
+            print("  %-28s %s" % (name, ", ".join(cols)))
+    if changed:
+        print("\n%d workbook(s) changed since the plan was built and were NOT "
+              "written — re-run:\n  %s" % (len(changed), ", ".join(changed)))
+
+    print("\nRe-verifying...")
+    stale = []
+    for t in touched:
+        folder = t["book"]["folder"]
+        if folder["name"] not in written:
+            continue
+        book, why = open_crm(folder, os.path.join(workdir, "verify"))
+        if book is None:
+            stale.append((folder["name"], "could not re-open: %s" % why))
+            continue
+        left = plan(book)
+        if left["any"]:
+            stale.append((folder["name"], describe(left) + " still pending"))
+    if failed or stale or changed:
+        if failed or stale:
+            print("VERIFY FAILED:")
+            for name, why in failed + stale:
+                print("  %s — %s" % (name, why))
+        return 1
+    print("Verified: a fresh read of every written workbook proposes zero changes.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Split the chapter CRMs' Status column into Status + "
+                    "'%s'." % NEW_COLUMN)
+    ap.add_argument("--write", action="store_true",
+                    help="apply the migration (default: report only)")
+    ap.add_argument("--city", help="limit to one chapter folder")
+    args = ap.parse_args()
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
@@ -304,6 +304,131 @@ def _covers(dv, col):
 
 
 # ---------------------------------------------------------------------------
+# Conditional formatting on Status
+# ---------------------------------------------------------------------------
+# Every CRM ships the same three `dxf` styles, and the Signal column already
+# uses all three — so the decision ladder is painted by REFERENCING them, not
+# by adding any. Editing styles.xml across 83 workbooks to introduce a fourth
+# colour would be real surgery for no gain, and dxfId is a positional index
+# into <dxfs>: appending to one workbook and not another silently paints the
+# wrong colour in whichever one drifted.
+#
+#   0  green  bold #1B7A48 on #C6EFCE   "settled, and settled well"
+#   1  amber       #9C6500 on #FFEB9C   "in flight — someone must act"
+#   2  red    bold #9C0006 on #FFC7CE   "settled no"
+DXF_GOOD, DXF_INFLIGHT, DXF_BAD = 0, 1, 2
+
+#: Status value -> dxfId. Deliberately PARTIAL: `Prospect` is the single most
+#: common value in the column and `Attended` is a neutral fact, so neither is
+#: painted. Colouring every value colours nothing — the point is that the rows
+#: needing attention stand out from the rows that do not.
+STATUS_DXF = {
+    "Accepted": DXF_GOOD, "Regular": DXF_GOOD, "Volunteer": DXF_GOOD,
+    "In progress": DXF_INFLIGHT, "Interviewing": DXF_INFLIGHT,
+    "Tentative": DXF_INFLIGHT,
+    "Declined": DXF_BAD,
+}
+
+#: How many <dxf> entries a workbook must have for the ids above to mean what
+#: they say. Fewer and the rules would reference a style that does not exist,
+#: which renders as arbitrary formatting rather than as an error.
+MIN_DXFS = 3
+
+# A blank Status is deliberately NOT painted. The sqref covers D2:D1000 and the
+# template pre-creates 1000 empty rows, so a blank rule lights up the entire
+# column on every chapter that has fewer than a thousand people — i.e. all of
+# them.
+_DXF_COUNT_RE = re.compile(rb'<dxfs\b[^>]*\bcount="(\d+)"')
+
+
+def dxf_count(parts):
+    m = _DXF_COUNT_RE.search(parts.get("xl/styles.xml", b""))
+    return int(m.group(1)) if m else 0
+
+
+def status_cf_rules():
+    """[(value, dxfId)] in the order the rules are written.
+
+    Sorted by DV_STATUS_VALUES so the block reads down the column's own
+    dropdown, and so two runs cannot produce different orderings of the same
+    rules — which would make the idempotency check below fail forever.
+    """
+    order = {v: i for i, v in enumerate(DV_EXPECTED["Status"].split(","))}
+    return sorted(STATUS_DXF.items(), key=lambda kv: order.get(kv[0], 99))
+
+
+def _cf_blocks(att):
+    return [el for el in att.root if el.tag == X + "conditionalFormatting"]
+
+
+def _cf_signature(el):
+    """(sqref, ((value, dxfId), ...)) for one block, for comparison."""
+    rules = []
+    for r in el:
+        f = r.find(X + "formula")
+        text = (f.text or "").strip() if f is not None else ""
+        rules.append((text.strip('"').replace("&quot;", "").strip('"'),
+                      int(r.get("dxfId", -1))))
+    return (el.get("sqref"), tuple(rules))
+
+
+def cf_plan(att, parts):
+    """"ok" | "due" | "foreign" | "no-dxfs" for the Status colour rules.
+
+    "foreign" means a conditionalFormatting block already covers the Status
+    column and is not the one this script writes — a human painted that column,
+    and their rules are not ours to replace. Reported, never overwritten.
+    """
+    if dxf_count(parts) < MIN_DXFS:
+        return "no-dxfs"
+    col = att.headers["Status"]
+    want = _cf_signature(_build_cf(att, priority=1))
+    for el in _cf_blocks(att):
+        cols = {col_of(end) for end in (el.get("sqref") or "").split(":")}
+        if cols != {col}:
+            continue
+        # Compare the rules, not the priority — a later block insertion may
+        # renumber priorities without changing what the rules mean.
+        return "ok" if _cf_signature(el)[1] == want[1] else "foreign"
+    return "due"
+
+
+def _build_cf(att, priority, last_row=1000):
+    """The <conditionalFormatting> element for the Status column."""
+    col = att.headers["Status"]
+    el = ET.Element(X + "conditionalFormatting", {
+        "sqref": "%s:%s" % (cell_ref(col, 2), cell_ref(col, last_row))})
+    for i, (value, dxf) in enumerate(status_cf_rules()):
+        rule = ET.SubElement(el, X + "cfRule", {
+            "type": "cellIs", "dxfId": str(dxf),
+            "priority": str(priority + i), "operator": "equal"})
+        ET.SubElement(rule, X + "formula").text = '"%s"' % value
+    return el
+
+
+def apply_cf(att):
+    """Insert the Status colour block at a schema-legal position.
+
+    CT_Worksheet fixes the child order, and `conditionalFormatting` must come
+    AFTER sheetData and BEFORE dataValidations. Appending to the end puts it
+    after pageMargins/pageSetup and Excel reports the file as corrupt — so the
+    insertion point is computed, never assumed.
+    """
+    kids = list(att.root)
+    existing = _cf_blocks(att)
+    priority = max([int(r.get("priority", 0)) for el in existing for r in el]
+                   + [0]) + 1
+    el = _build_cf(att, priority)
+    if existing:
+        at = kids.index(existing[-1]) + 1
+    else:
+        after = [X + "dataValidations", X + "hyperlinks", X + "printOptions",
+                 X + "pageMargins", X + "pageSetup"]
+        at = next((i for i, k in enumerate(kids) if k.tag in after), len(kids))
+    att.root.insert(at, el)
+
+
+# ---------------------------------------------------------------------------
 # The Guide tab
 # ---------------------------------------------------------------------------
 def guide_parts(parts):
@@ -427,7 +552,9 @@ def plan(book):
     p["role_col"] = (att.headers[NEW_COLUMN] if not p["add_column"]
                      else max(att.headers.values()) + 1)
     p["guide"], p["guide_missing"] = plan_guide(book["parts"], p["role_col"])
-    p["any"] = bool(p["add_column"] or p["rows"] or p["dv"] or p["guide"])
+    p["cf"] = cf_plan(att, book["parts"])
+    p["any"] = bool(p["add_column"] or p["rows"] or p["dv"] or p["guide"]
+                    or p["cf"] == "due")
     return p
 
 
@@ -440,6 +567,8 @@ def apply_plan(book, p):
         for header, value in op["sets"].items():
             att.write(op["rownum"], header, value)
     refused = apply_dropdowns(att)
+    if p["cf"] == "due":
+        apply_cf(att)
     att.serialize()
     if p["guide"]:
         apply_guide(book["parts"], p["guide"])
@@ -459,6 +588,8 @@ def describe(p):
         bits.append("dropdown(s): %s" % ", ".join(h for h, _ in p["dv"]))
     if p["guide"]:
         bits.append("%d Guide formula(s)" % len(p["guide"]))
+    if p["cf"] == "due":
+        bits.append("Status colour rules")
     return ", ".join(bits)
 
 
@@ -483,7 +614,7 @@ def _run(args, workdir):
             sys.exit("ABORT: no chapter folder matches %r." % args.city)
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
-    touched, skipped, guide_gaps = [], [], []
+    touched, skipped, guide_gaps, cf_gaps = [], [], [], []
     for folder in folders:
         book, why = open_crm(folder, workdir)
         if book is None:
@@ -493,11 +624,22 @@ def _run(args, workdir):
         p = plan(book)
         if p["guide_missing"]:
             guide_gaps.append((folder["name"], len(p["guide_missing"])))
+        if p["cf"] in ("foreign", "no-dxfs"):
+            cf_gaps.append((folder["name"], p["cf"]))
         if not p["any"]:
             continue
         print("  %-18s %s" % (folder["name"], describe(p)))
         touched.append({"book": book, "plan": p})
 
+    if cf_gaps:
+        print("\nStatus colour rules NOT written:")
+        for name, why in cf_gaps:
+            print("  %-28s %s" % (name, {
+                "foreign": "the Status column already has conditional formatting "
+                           "someone else wrote — left alone",
+                "no-dxfs": "fewer than %d <dxf> styles, so the rules would "
+                           "reference a style that does not exist" % MIN_DXFS,
+            }[why]))
     if guide_gaps:
         print("\nGuide tab not in the shipped shape — the formula(s) below were "
               "not found and are NOT rewritten; fix by hand or they keep counting "

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -21,9 +21,9 @@ Who syncs (the 2026-08 organizer-selection policy):
     their own team; below the threshold, organizer approval stays with AAIF
     ops and pipeline organizers are held back and reported.
 
-A pipeline person lands as `Prospect` (organizers) or their role status
-(hosts/speakers), never as a trusted team member — Drive access still keys off
-acceptance in sync_access.py, so reaching the CRM grants nothing by itself.
+A pipeline person lands with their real intake status and never as a trusted
+team member — Drive access still keys off acceptance in sync_access.py, so
+reaching the CRM grants nothing by itself.
 
 Each chapter folder under the Chapters Drive holds one "<City> CRM.xlsx" whose
 "Attendees" tab has eleven columns. Only six are ever written (CRM_WRITTEN) —
@@ -31,15 +31,29 @@ identity, decision and interest, and nothing else:
 
     Full name           <- role tab name
     Trusted/Regular     <- "Yes" for an ACCEPTED organizer (they're on the team)
-    Status              <- Organizer / Speaker / Host — or Prospect, for a
-                           pipeline organizer in a self-serve chapter
+    Status              <- the DECISION, mirrored from the intake: Prospect /
+                           In progress / Interviewing / Tentative / Accepted
+    Interested in       <- what they APPLIED FOR: Organizer / Speaker / Host,
+                           "/"-joined for someone who asked for more than one
     Notes (CRM)         <- provenance: role, intake status, date
     Email               <- role tab email        (also the dedupe key)
+    LinkedIn URL, Company, Role / title, Technical expertise
+                        <- their survey answers, where their role's branch of
+                           the form asks (organizers get no company or title
+                           question, hosts get no title)
     What brings you here? <- the survey answer verbatim, + talk/venue/city detail
 
-Deliberately NOT written: Signal, LinkedIn URL, Company, Role / title, Technical
-expertise. They exist on the sheet for an organizer to fill in by hand; the
-automation does not push a survey's worth of personal detail into the folder.
+Split apart on 2026-08-25: `Status` used to hold the ROLE, so a host whose
+intake row said "Prospect" read as a settled `Host` in their chapter's CRM.
+See CRM_ROLE / CRM_LIFECYCLE.
+
+Deliberately NOT written: Signal — the chapter's own private judgement of a
+person, which no form answer can supply.
+
+The `Interested in` column does not exist on a workbook last touched before
+2026-08-25; migrate_interested_in.py adds it, rewrites both dropdowns and the
+Guide tab's formulas, and backfills the existing rows. This script REFUSES to
+open a workbook without it rather than writing by column letter.
 
 The workbooks are stored .xlsx (not native Sheets), so they are edited as OOXML
 zip parts: download, rewrite the Attendees sheet XML, upload. Every part we do
@@ -51,7 +65,7 @@ Usage:
   python3 sync_crm.py --verbose          # also list every intake row NOT synced
   python3 sync_crm.py --write            # apply, then re-read and verify
 """
-import argparse, datetime, io, os, re, shutil, subprocess, sys, tempfile, zipfile
+import argparse, datetime, io, itertools, os, re, shutil, subprocess, sys, tempfile, zipfile
 from collections import Counter, namedtuple
 from xml.etree import ElementTree as ET
 
@@ -222,7 +236,21 @@ CRM_SHEET = "Attendees"
 # formula still references L, so letter addressing must never come back.
 CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)",
                "Email", "LinkedIn URL", "Company", "Role / title",
-               "Technical expertise", "What brings you here?")
+               "Technical expertise", "What brings you here?",
+               # Appended at column L, not slotted in beside Status where it
+               # reads best. Inserting a column would renumber every cell ref
+               # in ~1000 rows AND every dataValidation sqref AND the Guide
+               # tab's cross-sheet formulas; appending touches none of them.
+               # Nothing here addresses a column by letter anyway.
+               "Interested in")
+
+#: Added 2026-08-25 by the Status/role split. A workbook that predates
+#: migrate_interested_in.py does not have it, and Attendees() refuses to open
+#: one — the right failure (nothing is written by column letter), but the bare
+#: "missing column(s)" message sends an operator hunting a corrupt workbook
+#: instead of running the migration. open_crm() names the fix when this is the
+#: ONLY thing missing.
+NEW_COLUMN = "Interested in"
 
 # The "decided yes" statuses. A person with one of these always syncs, and they
 # are what an organizer must hold to count toward a chapter's self-serve
@@ -266,7 +294,38 @@ AAIF_OPS_NAMES = ("Rahul Parundekar", "Demetrios Brinkmann", "Demetrios",
 AAIF_OPS_FOLDED = frozenset(fold(n) for n in AAIF_OPS_NAMES)
 
 ROLE_TABS = ("Organizers", "Speakers", "Hosts")   # also the merge priority order
-CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
+
+# The CRM answers two different questions, in two different columns. Conflating
+# them is the bug this pair of maps exists to prevent:
+#
+#   Interested in  — what the person is ASKING TO DO          (CRM_ROLE)
+#   Status         — how far along the DECISION about them is (CRM_LIFECYCLE)
+#
+# Before 2026-08-25 a single `Status` column held both, written from the role
+# tab alone. A venue host whose intake row still said "Prospect" therefore read
+# as `Host` in their chapter's CRM — an organizer scanning the list saw a
+# settled venue host where triage had settled nothing. (Pipeline ORGANIZERS
+# were the one role spared, because they were special-cased to "Prospect".)
+# Notes (CRM) carried both facts correctly the whole time; nothing was lost,
+# it was just flattened into a cell the eye reads as a decision.
+CRM_ROLE = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
+
+# Raw intake dropdown value -> CRM lifecycle Status. Keys cover every value in
+# SYNC_STATUSES + PIPELINE_STATUSES (asserted below), including the blank cell
+# and the legacy "New" spelling.
+#
+# "Existing (from MLOps)" maps to "Accepted" rather than surviving as its own
+# value: it is a TRANSIT status on the intake — an MLOps-community organizer
+# being carried over — and every such row ends up Accepted. The CRM's question
+# is "is this person on the team", and for both values the answer is yes, which
+# is exactly what SYNC_STATUSES already encodes.
+CRM_LIFECYCLE = {
+    "": "Prospect", "New": "Prospect", "Prospect": "Prospect",
+    "In progress": "In progress",
+    "Interviewing": "Interviewing",
+    "Tentative": "Tentative",
+    "Accepted": "Accepted", "Existing (from MLOps)": "Accepted",
+}
 
 # Status values this script is allowed to overwrite — everything the automation
 # itself writes, plus the sheet's own defaults: a BLANK cell (""), "Prospect",
@@ -274,53 +333,88 @@ CRM_STATUS = {"Organizers": "Organizer", "Speakers": "Speaker", "Hosts": "Host"}
 # still hold it, and it must keep upgrading identically). The "" is load-
 # bearing for the same reason it is in PIPELINE_STATUSES above: a hand-added
 # CRM row starts blank, and dropping the "redundant" empty string would freeze
-# every such row out of its role upgrade. A human who moved someone to
+# every such row out of its status upgrade. A human who moved someone to
 # "Attended", "Regular", "Volunteer" or "Declined" has said something the intake
 # does not know; a later triage decision must not silently undo it.
-AUTO_STATUS = frozenset(("", "New", "Prospect", "Organizer", "Speaker", "Host"))
+AUTO_STATUS = frozenset(
+    ("", "New") + tuple(CRM_LIFECYCLE.values())
+    # The three PRE-SPLIT role values. Nothing writes them any more and the
+    # migrated dropdown no longer offers them, but every row synced before
+    # 2026-08-25 still holds one until migrate_interested_in.py reaches its
+    # workbook — and a chapter can always be re-created from an old backup.
+    # Keeping them auto-owned is what lets an ordinary sync REPAIR such a row;
+    # drop them and a stale "Host" reads as a human's decision and freezes that
+    # person at the wrong value permanently, which is the failure this whole
+    # change exists to end.
+    + ("Organizer", "Speaker", "Host"))
 
-# Keep the CRM minimal. Identity, decision and interest — nothing else. The five
-# columns left out (Signal, LinkedIn URL, Company, Role / title, Technical
-# expertise) still exist on the sheet for an organizer to fill in by hand; the
-# automation does not push a survey's worth of personal detail into a shared
-# folder. Enforced by Attendees.write(), not just by crm_fields()'s dict body.
-CRM_WRITTEN = ("Full name", "Trusted/Regular", "Status", "Notes (CRM)", "Email",
-               "What brings you here?")
+#: The words `Interested in` is built from. A cell holding only these, in any
+#: order and any "/"-joined combination, is one this script wrote and may
+#: rewrite; anything else is a human's note and is left alone.
+AUTO_ROLE_WORDS = frozenset(r.casefold() for r in CRM_ROLE.values())
+
+# The columns the automation may author. Everything the intake actually knows
+# about a person now lands here.
+#
+# Until 2026-08-25 this was six columns, on a "we do not push a survey's worth
+# of personal detail into a shared folder" rule dating from when the Chapters
+# folder was public-link. It is not: it is 92 individual per-chapter organizer
+# grants, so the audience for a chapter's CRM is that chapter's own organizers,
+# who need to know who is asking to speak and what they work on. The four
+# detail columns had been collected, parsed and merged all the way to
+# crm_fields() and then thrown away, leaving the sheet's most useful columns
+# permanently blank. Coverage is uneven BY ROLE and that is the intake's shape,
+# not a bug (see ROLE_FIELDS): organizers are asked neither company nor title,
+# hosts are not asked a title. A blank answer writes nothing.
+#
+# `Signal` is the one column still left out, and deliberately: it is the
+# chapter's own private judgement of a person, which no form answer can supply.
+# Enforced by Attendees.write(), not just by crm_fields()'s dict body.
+CRM_WRITTEN = ("Full name", "Trusted/Regular", "Status", "Interested in",
+               "Notes (CRM)", "Email", "LinkedIn URL", "Company", "Role / title",
+               "Technical expertise", "What brings you here?")
+
+# A status the intake offers but this map has never heard of would raise a
+# KeyError deep inside crm_fields(), one chapter into a run, after other
+# workbooks had already been written. Fail at import instead: the two status
+# lists and this map are edited by different people for different reasons, and
+# nothing else pins them together.
+_uncovered = [s for s in SYNC_STATUSES + PIPELINE_STATUSES if s not in CRM_LIFECYCLE]
+if _uncovered:
+    raise AssertionError(
+        "CRM_LIFECYCLE has no entry for intake status(es) %s — add them, or the "
+        "first person carrying one crashes mid-run." % sorted(_uncovered))
 
 # Rows whose email is at one of these domains are shipped fixture data — the
 # "Sam Taylor" sample the template puts in every chapter, and the Tatooine test
 # chapter's cast. They are cleared, and their rows reused by real people.
 DUMMY_DOMAINS = ("example.com", "example.org", "example.net", "example.edu")
 
-# The Status dropdown shipped without a value for a venue host, so hosts had
-# nowhere honest to land. Patched in place on every workbook we open.
+# The two dropdowns the split produces. sync_crm only ever CHECKS these —
+# migrate_interested_in.py owns writing them, and owning the schema in one
+# place is why this file no longer carries a bytes-level dropdown patcher.
 #
-# ONE source of truth for what the dropdown holds — the four literals below are
-# derived, never typed twice. Hand-maintained copies would drift the day a
-# value is added: all four would miss, every workbook would report "absent",
-# and the Host patch would quietly stop working across the whole fleet.
-# LEGACY carries "New"; the MIGRATED pair is the same list after
-# migrate_status_prospect.py retired it (Prospect is the surviving spelling) —
-# the patch must recognise both, or every migrated CRM reads as having no
-# Status list at all.
-DV_STATUS_VALUES = ("New", "Prospect", "Attended", "Regular", "Speaker",
-                    "Organizer", "Volunteer", "Declined")
-_DV_HOST_AFTER = "Volunteer"          # Host slots in just before Declined
+# Status is the decision ladder, in the order triage walks it, followed by the
+# four values only a human ever sets. The role values ("Speaker", "Organizer",
+# "Host") are GONE from this list — that they were ever on it is what let the
+# column mean two things at once.
+DV_STATUS_VALUES = tuple(dict.fromkeys(CRM_LIFECYCLE.values())) + (
+    "Attended", "Regular", "Volunteer", "Declined")
 
+# `Interested in` lists the combinations, not just the three singles: a person
+# who applied as both an organizer and a speaker is written as
+# "Organizer/Speaker", and a dropdown that cannot express what the sync writes
+# would flag correct data as invalid. Generated from CRM_ROLE in ROLE_TABS
+# order so the values and their spelling cannot drift from what crm_fields()
+# produces.
+DV_INTERESTED_VALUES = tuple(
+    "/".join(CRM_ROLE[t] for t in combo)
+    for n in range(1, len(ROLE_TABS) + 1)
+    for combo in itertools.combinations(ROLE_TABS, n))
 
-def dv_status_list(values, with_host):
-    """The comma-joined dropdown list, optionally with "Host" inserted."""
-    out = list(values)
-    if with_host:
-        out.insert(out.index(_DV_HOST_AFTER) + 1, "Host")
-    return ",".join(out)
-
-
-DV_STATUS_OLD = dv_status_list(DV_STATUS_VALUES, False)
-DV_STATUS_NEW = dv_status_list(DV_STATUS_VALUES, True)
-_DV_MIGRATED = tuple(v for v in DV_STATUS_VALUES if v != "New")
-DV_STATUS_OLD_MIGRATED = dv_status_list(_DV_MIGRATED, False)
-DV_STATUS_NEW_MIGRATED = dv_status_list(_DV_MIGRATED, True)
+#: header name -> the exact comma-joined list its dataValidation must hold.
+DV_EXPECTED = {"Status": ",".join(DV_STATUS_VALUES),
+               NEW_COLUMN: ",".join(DV_INTERESTED_VALUES)}
 
 # Per-role source columns on the intake role tabs, resolved by header name and
 # taken in order (first non-empty wins). Organizers have no company or title
@@ -556,7 +650,14 @@ def set_cell(row_el, col, text, style=None):
 class Attendees:
     """The Attendees sheet of one chapter CRM, addressed by header name."""
 
-    def __init__(self, parts, part_name):
+    def __init__(self, parts, part_name, require=CRM_HEADERS):
+        """`require` is the header set the workbook must already have.
+
+        It is a parameter for exactly one caller: migrate_interested_in.py,
+        which opens PRE-split workbooks in order to add the column that the
+        default CRM_HEADERS demands. Everything else takes the default, so the
+        sync still refuses a workbook it cannot address by header name.
+        """
         raw = parts[part_name]
         register_namespaces(raw)
         self.parts, self.part_name = parts, part_name
@@ -578,7 +679,15 @@ class Attendees:
             txt = clean_text(cell_text(c, self.sst))
             if txt:
                 self.headers[txt] = col_of(c.get("r"))
-        missing = [h for h in CRM_HEADERS if h not in self.headers]
+        missing = [h for h in require if h not in self.headers]
+        if missing == [NEW_COLUMN]:
+            # By far the likeliest miss, and the one with a one-command fix.
+            # Without this an operator reads "missing column(s): Interested in"
+            # across 62 chapters and goes looking for corrupt workbooks.
+            raise ValueError(
+                "no %r column yet — this workbook predates the 2026-08-25 "
+                "Status/role split. Run migrate_interested_in.py --write, then "
+                "re-run this sync." % NEW_COLUMN)
         if missing:
             raise ValueError("missing column(s): %s" % ", ".join(missing))
         # Row 2 is the shipped sample row and is the only place the per-column
@@ -624,7 +733,7 @@ class Attendees:
         decides folder access. Nothing downstream can detect it, because the
         verify only ever compares CRM_WRITTEN.
         """
-        return any(self.value(rownum, h) for h in CRM_HEADERS)
+        return any(self.value(rownum, h) for h in CRM_HEADERS if h in self.headers)
 
     def free_rows(self, also_free=()):
         """Row numbers available for new people, lowest first, then rows past the
@@ -647,11 +756,17 @@ class Attendees:
     def clear(self, rownum):
         """Blank every CRM column on a row, keeping the cells and their styles.
 
-        Goes through _write, not write: clearing legitimately touches all
-        eleven columns, including the five the automation may never author.
+        Goes through _write, not write: clearing legitimately touches every
+        column, including `Signal`, which the automation may never author.
+
+        Both this and occupied() skip a header the workbook does not actually
+        have. Only migrate_interested_in.py opens such a workbook (a pre-split
+        one, missing NEW_COLUMN), and without the guard value() raises KeyError
+        on the very column that migration exists to add.
         """
         for header in CRM_HEADERS:
-            self._write(rownum, header, "")
+            if header in self.headers:
+                self._write(rownum, header, "")
 
     def row_for(self, rownum):
         row = self.rows.get(rownum)
@@ -720,37 +835,52 @@ class Attendees:
         self.parts[self.part_name] = _XML_DECL + body[at:]
 
 
-def patch_status_dropdown(parts, part_name):
-    """Add "Host" to the Status column's data-validation list.
+_DV_BLOCK_RE = re.compile(
+    rb"<dataValidation\b[^>]*\bsqref=(?:\"|&quot;)([^\"&]+)(?:\"|&quot;)[^>]*>"
+    rb"(.*?)</dataValidation>", re.S)
+_DV_FORMULA_RE = re.compile(rb"<formula1>(?:\"|&quot;)(.*?)(?:\"|&quot;)</formula1>", re.S)
 
-    Returns "patched" (the part changed), "already" (Host is offered), or
-    "absent" (no list matching any known spelling — reported, never guessed at).
 
-    A bytes-level swap of the one formula string: the validation lives outside
-    <sheetData>, nothing else in the file mentions it, and re-serializing the
-    whole sheet through ElementTree just to change a literal would rewrite
-    unrelated markup. Both quote encodings are handled — the template writes
-    `"…"` and the older workbooks write `&quot;…&quot;`, and matching only the
-    first silently left every legacy CRM un-patched while reporting success.
-    Both the legacy list (leading "New") and the migrated list (Prospect only,
-    after migrate_status_prospect.py) are recognised — every "already" check
-    runs before any patch, so the pass a workbook actually matches decides.
+def dv_lists(raw):
+    """{0-based column index: the list's comma-joined values} for every
+    single-column ONE_OF_LIST dataValidation in the sheet part.
+
+    Read straight from the bytes, like the patcher this replaces: the
+    validations live outside <sheetData>, and both quote encodings occur in the
+    wild (the template writes `"…"`, the older workbooks `&quot;…&quot;` —
+    matching only the first is what once left every legacy CRM silently
+    unpatched while reporting success).
+
+    A multi-column sqref is skipped rather than guessed at: it would attribute
+    one list to several headers, and this function's only caller uses the
+    answer to decide whether a chapter's schema is correct.
     """
-    raw = parts[part_name]
-    variants = ((DV_STATUS_OLD, DV_STATUS_NEW),
-                (DV_STATUS_OLD_MIGRATED, DV_STATUS_NEW_MIGRATED))
-    for q in (b'"', b"&quot;"):
-        for _old, new in variants:
-            if b"<formula1>" + q + new.encode() + q + b"</formula1>" in raw:
-                return "already"
-    for q in (b'"', b"&quot;"):
-        for old, new in variants:
-            old_b = b"<formula1>" + q + old.encode() + q + b"</formula1>"
-            if old_b in raw:
-                parts[part_name] = raw.replace(
-                    old_b, b"<formula1>" + q + new.encode() + q + b"</formula1>")
-                return "patched"
-    return "absent"
+    out = {}
+    for m in _DV_BLOCK_RE.finditer(raw):
+        sqref = m.group(1).decode()
+        f = _DV_FORMULA_RE.search(m.group(2))
+        if f is None or " " in sqref.strip():
+            continue
+        cols = {col_of(end) for end in sqref.split(":")}
+        if len(cols) != 1:
+            continue
+        out[cols.pop()] = f.group(1).decode().replace("&quot;", '"')
+    return out
+
+
+def check_dropdowns(att):
+    """[] when both split columns carry the right list, else a header-name list.
+
+    Read-only on purpose. Until 2026-08-25 this file PATCHED the Status list in
+    place, which meant two scripts could author a workbook's schema; the
+    dropdown patch then had to be sequenced against the row serializer inside
+    finalize(), and getting that order wrong silently threw the patch away
+    while still reporting it applied. Schema is migrate_interested_in.py's job
+    now, and sync_crm reports what it finds.
+    """
+    lists = dv_lists(att.parts[att.part_name])
+    return [h for h, want in DV_EXPECTED.items()
+            if lists.get(att.headers[h]) != want]
 
 
 # ----------------------------------------------------------------------------
@@ -1021,43 +1151,75 @@ def merge_people(people, blocked=None):
 def crm_fields(p, today):
     """The CRM values for one merged person.
 
-    Only CRM_WRITTEN columns are produced — `Signal` and the detail columns are
-    deliberately absent, so the automation never touches them. A blank value
-    means "leave that cell alone", never "blank it out".
+    Only CRM_WRITTEN columns are produced — `Signal` is deliberately absent, so
+    the automation never touches the chapter's own judgement of someone. A
+    blank value means "leave that cell alone", never "blank it out".
 
-    Status and Trusted/Regular follow the ACCEPTED roles only:
-      * any accepted role -> that role's status (highest-priority accepted tab
-        wins), and Trusted/Regular = "Yes" for an accepted organizer;
-      * no accepted role, but an organizer application in flight -> "Prospect"
-        — a candidate for the chapter's own interviews, not on the team;
-      * a pipeline host/speaker -> their role status, never trusted.
-    "Prospect" is in AUTO_STATUS, so acceptance upgrades the row on a later run
-    without a human having to touch it.
+    The two columns the 2026-08-25 split created are filled INDEPENDENTLY, and
+    keeping them independent is the whole point:
+
+      * `Interested in` — every role the person applied for, whatever came of
+        it, in ROLE_TABS priority order ("Organizer/Speaker"). It is a
+        statement about their application, so a decision never changes it.
+      * `Status` — the decision, and nothing else. Accepted in ANY role reads
+        "Accepted"; otherwise it mirrors the intake's own pipeline value, so a
+        host still sitting at Prospect reads Prospect instead of announcing
+        itself as a settled `Host`.
+
+    Every value in CRM_LIFECYCLE is in AUTO_STATUS, so a later triage decision
+    upgrades the row on the next run without a human having to touch it.
     """
     # Derived, not stored: tabs/statuses are index-aligned by merge_people, so
     # the accepted roles need no third parallel list to keep in sync. strict=
     # True is the alignment tripwire: a future edit that appends to one list
     # but not the other must raise here, not silently truncate the zip and
     # demote an accepted person to Prospect.
-    acc = [t for t, s in zip(p["tabs"], p["statuses"], strict=True)
-           if s in SYNC_STATUSES]
-    if acc:
-        status = CRM_STATUS[acc[0]]
-        # An accepted organizer is on the chapter's team, not a guest to triage.
-        trusted = "Yes" if acc[0] == "Organizers" else ""
-    else:
-        status = "Prospect" if "Organizers" in p["tabs"] else CRM_STATUS[p["tabs"][0]]
-        trusted = ""
+    roles = list(zip(p["tabs"], p["statuses"], strict=True))
+    accepted_tabs = [t for t, st in roles if st in SYNC_STATUSES]
+    # tabs[0] is the highest-priority tab a merged person appears on, so an
+    # unaccepted person's Status is the one from their primary application.
+    # No ladder is invented over the in-flight values ("is Tentative further
+    # along than Interviewing?" has no answer this script is entitled to give);
+    # acceptance is the only ordering it actually knows.
+    status = "Accepted" if accepted_tabs else CRM_LIFECYCLE[p["statuses"][0]]
     return {
         "Full name": p["name"],
-        "Trusted/Regular": trusted,
+        # An accepted organizer is on the chapter's team, not a guest to triage.
+        "Trusted/Regular": "Yes" if "Organizers" in accepted_tabs else "",
         "Status": status,
+        NEW_COLUMN: join_distinct([CRM_ROLE[t] for t in p["tabs"]], "/"),
         "Notes (CRM)": "Intake: %s · %s · %s" % (
-            join_distinct([CRM_STATUS[t] for t in p["tabs"]], "/"),
+            join_distinct([CRM_ROLE[t] for t in p["tabs"]], "/"),
             join_distinct(p["statuses"], "/"), today),
         "Email": p["email"],
+        "LinkedIn URL": p["linkedin"],
+        "Company": p["company"],
+        "Role / title": p["title"],
+        "Technical expertise": p["expertise"],
         "What brings you here?": p["interest"],
     }
+
+
+def is_auto_role(value):
+    """True if `Interested in` still holds a value this script authored.
+
+    That is: blank, or nothing but the three role words in any "/"-joined
+    combination and any casing. A human who typed "Organizer (co-lead)" or
+    "Sponsor" has said something the intake does not know, and the same rule
+    that protects a hand-set "Declined" in Status protects it here.
+    """
+    v = clean_text(value)
+    if not v:
+        return True
+    parts = [x.strip() for x in v.split("/")]
+    return all(x.casefold() in AUTO_ROLE_WORDS for x in parts if x) and any(parts)
+
+
+#: header -> "may this script overwrite the value already in the cell?".
+#: Every other column is write-once: content already there is a human's and is
+#: left alone. These two are re-derived from the intake on every run, which is
+#: how a re-triage reaches a chapter without anyone editing a workbook.
+AUTO_OWNED = {"Status": lambda v: v in AUTO_STATUS, NEW_COLUMN: is_auto_role}
 
 
 def is_dummy(email):
@@ -1096,9 +1258,10 @@ def plan_workbook(att, people, today):
     Two write rules, and they are the whole safety story for a sheet humans curate:
       * a cell that already has content is left alone, so notes, corrected
         spellings and hand-added detail survive every re-run;
-      * except `Status`, which is upgraded when it still holds a value this
-        script wrote (AUTO_STATUS) — that is how a person's role is corrected
-        after re-triage, without ever undoing a human's "Declined".
+      * except the two AUTO_OWNED columns (`Status` and `Interested in`),
+        which are upgraded while they still hold a value this script wrote —
+        that is how a re-triage reaches a chapter, without ever undoing a
+        human's "Declined".
     """
     # Fixture rows go first so their row numbers are reusable below, and so a
     # dummy address can never be mistaken for an existing person to merge into.
@@ -1134,7 +1297,8 @@ def plan_workbook(att, people, today):
             current = "" if new else att.value(rownum, header)
             if current == value:
                 continue
-            if current and not (header == "Status" and current in AUTO_STATUS):
+            owned = AUTO_OWNED.get(header)
+            if current and not (owned and owned(current)):
                 continue
             sets[header] = value
         if sets:
@@ -1164,16 +1328,17 @@ def apply_ops(att, ops):
             att.write(op["rownum"], header, value)
 
 
-def finalize(book, ops, expected_dv=None):
-    """Produce the workbook's new bytes: rows first, then serialize, then the
-    dropdown patch — in that order, and only in that order.
+def finalize(book, ops):
+    """Produce the workbook's new bytes: apply the row ops, then serialize.
 
-    `serialize()` rewrites the sheet part wholesale from the element tree, which
-    was parsed before any bytes-level edit. Patching the dropdown first and
-    serializing second therefore throws the patch away, and the run still reports
-    it as applied — exactly what shipped to a probe workbook until this was
-    caught. Keeping both steps in one function is what stops the order drifting
-    apart again.
+    This used to also patch the Status dropdown, which made the ORDER of the two
+    steps load-bearing and easy to get wrong: `serialize()` rewrites the sheet
+    part wholesale from an element tree parsed before any bytes-level edit, so
+    patching first and serializing second threw the patch away while still
+    reporting it applied — which is what shipped to a probe workbook before it
+    was caught. Since 2026-08-25 the schema (columns and dropdowns) belongs to
+    migrate_interested_in.py alone and this function only writes cells, so
+    there is no longer an order to get wrong.
     """
     # finalize serializes through `att` but saves `book.parts` — they must be
     # the same dict, or the returned zip silently loses either the row writes or
@@ -1183,14 +1348,6 @@ def finalize(book, ops, expected_dv=None):
         raise ValueError("Book.parts/part must be the same objects Attendees holds")
     apply_ops(book.att, ops)
     book.att.serialize()
-    got = patch_status_dropdown(book.parts, book.part)
-    if expected_dv is not None and got != expected_dv:
-        # The prediction was made against the downloaded bytes; the real patch
-        # runs against ElementTree's re-encoding of them. They agree today
-        # because both quote spellings are handled — this is what catches the
-        # day they stop agreeing, rather than reporting a patch never applied.
-        raise ValueError("dropdown patch predicted %r but returned %r for %s"
-                         % (expected_dv, got, book.crm["name"]))
     return save_parts(book.names, book.parts)
 
 
@@ -1341,7 +1498,7 @@ def write_workbooks(touched, workdir, backup_dir):
                 print("  SKIPPED %s — workbook changed since the plan was built; "
                       "NOT written, re-run to sync it" % name, file=sys.stderr)
                 continue
-            upload(book.crm["id"], book.path, finalize(book, t["ops"], t["dv"]), XLSX)
+            upload(book.crm["id"], book.path, finalize(book, t["ops"]), XLSX)
             written.append(name)
             print("  wrote %s (%s)" % (name, book.crm["name"]))
         except Exception as e:                     # one bad workbook must not
@@ -1442,20 +1599,20 @@ def _run(args, workdir):
         kept = preexisting(book.att, ops, grp)
         if kept:
             keepers.append((folder["name"], kept))
-        # Detection only — over a shallow copy, so the real patch happens exactly
-        # once, inside finalize(), after the sheet has been serialized.
-        dv = patch_status_dropdown(dict(book.parts), book.part)
-        if dv == "absent":
-            # Not fatal — people still sync — but say so: a chapter whose Status
-            # column has no dropdown at all will not constrain what gets typed.
-            no_dropdown.append(folder["name"])
-        if not ops and dv != "patched":
+        # Read-only. People still sync into a workbook whose dropdowns are
+        # stale — the values written are correct either way — but an organizer
+        # picking from a Status list that still offers "Speaker" can re-create
+        # the exact conflation this split removed, so it is reported every run
+        # until migrate_interested_in.py has been there.
+        stale_dv = check_dropdowns(book.att)
+        if stale_dv:
+            no_dropdown.append((folder["name"], stale_dv))
+        if not ops:
             continue
         n = {k: sum(1 for o in ops if o["kind"] == k) for k in ("clear", "add", "fill")}
         bits = ([("%d dummy cleared" % n["clear"])] if n["clear"] else []) \
             + ([("%d new" % n["add"])] if n["add"] else []) \
-            + ([("%d filled in" % n["fill"])] if n["fill"] else []) \
-            + (['Status dropdown += "Host"'] if dv == "patched" else [])
+            + ([("%d filled in" % n["fill"])] if n["fill"] else [])
         print("  %-18s %s" % (folder["name"], ", ".join(bits)))
         for o in ops:
             mark = {"clear": "-", "add": "+", "fill": "~"}[o["kind"]]
@@ -1465,7 +1622,7 @@ def _run(args, workdir):
             print("      %s row %-4d %s <%s> — %s"
                   % (mark, o["rownum"], redact_name(o["name"]),
                      redact_email(o["email"]), detail))
-        touched.append({"book": book, "ops": ops, "dv": dv})
+        touched.append({"book": book, "ops": ops})
 
     if near_misses:
         print("\nNear-miss chapter names (NOT written — fix the intake city or rename the folder):")
@@ -1502,8 +1659,11 @@ def _run(args, workdir):
               "'What brings you here?' is the generic branch text for their role."
               % len(fallbacks))
     if no_dropdown:
-        print("\nNo Status dropdown to extend (people still sync; the column just "
-              "won't constrain typing):\n  %s" % ", ".join(no_dropdown))
+        print("\nStale or missing dropdown(s) — people still sync, but the column "
+              "won't constrain what an organizer types. Run "
+              "migrate_interested_in.py --write:")
+        for name, cols in no_dropdown:
+            print("  %-28s %s" % (name, ", ".join(repr(c) for c in cols)))
     if rejected and args.verbose:
         print("\nIntake rows not synced:")
         for r in rejected:
@@ -1552,8 +1712,6 @@ def _run(args, workdir):
         left = plan_workbook(book.att, by_folder.get(folder["id"], []), today)
         if left:
             stale.append((folder["name"], "%d op(s) still pending" % len(left)))
-        elif t["dv"] == "patched" and patch_status_dropdown(dict(book.parts), book.part) != "already":
-            stale.append((folder["name"], 'Status dropdown still lacks "Host"'))
     if failed or stale or changed:
         if failed or stale:
             print("VERIFY FAILED:")

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -26,8 +26,7 @@ team member — Drive access still keys off acceptance in sync_access.py, so
 reaching the CRM grants nothing by itself.
 
 Each chapter folder under the Chapters Drive holds one "<City> CRM.xlsx" whose
-"Attendees" tab has eleven columns. Only six are ever written (CRM_WRITTEN) —
-identity, decision and interest, and nothing else:
+"Attendees" tab has twelve columns. All but `Signal` are written (CRM_WRITTEN):
 
     Full name           <- role tab name
     Trusted/Regular     <- "Yes" for an ACCEPTED organizer (they're on the team)
@@ -123,7 +122,19 @@ def set_redaction(on):
 #: Columns whose values are categorical, not personal — the only ones a
 #: redacted report still shows. Everything else (survey answers, company,
 #: phone, LinkedIn…) could identify someone, so it prints as `…`.
-SHOWN_UNDER_REDACT = ("Role", "Status", "Signal", "Trusted/Regular")
+#:
+#: EXACT header names, matched with `in`, never a substring test. It WAS a
+#: substring test against the tag "Role", which was safe only for as long as no
+#: written column happened to contain that word — and on 2026-08-25 `Role /
+#: title` joined CRM_WRITTEN, so `"Role" in "Role / title"` started printing a
+#: free-text job title in full under --redact. That flag defaults ON under CI
+#: precisely because a CI log on a public repo is a permanent publication, and
+#: a headline beside a chapter name re-identifies someone the masked name and
+#: email were protecting. A membership test cannot acquire a new member by
+#: accident; a substring test can.
+#: (Spelled out rather than referencing NEW_COLUMN, which is defined further
+#: down; the assertion beside CRM_HEADERS pins the two together.)
+SHOWN_UNDER_REDACT = ("Status", "Interested in", "Signal", "Trusted/Regular")
 
 
 def redact_sets(sets):
@@ -131,7 +142,7 @@ def redact_sets(sets):
     role/status-like columns, so the report still shows WHICH columns change."""
     if not REDACT:
         return sets
-    return {k: (v if any(tag in k for tag in SHOWN_UNDER_REDACT) else "…")
+    return {k: (v if k in SHOWN_UNDER_REDACT else "…")
             for k, v in sets.items()}
 
 
@@ -229,11 +240,13 @@ TEMPLATE_FOLDER = "TemplateCity"                        # cloned per city; never
 XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 CRM_SHEET = "Attendees"
-# The eleven the sheet must have. PRESENCE is checked, not order or position —
+# The twelve the sheet must have. PRESENCE is checked, not order or position —
 # every access is by header name, and extra columns are tolerated. A workbook
 # missing any of them is skipped with a report line rather than written by column
-# letter: the columns were renumbered once already, and the Guide tab's live-list
-# formula still references L, so letter addressing must never come back.
+# letter: the columns have been renumbered twice more since (2026-08-25 added
+# `Interested in`, and migrate_column_order.py then moved it to D), and the
+# Guide tab's live-list formula was left pointing at a column that did not
+# exist. Letter addressing must never come back.
 CRM_HEADERS = ("Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)",
                "Email", "LinkedIn URL", "Company", "Role / title",
                "Technical expertise", "What brings you here?",
@@ -327,6 +340,23 @@ CRM_LIFECYCLE = {
     "Accepted": "Accepted", "Existing (from MLOps)": "Accepted",
 }
 
+#: Statuses only a HUMAN ever sets. The intake has no way to express any of
+#: them, so the sync must never write or overwrite one. Named rather than
+#: inlined because AUTO_STATUS is built by union and would otherwise grow into
+#: this set silently: one plausible edit — `CRM_LIFECYCLE["Denied"] =
+#: "Declined"`, the CRM already offers "Declined" — would put it in AUTO_STATUS
+#: and the next sync would overwrite every hand-set "Declined" across the
+#: estate, undoing exactly what four separate comments promise is protected.
+#: The assertion below is what makes that promise structural.
+HUMAN_ONLY_STATUSES = ("Attended", "Regular", "Volunteer", "Declined")
+
+#: The decision ladder, in the order triage walks it. Used ONLY to describe a
+#: change in the report — never to decide one. Ranking a person is the intake's
+#: job; this exists so a run that moves someone BACKWARDS says so out loud
+#: instead of printing the new value and nothing else.
+LIFECYCLE_ORDER = tuple(dict.fromkeys(CRM_LIFECYCLE.values()))
+
+
 # Status values this script is allowed to overwrite — everything the automation
 # itself writes, plus the sheet's own defaults: a BLANK cell (""), "Prospect",
 # and its legacy spelling "New" (pre-2026-08-22 rows and un-migrated dropdowns
@@ -385,6 +415,41 @@ if _uncovered:
         "CRM_LIFECYCLE has no entry for intake status(es) %s — add them, or the "
         "first person carrying one crashes mid-run." % sorted(_uncovered))
 
+# The redaction whitelist names real columns, and names only categorical ones.
+# Both halves are asserted because both have already gone wrong: a substring
+# test silently added `Role / title` to it (a free-text job title, printed in
+# full under --redact), and nothing would otherwise catch a typo or a header
+# rename quietly turning a "shown" column into a masked one.
+_not_a_header = [h for h in SHOWN_UNDER_REDACT if h not in CRM_HEADERS]
+if _not_a_header:
+    raise AssertionError(
+        "SHOWN_UNDER_REDACT names %s, which is not a CRM column — a typo or a "
+        "rename, and it masks a column the report is supposed to show."
+        % sorted(_not_a_header))
+_free_text = [h for h in SHOWN_UNDER_REDACT
+              if h in ("Full name", "Email", "Notes (CRM)", "LinkedIn URL",
+                       "Company", "Role / title", "Technical expertise",
+                       "What brings you here?")]
+if _free_text:
+    raise AssertionError(
+        "SHOWN_UNDER_REDACT names %s, which carries free text about a person "
+        "and must never print unmasked in a CI log." % sorted(_free_text))
+
+# The promises this file makes in prose, made structural. Each has a plausible
+# one-line edit that would break it silently, and each currently fails (if at
+# all) as a KeyError deep inside a per-chapter loop, after other workbooks have
+# already been written.
+_clobbered = sorted(set(HUMAN_ONLY_STATUSES) & AUTO_STATUS)
+if _clobbered:
+    raise AssertionError(
+        "AUTO_STATUS contains %s, so the sync would overwrite a status only a "
+        "human ever sets. The intake cannot express these; a CRM_LIFECYCLE "
+        "entry mapping onto one is the likely cause." % _clobbered)
+_unwritable = sorted(set(CRM_WRITTEN) - set(CRM_HEADERS))
+if _unwritable:
+    raise AssertionError("CRM_WRITTEN names %s, which is not a CRM column."
+                         % _unwritable)
+
 # Rows whose email is at one of these domains are shipped fixture data — the
 # "Sam Taylor" sample the template puts in every chapter, and the Tatooine test
 # chapter's cast. They are cleared, and their rows reused by real people.
@@ -398,8 +463,7 @@ DUMMY_DOMAINS = ("example.com", "example.org", "example.net", "example.edu")
 # four values only a human ever sets. The role values ("Speaker", "Organizer",
 # "Host") are GONE from this list — that they were ever on it is what let the
 # column mean two things at once.
-DV_STATUS_VALUES = tuple(dict.fromkeys(CRM_LIFECYCLE.values())) + (
-    "Attended", "Regular", "Volunteer", "Declined")
+DV_STATUS_VALUES = tuple(dict.fromkeys(CRM_LIFECYCLE.values())) + HUMAN_ONLY_STATUSES
 
 # `Interested in` lists the combinations, not just the three singles: a person
 # who applied as both an organizer and a speaker is written as
@@ -415,6 +479,12 @@ DV_INTERESTED_VALUES = tuple(
 #: header name -> the exact comma-joined list its dataValidation must hold.
 DV_EXPECTED = {"Status": ",".join(DV_STATUS_VALUES),
                NEW_COLUMN: ",".join(DV_INTERESTED_VALUES)}
+
+_undropdowned = sorted(set(DV_EXPECTED) - set(CRM_HEADERS))
+if _undropdowned:
+    raise AssertionError("DV_EXPECTED names %s, which is not a CRM column — "
+                         "check_dropdowns would KeyError per chapter."
+                         % _undropdowned)
 
 # Per-role source columns on the intake role tabs, resolved by header name and
 # taken in order (first non-empty wins). Organizers have no company or title
@@ -533,13 +603,29 @@ def register_namespaces(xml_bytes):
 
 
 def col_of(ref):
-    """'AB12' -> 27 (0-based column index)."""
+    """'AB12' -> 27 (0-based column index). '$AB$12' too. -1 if there is no
+    column letter at all.
+
+    The `$` handling is not cosmetic. Without it `col_of("$D$2")` returned -1 —
+    it broke on the very first character — and -1 is a plausible-looking index
+    that three callers used as a real answer: a `$`-anchored dataValidation got
+    filed under column -1, so `check_dropdowns` reported that chapter stale on
+    every run forever, `apply_dropdowns` failed to find the existing rule and
+    appended a SECOND one over the same cells, and `cf_plan` returned "due" for
+    a column a human had already painted and added a second colour block on top.
+    Every one of those fails OPEN. Excel and Sheets both write anchored sqrefs
+    routinely. Callers that can be handed a non-reference still check for -1.
+    """
     n = 0
+    seen = False
     for ch in ref:
+        if ch == "$" and not seen:
+            continue                      # a leading/interior anchor, not data
         if not ch.isalpha():
             break
+        seen = True
         n = n * 26 + (ord(ch.upper()) - 64)
-    return n - 1
+    return n - 1 if seen else -1
 
 
 def cell_ref(col, row):
@@ -725,13 +811,14 @@ class Attendees:
     def occupied(self, rownum):
         """True if ANY CRM column on the row holds something.
 
-        Not just name+email: the five columns this script never writes are also
-        never cleared, so a row whose name and email an operator deleted still
-        carries the departed person's LinkedIn, Company and expertise. Treating
-        it as free hands those fields to the next person written there — a real
-        current organizer showing a stranger's employer, in the workbook that
-        decides folder access. Nothing downstream can detect it, because the
-        verify only ever compares CRM_WRITTEN.
+        Not just name+email: `Signal` is never written and never cleared, so a
+        row whose name and email an operator deleted still carries the departed
+        person's rating. Treating it as free hands that to the next person
+        written there — a real current organizer inheriting a stranger's
+        `Non-grata`, in the workbook that decides folder access. Nothing
+        downstream can detect it, because the verify only compares CRM_WRITTEN.
+        (Before 2026-08-25 this covered five columns, four of which the
+        automation now writes; the hazard is narrower, not gone.)
         """
         return any(self.value(rownum, h) for h in CRM_HEADERS if h in self.headers)
 
@@ -787,11 +874,13 @@ class Attendees:
     def write(self, rownum, header, text):
         """Write one CRM cell. Only CRM_WRITTEN columns may be written.
 
-        The "we never push survey detail into this folder" promise was upheld
-        only by the literal body of crm_fields() and guarded only by a test.
-        Enforcing it here means the privacy boundary cannot be crossed by a
-        future caller at all — use clear() for the blanking path, which is
-        allowed to touch every column.
+        What this enforces is narrower than when it was written: the "never
+        push survey detail into this folder" rule was retired on 2026-08-25
+        (see CRM_WRITTEN), and the surviving promise is that `Signal` — the
+        chapter's own private rating of a person, which no form answer can
+        supply — is never authored by the automation. Enforcing it here rather
+        than in crm_fields()'s dict body means a future caller cannot cross it
+        either. Use clear() for the blanking path, which may touch every column.
         """
         if header not in CRM_WRITTEN:
             raise ValueError(
@@ -862,7 +951,9 @@ def dv_lists(raw):
         if f is None or " " in sqref.strip():
             continue
         cols = {col_of(end) for end in sqref.split(":")}
-        if len(cols) != 1:
+        # -1 means "no column letter" — unattributable, not column A. Filing it
+        # anyway is how a garbled sqref silently claims a real column's list.
+        if len(cols) != 1 or -1 in cols:
             continue
         out[cols.pop()] = f.group(1).decode().replace("&quot;", '"')
     return out
@@ -1174,7 +1265,13 @@ def crm_fields(p, today):
     # True is the alignment tripwire: a future edit that appends to one list
     # but not the other must raise here, not silently truncate the zip and
     # demote an accepted person to Prospect.
-    roles = list(zip(p["tabs"], p["statuses"], strict=True))
+    # strict=True over ALL THREE lists. `rows` was outside the zip, so an edit
+    # that appended to tabs+statuses but not rows passed the tripwire and
+    # silently misattributed intake row numbers in every report line — a report
+    # pointing an operator at the wrong intake row is worse than one pointing
+    # nowhere. The row numbers are not used here; being in the zip is the point.
+    roles = [(t, st) for t, st, _ in
+             zip(p["tabs"], p["statuses"], p["rows"], strict=True)]
     accepted_tabs = [t for t, st in roles if st in SYNC_STATUSES]
     # tabs[0] is the highest-priority tab a merged person appears on, so an
     # unaccepted person's Status is the one from their primary application.
@@ -1221,6 +1318,14 @@ def is_auto_role(value):
 #: how a re-triage reaches a chapter without anyone editing a workbook.
 AUTO_OWNED = {"Status": lambda v: v in AUTO_STATUS, NEW_COLUMN: is_auto_role}
 
+# Defined here rather than beside the other invariants because AUTO_OWNED is,
+# so it can be checked at all. A header here that is not writable would raise
+# only when a chapter happened to have content in that cell.
+_unowned = sorted(set(AUTO_OWNED) - set(CRM_WRITTEN))
+if _unowned:
+    raise AssertionError("AUTO_OWNED names %s, which the automation may not "
+                         "write at all." % _unowned)
+
 
 def is_dummy(email):
     """True only for the reserved example domains. This is the ONLY gate on
@@ -1248,6 +1353,14 @@ def preexisting(att, ops, people=()):
             if r > 1 and r not in touched and att.occupied(r)
             and fold_email(att.value(r, "Email")) not in expected
             and not is_dummy(att.value(r, "Email"))]
+
+
+#: The three op kinds, and the two that write. Named so the report and the
+#: writer cannot drift: the writer already raised on an unknown kind, but the
+#: REPORT — which is the default path — indexed a literal dict and would
+#: KeyError mid-sweep after other chapters had printed, or silently undercount.
+OP_KINDS = ("clear", "add", "fill")
+WRITE_KINDS = ("add", "fill")
 
 
 def plan_workbook(att, people, today):
@@ -1303,12 +1416,45 @@ def plan_workbook(att, people, today):
             sets[header] = value
         if sets:
             ops.append({"kind": "add" if new else "fill", "email": p["email"],
-                        "name": p["name"], "rownum": rownum, "sets": sets})
+                        "name": p["name"], "rownum": rownum, "sets": sets,
+                        # What each cell held before. The report used to print
+                        # only the NEW value, which made overwriting a chapter's
+                        # own decision typographically identical to filling a
+                        # blank cell — see the demotion report in _run.
+                        "was": {h: ("" if new else att.value(rownum, h))
+                                for h in sets}})
         if new:
             # Claim the row even when nothing was written, so two people can
             # never be planned into the same empty row.
             by_email[fold_email(p["email"])] = rownum
+    # Validate on the way OUT of the constructor, not on the way in to the
+    # writer: --write is the rare path, the report is the default one.
+    bad = sorted({o["kind"] for o in ops} - set(OP_KINDS))
+    if bad:
+        raise ValueError("plan_workbook produced unknown op kind(s) %s" % bad)
     return ops
+
+
+def demotions(ops):
+    """[(op, header, old, new)] where a cell moves BACKWARDS down the ladder.
+
+    Only describes; never decides. `AUTO_STATUS` legitimately includes every
+    lifecycle value, so the intake can and does move someone back — a chapter
+    that recorded `Accepted` locally without the intake agreeing is, as far as
+    Drive access is concerned, wrong, and correcting it is the point of this
+    engine. But it is a real edit to a human's cell, and printing only the
+    destination hid it completely. This is what puts it on screen.
+    """
+    out = []
+    for o in ops:
+        for header, new in o["sets"].items():
+            old = o.get("was", {}).get(header, "")
+            if header != "Status" or not old or old == new:
+                continue
+            if old in LIFECYCLE_ORDER and new in LIFECYCLE_ORDER \
+                    and LIFECYCLE_ORDER.index(new) < LIFECYCLE_ORDER.index(old):
+                out.append((o, header, old, new))
+    return out
 
 
 def apply_ops(att, ops):
@@ -1320,10 +1466,10 @@ def apply_ops(att, ops):
     # form treats any future kind as a write — the fail-open direction, on the
     # one path that touches the workbook, while the report (which indexes a
     # dict of the three known marks) would crash or undercount.
-    unknown = [o["kind"] for o in ops if o["kind"] not in ("clear", "add", "fill")]
+    unknown = [o["kind"] for o in ops if o["kind"] not in OP_KINDS]
     if unknown:
         raise ValueError("unknown op kind(s) %s — refusing to write" % sorted(set(unknown)))
-    for op in (o for o in ops if o["kind"] in ("add", "fill")):
+    for op in (o for o in ops if o["kind"] in WRITE_KINDS):
         for header, value in op["sets"].items():
             att.write(op["rownum"], header, value)
 
@@ -1341,9 +1487,8 @@ def finalize(book, ops):
     there is no longer an order to get wrong.
     """
     # finalize serializes through `att` but saves `book.parts` — they must be
-    # the same dict, or the returned zip silently loses either the row writes or
-    # the dropdown patch. open_crm builds them that way; assert it rather than
-    # trusting every future caller to.
+    # the same dict, or the returned zip silently loses the row writes. open_crm
+    # builds them that way; assert it rather than trusting every future caller to.
     if book.parts is not book.att.parts or book.part != book.att.part_name:
         raise ValueError("Book.parts/part must be the same objects Attendees holds")
     apply_ops(book.att, ops)
@@ -1580,11 +1725,12 @@ def _run(args, workdir):
               % len(merge_blocked))
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
-    touched, skipped, no_dropdown, keepers = [], [], [], []
-    # Every folder is opened, not just the ones with people: the Status dropdown
-    # patch has to reach chapters that gained nobody this run, and TemplateCity
-    # most of all — otherwise every chapter created from it re-inherits a list
-    # with no value for a venue host.
+    touched, skipped, no_dropdown, keepers, demoted = [], [], [], [], []
+    # Every folder is opened, not just the ones with people: every workbook
+    # carries the template's fixture row and has to be checked for it, and the
+    # read-only dropdown check has to reach chapters that gained nobody this
+    # run. (This used to PATCH the dropdown; schema moved to
+    # migrate_interested_in.py on 2026-08-25.)
     for folder in folders:
         book, why = open_crm(folder, workdir)
         if book is None:
@@ -1609,21 +1755,39 @@ def _run(args, workdir):
             no_dropdown.append((folder["name"], stale_dv))
         if not ops:
             continue
-        n = {k: sum(1 for o in ops if o["kind"] == k) for k in ("clear", "add", "fill")}
+        n = {k: sum(1 for o in ops if o["kind"] == k) for k in OP_KINDS}
         bits = ([("%d dummy cleared" % n["clear"])] if n["clear"] else []) \
             + ([("%d new" % n["add"])] if n["add"] else []) \
             + ([("%d filled in" % n["fill"])] if n["fill"] else [])
         print("  %-18s %s" % (folder["name"], ", ".join(bits)))
         for o in ops:
-            mark = {"clear": "-", "add": "+", "fill": "~"}[o["kind"]]
+            mark = {"clear": "-", "add": "+", "fill": "~"}.get(o["kind"], "?")
+            # Show the TRANSITION, not just the destination: `Status='Prospect'`
+            # reads as filling a blank cell whether or not it just replaced a
+            # chapter's hand-set `Accepted`.
+            was = redact_sets(o.get("was", {}))
             detail = ("dummy row wiped" if o["kind"] == "clear" else
-                      ", ".join("%s=%r" % (k, v if len(v) < 60 else v[:57] + "…")
-                                for k, v in redact_sets(o["sets"]).items()))
+                      ", ".join(
+                          ("%s: %r -> %r" % (k, was[k], v)) if was.get(k)
+                          else ("%s=%r" % (k, v if len(v) < 60 else v[:57] + "…"))
+                          for k, v in redact_sets(o["sets"]).items()))
             print("      %s row %-4d %s <%s> — %s"
                   % (mark, o["rownum"], redact_name(o["name"]),
                      redact_email(o["email"]), detail))
+        demoted += [(folder["name"],) + d[1:] + (d[0],) for d in demotions(ops)]
         touched.append({"book": book, "ops": ops})
 
+    if demoted:
+        # Loud, and separate. These are the rows where the intake overrode a
+        # value a chapter had already set — legitimate (the intake is what
+        # drives Drive access) but never something to discover later.
+        print("\nStatus moved BACKWARDS — the intake disagrees with a value the "
+              "chapter had set. Legitimate if triage really did reverse; check "
+              "the intake row if not:")
+        for name, header, old, new, op in demoted:
+            print("  %-18s row %-4d %s <%s> — %r -> %r"
+                  % (name, op["rownum"], redact_name(op["name"]),
+                     redact_email(op["email"]), old, new))
     if near_misses:
         print("\nNear-miss chapter names (NOT written — fix the intake city or rename the folder):")
         for m in near_misses:

--- a/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Unit tests for migrate_column_order.py (no network/gws).
+
+The fixture is a POST-split workbook — twelve columns with `Interested in`
+appended at L, both dropdowns, the Status colour rules and the Guide's
+repointed formulas — because that is the only shape this migration runs
+against. It is built from migrate_interested_in's own fixture, put through
+that migration, so the input here is literally what the previous script
+produces rather than a hand-written guess at it.
+"""
+import os, sys
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import migrate_column_order as mo
+import migrate_interested_in as mig
+
+# The fixture module is a plain script: importing it RUNS its checks and prints
+# its own verdict. Silence that, or this suite's output opens with another
+# suite's "All checks passed." and a real failure here reads as coming from
+# there. Its exit status still surfaces — it calls sys.exit on failure.
+import contextlib, io as _io
+with contextlib.redirect_stdout(_io.StringIO()):
+    import test_migrate_interested_in as fx
+from sync_crm import (Attendees, NEW_COLUMN, X, check_dropdowns,
+                      col_of, load_parts, save_parts, sheet_part)
+
+fails = 0
+def check(label, got, want):
+    global fails
+    ok = got == want
+    fails += 0 if ok else 1
+    print("%s %s" % ("ok  " if ok else "FAIL", label))
+    if not ok:
+        print("      got : %r\n      want: %r" % (got, want))
+
+
+#: The layout every chapter had after migrate_interested_in — the input here.
+APPENDED = ["Full name", "Signal", "Trusted/Regular", "Status", "Notes (CRM)",
+            "Email", "LinkedIn URL", "Company", "Role / title",
+            "Technical expertise", "What brings you here?", "Interested in"]
+#: ...and the one this migration produces.
+WANTED = ["Full name", "Signal", "Trusted/Regular", "Interested in", "Status",
+          "Notes (CRM)", "Email", "LinkedIn URL", "Company", "Role / title",
+          "Technical expertise", "What brings you here?"]
+
+MAP = mo.move_mapping({h: i for i, h in enumerate(APPENDED)})
+
+
+def split_book(rows_data=()):
+    """A workbook in the post-split, pre-reorder shape — produced by actually
+    running the previous migration, not by describing its output."""
+    names, parts = fx.make_pre_xlsx(rows_data=rows_data)
+    att = Attendees(parts, sheet_part(parts, "Attendees"),
+                    require=mig.PRE_SPLIT_HEADERS)
+    book = {"att": att, "parts": parts, "names": names,
+            "part": sheet_part(parts, "Attendees")}
+    raw, _ = mig.apply_plan(book, mig.plan(book))
+    names, parts = load_parts(raw)
+    return names, parts, Attendees(parts, sheet_part(parts, "Attendees"))
+
+
+# ---------------------------------------------------------------------------
+# The mapping
+# ---------------------------------------------------------------------------
+check("the fixture starts in the appended layout",
+      mo.target_order({h: i for i, h in enumerate(APPENDED)}), APPENDED)
+check("the move produces the wanted order",
+      mo.target_order({h: MAP[i] for i, h in enumerate(APPENDED)}), WANTED)
+check("Interested in lands immediately before Status",
+      WANTED.index(NEW_COLUMN) + 1, WANTED.index("Status"))
+check("the mapping is a bijection", sorted(MAP.values()), list(range(12)))
+check("columns left of the insert point do not move",
+      [MAP[i] for i in (0, 1, 2)], [0, 1, 2])
+check("everything from Status rightward shifts by one",
+      [MAP[i] for i in range(3, 11)], list(range(4, 12)))
+check("re-planning an already-ordered workbook is a no-op",
+      mo.move_mapping({h: i for i, h in enumerate(WANTED)}), None)
+
+# A chapter that added a column of its own keeps its position on the right.
+_extra = dict({h: i for i, h in enumerate(APPENDED)}, **{"Chapter notes": 12})
+check("an extra column past the headers stays where it is",
+      mo.move_mapping(_extra)[12], 12)
+check("...and the wanted order is unaffected by it",
+      mo.target_order({h: mo.move_mapping(_extra)[i] for h, i in _extra.items()}),
+      WANTED + ["Chapter notes"])
+
+
+# ---------------------------------------------------------------------------
+# Reference rewriting
+# ---------------------------------------------------------------------------
+for ref, want in (("D2:D1000", "E2:E1000"),     # Status dropdown + colours
+                  ("L2:L1000", "D2:D1000"),     # Interested in dropdown
+                  ("B2:B1000", "B2:B1000"),     # Signal — untouched
+                  ("A2:A1000", "A2:A1000"),
+                  ("C2:C1000", "C2:C1000"),
+                  ("$A$1:$K$1", "$A$1:$L$1")):  # autoFilter, widened
+    check("remap_ref(%-11r)" % ref, mo.remap_ref(ref, MAP), want)
+check("the $ anchors survive", mo.remap_ref("$D$2", MAP), "$E$2")
+check("a cf rule that tests another column is rewritten",
+      mo.remap_formula('$B2="Non-grata"', MAP), '$B2="Non-grata"')
+check("...and one testing a column that DOES move",
+      mo.remap_formula('$D2="Accepted"', MAP), '$E2="Accepted"')
+
+# The Guide's cross-sheet references, and only those.
+GUIDE_FILTER = ("=FILTER({Attendees!A2:A, Attendees!L2:L, Attendees!H2:H, "
+                "Attendees!I2:I, Attendees!K2:K, Attendees!B2:B, Attendees!E2:E}, "
+                '(Attendees!C2:C="Yes")+(Attendees!B2:B="High"), '
+                'Attendees!B2:B<>"Non-grata")')
+check("the live list is remapped, open-ended ranges included",
+      mo.remap_formula(GUIDE_FILTER, MAP, prefix="Attendees!"),
+      "=FILTER({Attendees!A2:A, Attendees!D2:D, Attendees!I2:I, "
+      "Attendees!J2:J, Attendees!L2:L, Attendees!B2:B, Attendees!F2:F}, "
+      '(Attendees!C2:C="Yes")+(Attendees!B2:B="High"), '
+      'Attendees!B2:B<>"Non-grata")')
+check("the dashboard tiles follow the column",
+      mo.remap_formula('COUNTIF(Attendees!L2:L1000,"*Speaker*")', MAP,
+                       prefix="Attendees!"),
+      'COUNTIF(Attendees!D2:D1000,"*Speaker*")')
+check("an unrelated Attendees column is still remapped",
+      mo.remap_formula("COUNTA(Attendees!A2:A1000)", MAP, prefix="Attendees!"),
+      "COUNTA(Attendees!A2:A1000)")
+# THE trap: the Guide has its own cells, and they must not move with the
+# Attendees layout. Without the prefix scope the dashboard rewrites itself.
+check("a Guide-LOCAL reference is left alone",
+      mo.remap_formula("B5+Attendees!E2", MAP, prefix="Attendees!"),
+      "B5+Attendees!F2")
+check("...even when it names a column that moves",
+      mo.remap_formula("SUM(D2:D9)", MAP, prefix="Attendees!"), "SUM(D2:D9)")
+
+
+# ---------------------------------------------------------------------------
+# The move, end to end
+# ---------------------------------------------------------------------------
+ROWS = [
+    fx.row("Ada", "Organizer", "Intake: Organizer · Accepted · 2026-08-07", "ada@x.io"),
+    fx.row("Bo", "Host", "Intake: Host · New · 2026-08-21", "bo@x.io"),
+    fx.row("Eve", "Declined", "Pitched from the floor.", "eve@x.io"),
+]
+names, parts, att = split_book(ROWS)
+check("the input really is the appended layout", mo.target_order(att.headers), APPENDED)
+before = mo.snapshot(att)
+check("the snapshot captured the rows", len(before), 3)
+
+mapping = mo.move_mapping(att.headers)
+raw, snap = mo.apply_move({"att": att, "parts": parts, "names": names,
+                           "part": sheet_part(parts, "Attendees")}, mapping)
+mo_names, mo_parts = load_parts(raw)
+post = Attendees(mo_parts, sheet_part(mo_parts, "Attendees"))
+
+check("every zip part survives", sorted(mo_names), sorted(names))
+check("the columns are in the wanted order", mo.target_order(post.headers), WANTED)
+check("re-planning the moved workbook is a no-op", mo.move_mapping(post.headers), None)
+
+# THE check that matters. Compared BY HEADER, so a workbook whose refs were
+# renumbered inconsistently fails here even though it opens cleanly and still
+# has twelve columns.
+check("every row holds exactly the values it held before", mo.snapshot(post), before)
+check("...spot-checked on the row the split was about",
+      [post.value(3, h) for h in ("Full name", "Status", NEW_COLUMN, "Email")],
+      ["Bo", "Prospect", "Host", "bo@x.io"])
+check("a human's Declined still sits with the right person",
+      [post.value(4, h) for h in ("Full name", "Status", "Email")],
+      ["Eve", "Declined", "eve@x.io"])
+
+# The dropdowns and colour rules must have FOLLOWED their columns, not stayed
+# at the letters they were written for.
+check("both dropdowns followed their columns", check_dropdowns(post), [])
+check("the Status colour rules follow Status",
+      mig.cf_plan(post, mo_parts), "ok")
+d = mo_parts[sheet_part(mo_parts, "Attendees")].decode()
+check("the colour block now names column E",
+      'sqref="E2:E1000"' in d and 'sqref="D2:D1000"' in d, True)
+check("the Signal rules and dropdown did not move",
+      d.count('sqref="B2:B1000"'), 2)   # 1 cf block + 1 dropdown
+check("the name-turns-red rule still tests Signal",
+      '$B2="Non-grata"' in d or "$B2=&quot;Non-grata&quot;" in d, True)
+
+# Structure.
+check("the dimension covers the last column",
+      ET.fromstring(mo_parts["xl/worksheets/sheet1.xml"]).find(X + "dimension").get("ref"),
+      "A1:L4")
+check("the autoFilter was widened to cover every column",
+      ET.fromstring(mo_parts["xl/worksheets/sheet1.xml"]).find(X + "autoFilter").get("ref"),
+      "$A$1:$L$1")
+for row in post.rows.values():
+    cols = [col_of(c.get("r")) for c in row]
+    check("row %s cells stay in ascending column order" % row.get("r"),
+          cols, sorted(cols))
+
+# The moved column keeps the width the previous migration gave it, and its
+# neighbours keep theirs — <col> entries are RANGES, so a naive rewrite
+# re-widens whatever shared a run with the moved column.
+widths = {}
+for c in post.root.find(X + "cols"):
+    for i in range(int(c.get("min")) - 1, int(c.get("max")) - 1 + 1):
+        widths[i] = c.get("width")
+check("the moved column kept its width", widths.get(3), mig.NEW_COL_WIDTH)
+check("column A kept its width", widths.get(0), "22")
+check("no neighbour inherited the moved column's width",
+      [i for i, w in widths.items() if w == mig.NEW_COL_WIDTH], [3])
+
+# The Guide followed too.
+g = mo_parts[sheet_part(mo_parts, "Guide")].decode()
+check("the dashboard tiles point at the moved column",
+      'COUNTIF(Attendees!D2:D1000,"*Speaker*")' in g, True)
+check("no tile still points at the old position",
+      'Attendees!L2:L1000' in g, False)
+check("the unrelated COUNTA is untouched",
+      "COUNTA(Attendees!A2:A1000)" in g, True)
+
+# A round trip through the real reader, which is what the verify does.
+rt_names, rt_parts = load_parts(save_parts(mo_names, mo_parts))
+rt = Attendees(rt_parts, sheet_part(rt_parts, "Attendees"))
+check("the workbook survives a save/load round-trip",
+      mo.target_order(rt.headers), WANTED)
+check("...with the data still intact", mo.snapshot(rt), before)
+
+
+# ---------------------------------------------------------------------------
+# The PREVIOUS migration must stay truthful about a reordered workbook
+# ---------------------------------------------------------------------------
+# migrate_interested_in derives the Guide's target formulas from the live header
+# map. If it hardcoded the letters, then the moment this reorder ran it would
+# report three unrecognised Guide formulas on all 83 chapters, forever, about a
+# Guide that is perfectly correct.
+post_headers = dict(post.headers)
+check("the split migration sees a reordered workbook as fully migrated",
+      mig.plan({"att": post, "parts": mo_parts})["any"], False)
+check("...with no Guide formulas reported unrecognised",
+      mig.plan_guide(mo_parts, post_headers)[1], [])
+check("...and its dropdown/colour checks still pass",
+      (mig.dv_plan(post), mig.cf_plan(post, mo_parts)), ([], "ok"))
+
+# And the sync is layout-independent by construction — it addresses by header
+# name only, so the move must be invisible to it.
+check("the sync can open the reordered workbook", check_dropdowns(post), [])
+check("...and reads every column back by name",
+      sorted(post.headers), sorted(WANTED))
+
+
+print()
+if fails:
+    print("FAILED %d check(s)" % fails)
+    sys.exit(1)
+print("All checks passed.")

--- a/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
@@ -8,7 +8,7 @@ against. It is built from migrate_interested_in's own fixture, put through
 that migration, so the input here is literally what the previous script
 produces rather than a hand-written guess at it.
 """
-import os, sys
+import os, re, sys
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -97,10 +97,31 @@ for ref, want in (("D2:D1000", "E2:E1000"),     # Status dropdown + colours
                   ("$A$1:$K$1", "$A$1:$L$1")):  # autoFilter, widened
     check("remap_ref(%-11r)" % ref, mo.remap_ref(ref, MAP), want)
 check("the $ anchors survive", mo.remap_ref("$D$2", MAP), "$E$2")
-check("a cf rule that tests another column is rewritten",
-      mo.remap_formula('$B2="Non-grata"', MAP), '$B2="Non-grata"')
-check("...and one testing a column that DOES move",
+check("a cf rule testing a column that MOVES is rewritten",
       mo.remap_formula('$D2="Accepted"', MAP), '$E2="Accepted"')
+check("...and one testing a column that does not is left alone",
+      mo.remap_formula('$B2="Non-grata"', MAP), '$B2="Non-grata"')
+
+# REGRESSION (found in review, after this had already run on 83 workbooks).
+# The open-ended-range pass ran a SECOND time over a range the first pass had
+# already rewritten, because its lookahead `(?![A-Z0-9])` did not exclude `$`:
+# `$L$2:$L$1000` -> `$D$2:$D$1000` -> `$D$2:$E$1000`, a range spanning TWO
+# columns, inside a live dashboard formula, with no error anywhere. Only
+# relative refs appeared in the shipped template, which is the sole reason the
+# suite missed it — Sheets writes absolute ranges routinely.
+for f, want in (("Attendees!$L$2:$L$1000", "Attendees!$D$2:$D$1000"),
+                ("Attendees!$D$2:$D$1000", "Attendees!$E$2:$E$1000"),
+                ("Attendees!$B$2:$B$1000", "Attendees!$B$2:$B$1000"),
+                ("Attendees!$A$1:$K$1",    "Attendees!$A$1:$L$1"),
+                ("Attendees!L2:L1000",     "Attendees!D2:D1000"),
+                ("Attendees!L2:L",         "Attendees!D2:D")):
+    got = mo.remap_formula(f, MAP, prefix="Attendees!")
+    check("absolute/relative range %-24r" % f, got, want)
+check("no remapped range ever spans two columns",
+      [g for g in (mo.remap_formula("Attendees!$%s$2:$%s$1000" % (c, c), MAP,
+                                    prefix="Attendees!")
+                   for c in "ABCDEFGHIJKL")
+       if len(set(re.findall(r"\$([A-Z]+)\$", g))) != 1], [])
 
 # The Guide's cross-sheet references, and only those.
 GUIDE_FILTER = ("=FILTER({Attendees!A2:A, Attendees!L2:L, Attendees!H2:H, "
@@ -173,8 +194,8 @@ check("the colour block now names column E",
       'sqref="E2:E1000"' in d and 'sqref="D2:D1000"' in d, True)
 check("the Signal rules and dropdown did not move",
       d.count('sqref="B2:B1000"'), 2)   # 1 cf block + 1 dropdown
-check("the name-turns-red rule still tests Signal",
-      '$B2="Non-grata"' in d or "$B2=&quot;Non-grata&quot;" in d, True)
+check("the name-turns-red rule still tests Signal, in the fixture's encoding",
+      '$B2="Non-grata"' in d, True)
 
 # Structure.
 check("the dimension covers the last column",
@@ -217,6 +238,96 @@ check("the workbook survives a save/load round-trip",
 check("...with the data still intact", mo.snapshot(rt), before)
 
 
+# A chapter's own data column past the last HEADER is outside move_mapping
+# (which is built from headers), so taking the sheet's new extent from the
+# mapping narrowed <dimension> and <autoFilter> past that data — and
+# Attendees.serialize()'s "never NARROW" guard cannot help, because it
+# recomputes the width from the ref this code just shrank.
+_n4, _p4 = fx.make_pre_xlsx(rows_data=[fx.row("Bo", "Host",
+    "Intake: Host · New · 2026-08-21", "b@x.io")])
+_d4 = _p4["xl/worksheets/sheet1.xml"].decode().replace(
+    "</sheetData>",
+    '<row r="9"><c r="M9" t="inlineStr"><is><t>note</t></is></c></row></sheetData>", 1'[:-4],
+    1).replace('<dimension ref="A1:K2"', '<dimension ref="A1:M9"')
+_p4["xl/worksheets/sheet1.xml"] = _d4.encode()
+_b4 = {"att": Attendees(_p4, sheet_part(_p4, "Attendees"), require=mig.PRE_SPLIT_HEADERS),
+       "parts": _p4, "names": _n4, "part": sheet_part(_p4, "Attendees")}
+_raw4, _ = mig.apply_plan(_b4, mig.plan(_b4))
+_n4, _p4 = load_parts(_raw4)
+_a4 = Attendees(_p4, sheet_part(_p4, "Attendees"))
+_raw4, _ = mo.apply_move({"att": _a4, "parts": _p4, "names": _n4,
+                          "part": sheet_part(_p4, "Attendees")},
+                         mo.move_mapping(_a4.headers))
+_, _pm = load_parts(_raw4)
+_dm = _pm[sheet_part(_pm, "Attendees")].decode()
+check("an un-headered data column does not narrow <dimension>",
+      re.search(r'<dimension ref="([^"]+)"', _dm).group(1), "A1:M9")
+check("...nor the autoFilter", re.search(r'<autoFilter ref="([^"]+)"', _dm).group(1),
+      "$A$1:$M$1")
+check("...and its data survives", 'r="M9"' in _dm, True)
+
+
+# ---------------------------------------------------------------------------
+# Hyperlinks, and the elements this move refuses to touch
+# ---------------------------------------------------------------------------
+# REGRESSION (found in review, after this had run on 83 workbooks). Hyperlinks
+# carry a ref like everything else. Leaving them behind is silent in the worst
+# way: the link stays on the ADDRESS while its column slides out from under it,
+# so a LinkedIn URL ends up on the Email cell and clicking someone's address
+# opens a profile. snapshot() compares cell VALUES, so the verify cannot see
+# it. Dallas and Kampala had 6 such links between them.
+names, parts = fx.make_pre_xlsx(rows_data=[fx.row("Ada","Organizer",
+    "Intake: Organizer · Accepted · 2026-08-07","ada@x.io")])
+_s = parts["xl/worksheets/sheet1.xml"].decode().replace(
+    "<dataValidations", '<hyperlinks><hyperlink ref="G2" location="linkedin"/></hyperlinks>'
+    "<dataValidations", 1)
+parts["xl/worksheets/sheet1.xml"] = _s.encode()
+att_h = Attendees(parts, sheet_part(parts, "Attendees"), require=mig.PRE_SPLIT_HEADERS)
+check("G is 'LinkedIn URL' before the move",
+      mo.target_order(att_h.headers)[6], "LinkedIn URL")
+mig.apply_plan({"att": att_h, "parts": parts, "names": names,
+                "part": sheet_part(parts, "Attendees")}, mig.plan({"att": att_h, "parts": parts}))
+_n, _p = load_parts(save_parts(names, parts))
+att_h = Attendees(_p, sheet_part(_p, "Attendees"))
+raw_h, _ = mo.apply_move({"att": att_h, "parts": _p, "names": _n,
+                          "part": sheet_part(_p, "Attendees")}, mo.move_mapping(att_h.headers))
+_, ph = load_parts(raw_h)
+post_h = Attendees(ph, sheet_part(ph, "Attendees"))
+dh = ph[sheet_part(ph, "Attendees")].decode()
+check("the hyperlink followed its column G -> H",
+      re.search(r'<hyperlink ref="([^"]+)"', dh).group(1), "H2")
+check("...and H is 'LinkedIn URL' after the move",
+      mo.target_order(post_h.headers)[7], "LinkedIn URL")
+check("...so it is NOT sitting on Email",
+      mo.target_order(post_h.headers)[6], "Email")
+
+# Elements whose position this move cannot renumber are refused, not ignored —
+# a cell formula's cached <v> survives the move, so the verify would pass.
+_, _, att_ok = split_book()
+check("a normal workbook has nothing unmovable", mo.unmovable(att_ok), [])
+for frag, want in (('<mergeCells count="1"><mergeCell ref="A1:B1"/></mergeCells>',
+                    ["1 merged cell(s)"]),
+                   ('<autoFilter ref="$A$1:$L$1"><filterColumn colId="3"/></autoFilter>',
+                    ["1 autoFilter column filter(s)"])):
+    _n2, _p2 = fx.make_pre_xlsx()
+    _p2["xl/worksheets/sheet1.xml"] = _p2["xl/worksheets/sheet1.xml"].decode().replace(
+        "<dataValidations", frag + "<dataValidations", 1).encode()
+    _a2 = Attendees(_p2, sheet_part(_p2, "Attendees"), require=mig.PRE_SPLIT_HEADERS)
+    check("unmovable detects %s" % want[0], mo.unmovable(_a2), want)
+_n3, _p3 = fx.make_pre_xlsx(rows_data=[fx.row("Ada","Organizer","n","a@x.io")])
+_d3 = _p3["xl/worksheets/sheet1.xml"].decode()
+# A chapter's own helper formula in a spare column, with a CACHED result — the
+# cache is why snapshot() cannot see the breakage and the workbook must be
+# refused instead.
+_d3 = _d3.replace("</sheetData>",
+                  '<row r="9"><c r="M9"><f>IF(D2="Accepted",1,0)</f><v>0</v></c>'
+                  "</row></sheetData>", 1)
+_p3["xl/worksheets/sheet1.xml"] = _d3.encode()
+_a3 = Attendees(_p3, sheet_part(_p3, "Attendees"), require=mig.PRE_SPLIT_HEADERS)
+check("unmovable detects a chapter's own cell formula",
+      mo.unmovable(_a3), ["1 cell formula(s)"])
+
+
 # ---------------------------------------------------------------------------
 # The PREVIOUS migration must stay truthful about a reordered workbook
 # ---------------------------------------------------------------------------
@@ -230,7 +341,7 @@ check("the split migration sees a reordered workbook as fully migrated",
 check("...with no Guide formulas reported unrecognised",
       mig.plan_guide(mo_parts, post_headers)[1], [])
 check("...and its dropdown/colour checks still pass",
-      (mig.dv_plan(post), mig.cf_plan(post, mo_parts)), ([], "ok"))
+      (mig.dv_plan(post), mig.cf_plan(post, mo_parts)), (([], []), mig.CF_OK))
 
 # And the sync is layout-independent by construction — it addresses by header
 # name only, so the move must be invisible to it.

--- a/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Unit tests for migrate_interested_in.py (no network/gws).
+
+The fixture is a PRE-split workbook — eleven columns, the old Status dropdown
+with its role values, and the Guide tab's real formulas — because that is the
+only shape this migration ever runs against. Built here rather than checked in
+as a binary, for the reason sync_crm's tests give: a binary would silently stop
+resembling the live workbooks, and this cannot.
+"""
+import os, sys
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import migrate_interested_in as mig
+import sync_crm
+from sync_crm import (Attendees, DV_EXPECTED, NEW_COLUMN, X, check_dropdowns,
+                      cell_ref, col_of, load_parts, sheet_part)
+
+fails = 0
+def check(label, got, want):
+    global fails
+    ok = got == want
+    fails += 0 if ok else 1
+    print("%s %s" % ("ok  " if ok else "FAIL", label))
+    if not ok:
+        print("      got : %r\n      want: %r" % (got, want))
+
+
+# ---------------------------------------------------------------------------
+# Fixture: the workbook as it was BEFORE the split
+# ---------------------------------------------------------------------------
+PRE = mig.PRE_SPLIT_HEADERS
+# The list every chapter carried until 2026-08-25 — roles and lifecycle values
+# in one column, which is the conflation being undone.
+OLD_DV = "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
+
+# The Guide tab's real content, verbatim from the shipped template: two
+# dashboard COUNTIFs against the Status column and the live-list FILTER whose
+# `Attendees!L2:L` points at a column that does not exist on this layout.
+GUIDE = (
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    '<sheetData>'
+    '<row r="1"><c r="B1" t="inlineStr"><is><t>'
+    '=FILTER({Attendees!A2:A, Attendees!I2:I, Attendees!K2:K, Attendees!L2:L, '
+    'Attendees!B2:B, Attendees!E2:E}, (Attendees!C2:C=&quot;Yes&quot;)'
+    '+(Attendees!B2:B=&quot;High&quot;), Attendees!B2:B&lt;&gt;&quot;Non-grata&quot;)'
+    '</t></is></c></row>'
+    '<row r="2"><c r="D2"><f>COUNTIF(Attendees!D2:D1000,"Speaker")</f><v>3</v></c></row>'
+    '<row r="3"><c r="D3"><f>COUNTIF(Attendees!D2:D1000,"Organizer")</f><v>5</v></c></row>'
+    '<row r="4"><c r="D4"><f>COUNTA(Attendees!A2:A1000)</f><v>9</v></c></row>'
+    '</sheetData></worksheet>')
+
+
+def _c(ref, text, style=None):
+    s = ' s="%s"' % style if style else ""
+    if text is None:
+        return '<c r="%s"%s t="n" />' % (ref, s)
+    return '<c r="%s"%s t="inlineStr"><is><t>%s</t></is></c>' % (ref, s, text)
+
+
+def make_pre_xlsx(rows_data=(), headers=PRE, dv=OLD_DV, guide=GUIDE, cols=True):
+    """A pre-split workbook. `rows_data` is [[cell, ...]] starting at row 2."""
+    head = "".join(_c(cell_ref(i, 1), h, "2") for i, h in enumerate(headers))
+    rows = ['<row r="1" ht="30" customHeight="1" s="20">%s</row>' % head]
+    for n, vals in enumerate(rows_data, start=2):
+        cells = "".join(_c(cell_ref(i, n), v, "3") for i, v in enumerate(vals) if v)
+        rows.append('<row r="%d">%s</row>' % (n, cells))
+    # The shipped <cols>: one run covering L..S (12..19) at the default width,
+    # which is what widen_column has to split rather than narrow wholesale.
+    colblock = ('<cols><col width="22" customWidth="1" style="20" min="1" max="1" />'
+                '<col width="8.71" customWidth="1" style="20" min="12" max="19" />'
+                '</cols>') if cols else ""
+    sheet = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        '<dimension ref="A1:K%d" />%s<sheetData>%s</sheetData>'
+        '<dataValidations count="2">'
+        '<dataValidation sqref="B2:B1000" type="list">'
+        '<formula1>"High,Low,Non-grata,New"</formula1></dataValidation>'
+        '<dataValidation sqref="D2:D1000" type="list">'
+        '<formula1>"%s"</formula1></dataValidation>'
+        '</dataValidations></worksheet>'
+        % (1 + len(rows_data), colblock, "".join(rows), dv))
+    parts = {
+        "[Content_Types].xml": "<Types />",
+        "_rels/.rels": "<Relationships />",
+        "xl/workbook.xml":
+            '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+            ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+            '<sheets><sheet name="Attendees" sheetId="1" r:id="rId7" />'
+            '<sheet name="Guide" sheetId="2" r:id="rId9" /></sheets></workbook>',
+        "xl/_rels/workbook.xml.rels":
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            '<Relationship Id="rId7" Target="worksheets/sheet1.xml" />'
+            '<Relationship Id="rId9" Target="worksheets/sheet2.xml" /></Relationships>',
+        "xl/worksheets/sheet1.xml": sheet,
+        "xl/worksheets/sheet2.xml": guide,
+    }
+    names = list(parts)
+    return names, {n: v.encode() for n, v in parts.items()}
+
+
+def row(name, status, note, email):
+    """One pre-split Attendees row: A name, D status, E note, F email."""
+    return [name, "", "", status, note, email, "", "", "", "", ""]
+
+
+def opened(**kw):
+    names, parts = make_pre_xlsx(**kw)
+    att = Attendees(parts, sheet_part(parts, "Attendees"),
+                    require=mig.PRE_SPLIT_HEADERS)
+    return names, parts, att
+
+
+# ---------------------------------------------------------------------------
+# parse_note — the provenance string is the only source of truth for a backfill
+# ---------------------------------------------------------------------------
+check("an accepted organizer's note",
+      mig.parse_note("Intake: Organizer · Accepted · 2026-08-07"),
+      ("Organizer", "Accepted"))
+check("a pipeline host's note — the row this whole change is about",
+      mig.parse_note("Intake: Host · New · 2026-08-21"),
+      ("Host", "Prospect"))
+check("the legacy New spelling maps like Prospect",
+      mig.parse_note("Intake: Speaker · Prospect · 2026-08-21"),
+      ("Speaker", "Prospect"))
+check("a multi-role note keeps every role",
+      mig.parse_note("Intake: Organizer/Speaker/Host · New · 2026-08-21"),
+      ("Organizer/Speaker/Host", "Prospect"))
+check("accepted in ANY role wins, matching crm_fields",
+      mig.parse_note("Intake: Organizer/Speaker · Tentative/Accepted · 2026-08-07"),
+      ("Organizer/Speaker", "Accepted"))
+check("'Existing (from MLOps)' is an accepted status",
+      mig.parse_note("Intake: Organizer · Existing (from MLOps) · 2026-08-07"),
+      ("Organizer", "Accepted"))
+check("an in-flight status is carried through verbatim",
+      mig.parse_note("Intake: Organizer · Interviewing · 2026-08-07"),
+      ("Organizer", "Interviewing"))
+for note in ("", "Met at the Feb event; will co-host.",
+             "Intake: Sponsor · Accepted · 2026-08-07",
+             "Intake: Organizer · Accepted"):
+    check("unparsable note %-46r -> nothing" % note[:44], mig.parse_note(note), ("", ""))
+check("a note with an unrecognised STATUS still relocates the role",
+      mig.parse_note("Intake: Host · Retired · 2026-08-07"), ("Host", ""))
+
+# Every status the sync can stamp into a note must parse back out, or the
+# backfill silently blanks the Status of everyone carrying it.
+_unparsable = [st for st in sync_crm.SYNC_STATUSES + sync_crm.PIPELINE_STATUSES
+                if st and mig.parse_note("Intake: Host · %s · 2026-08-07" % st)[1] == ""]
+check("every intake status round-trips through a note", _unparsable, [])
+
+
+# ---------------------------------------------------------------------------
+# plan_row — what actually gets rewritten
+# ---------------------------------------------------------------------------
+check("THE bug: a pipeline host reading 'Host' becomes Prospect + Host",
+      mig.plan_row("", "Host", "Intake: Host · New · 2026-08-21"),
+      {NEW_COLUMN: "Host", "Status": "Prospect"})
+check("an accepted organizer keeps their standing, stated properly",
+      mig.plan_row("", "Organizer", "Intake: Organizer · Accepted · 2026-08-07"),
+      {NEW_COLUMN: "Organizer", "Status": "Accepted"})
+check("a pipeline organizer already said Prospect — only the role moves in",
+      mig.plan_row("", "Prospect", "Intake: Organizer · New · 2026-08-21"),
+      {NEW_COLUMN: "Organizer"})
+check("a role with no usable note is RELOCATED, and no status is invented",
+      mig.plan_row("", "Speaker", "Met her at the Feb event."),
+      {NEW_COLUMN: "Speaker", "Status": ""})
+
+# The curated values. A human who set these said something the intake does not
+# know, and none of them is a role, so none is this script's business.
+for human in ("Attended", "Regular", "Volunteer", "Declined"):
+    check("a human's %r is untouched" % human,
+          mig.plan_row("", human, "Intake: Host · New · 2026-08-21"),
+          {NEW_COLUMN: "Host"})
+check("a blank Status stays blank",
+      mig.plan_row("", "", "Met at the Feb event."), {})
+check("an already-filled Interested in is never restated",
+      mig.plan_row("Organizer", "Organizer",
+                   "Intake: Organizer · Accepted · 2026-08-07"),
+      {"Status": "Accepted"})
+check("a human's note in Interested in survives",
+      mig.plan_row("Organizer (co-lead)", "Prospect",
+                   "Intake: Organizer · New · 2026-08-21"), {})
+check("a hand-typed lowercase role is still recognised",
+      mig.plan_row("", "host", "Met at the Feb event."),
+      {NEW_COLUMN: "Host", "Status": ""})
+
+# Idempotency at the row level: the output of a pass is a fixed point.
+_first = mig.plan_row("", "Host", "Intake: Host · New · 2026-08-21")
+check("re-planning a migrated row proposes nothing",
+      mig.plan_row(_first[NEW_COLUMN], _first["Status"],
+                   "Intake: Host · New · 2026-08-21"), {})
+
+
+# ---------------------------------------------------------------------------
+# The column: added, widened, addressable
+# ---------------------------------------------------------------------------
+names, parts, att = opened(rows_data=[row("Ada", "Host", "Intake: Host · New · 2026-08-21",
+                                          "ada@x.io")])
+check("the fixture really is pre-split", NEW_COLUMN in att.headers, False)
+col = mig.add_column(att)
+check("the new column lands past the last header (L)", col, 11)
+check("...and is addressable by name", att.headers[NEW_COLUMN], 11)
+check("...and carries the header row's style",
+      next(c.get("s") for c in att.rows[1].findall(X + "c")
+           if col_of(c.get("r")) == col), "2")
+check("add_column is idempotent", mig.add_column(att), 11)
+
+mig.widen_column(att, col)
+runs = [(int(c.get("min")), int(c.get("max")), c.get("width"))
+        for c in att.root.find(X + "cols")]
+check("the shared 12-19 run is SPLIT, not re-widened wholesale",
+      runs, [(1, 1, "22"), (12, 12, mig.NEW_COL_WIDTH), (13, 19, "8.71")])
+mig.widen_column(att, col)
+check("widen_column is idempotent",
+      [(int(c.get("min")), int(c.get("max")), c.get("width"))
+       for c in att.root.find(X + "cols")], runs)
+_, _, att_nc = opened(cols=False)
+mig.widen_column(att_nc, mig.add_column(att_nc))
+check("a workbook with no <cols> is left alone rather than crashing",
+      att_nc.root.find(X + "cols"), None)
+
+
+# ---------------------------------------------------------------------------
+# The dropdowns
+# ---------------------------------------------------------------------------
+names, parts, att = opened()
+check("the pre-split lists are both reported wrong",
+      sorted(h for h, _ in mig.dv_plan(att)), sorted(["Status", NEW_COLUMN]))
+check("...and the Status one is reported with what it currently holds",
+      dict(mig.dv_plan(att))["Status"], OLD_DV)
+mig.add_column(att)
+check("apply_dropdowns refuses nothing on a normal workbook",
+      mig.apply_dropdowns(att), [])
+check("both lists are now right", mig.dv_plan(att), [])
+check("no role word is left on the Status list",
+      [r for r in mig.ROLE_WORDS.values()
+       if r in DV_EXPECTED["Status"].split(",")], [])
+check("the Signal list — an unrelated 'New' — is untouched",
+      [mig._dv_formula(dv) for dv in mig._dv_elements(att)
+       if mig._dv_column(dv) == 1], ["High,Low,Non-grata,New"])
+check("the count attribute is refreshed",
+      att.root.find(X + "dataValidations").get("count"), "3")
+
+# A validation spanning several columns cannot be rewritten without silently
+# re-validating its neighbour, so it is refused and reported, never guessed at.
+names, parts = make_pre_xlsx()
+parts["xl/worksheets/sheet1.xml"] = parts["xl/worksheets/sheet1.xml"].replace(
+    b'sqref="D2:D1000"', b'sqref="C2:D1000"')
+att_m = Attendees(parts, sheet_part(parts, "Attendees"), require=mig.PRE_SPLIT_HEADERS)
+mig.add_column(att_m)
+check("a merged sqref is refused, not rewritten",
+      mig.apply_dropdowns(att_m), ["Status"])
+check("...and the merged rule is left exactly as it was",
+      [dv.get("sqref") for dv in mig._dv_elements(att_m)
+       if dv.get("sqref") == "C2:D1000"], ["C2:D1000"])
+
+
+# ---------------------------------------------------------------------------
+# The Guide tab
+# ---------------------------------------------------------------------------
+names, parts = make_pre_xlsx()
+todo, missing = mig.plan_guide(parts, 11)
+check("all three Guide formulas are due", len(todo), 3)
+check("...and none is unrecognised", missing, [])
+mig.apply_guide(parts, todo)
+g = parts["xl/worksheets/sheet2.xml"].decode()
+check("the Speaker dashboard tile now counts the new column",
+      '<f>COUNTIF(Attendees!L2:L1000,"*Speaker*")</f>' in g, True)
+check("the Organizer tile too",
+      '<f>COUNTIF(Attendees!L2:L1000,"*Organizer*")</f>' in g, True)
+check("no dashboard tile still counts Status for a role",
+      'COUNTIF(Attendees!D2:D1000,"Speaker")' in g
+      or 'COUNTIF(Attendees!D2:D1000,"Organizer")' in g, False)
+check("the unrelated COUNTA is untouched",
+      '<f>COUNTA(Attendees!A2:A1000)</f>' in g, True)
+check("the live list no longer has a dangling reference",
+      "Attendees!L2:L," in g and "Attendees!H2:H" in g, True)
+check("the live list's filter conditions are unchanged",
+      "(Attendees!C2:C=&quot;Yes&quot;)+(Attendees!B2:B=&quot;High&quot;)" in g, True)
+check("re-planning a migrated Guide proposes nothing", mig.plan_guide(parts, 11)[0], [])
+
+# A Guide someone edited: report the miss rather than regex something we do not
+# understand into a formula.
+names, parts = make_pre_xlsx(
+    guide=GUIDE.replace('COUNTIF(Attendees!D2:D1000,"Speaker")', 'COUNTIF(Foo!A1:A9,"x")'))
+todo, missing = mig.plan_guide(parts, 11)
+check("an edited Guide formula is reported, not rewritten", len(missing), 1)
+check("...and the ones still recognised are still planned", len(todo), 2)
+
+# The LEGACY storage shape, which five live chapters actually have (Austin,
+# Dallas, Kampala, London, Tatooine as of 2026-08-25): the formulas escape
+# their quotes as &quot; and every string lives in the SHARED table rather
+# than inline in the sheet. Searching only the sheet part for only the `"`
+# spelling found none of it, and reported all three edits as unrecognised
+# while those dashboards sat there still counting the Status column.
+LEGACY_GUIDE = (
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    '<sheetData>'
+    '<row r="1"><c r="B1" t="s"><v>0</v></c></row>'
+    '<row r="2"><c r="D2"><f>COUNTIF(Attendees!D2:D1000,&quot;Speaker&quot;)</f>'
+    '<v>3</v></c></row>'
+    '<row r="3"><c r="D3"><f>COUNTIF(Attendees!D2:D1000,&quot;Organizer&quot;)</f>'
+    '<v>5</v></c></row>'
+    '</sheetData></worksheet>')
+LEGACY_SST = (
+    '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><si><t>'
+    '=FILTER({Attendees!A2:A, Attendees!I2:I, Attendees!K2:K, Attendees!L2:L, '
+    'Attendees!B2:B, Attendees!E2:E}, (Attendees!C2:C=&quot;Yes&quot;)'
+    '+(Attendees!B2:B=&quot;High&quot;), Attendees!B2:B&lt;&gt;&quot;Non-grata&quot;)'
+    '</t></si></sst>')
+names, parts = make_pre_xlsx(guide=LEGACY_GUIDE)
+parts["xl/sharedStrings.xml"] = LEGACY_SST.encode()
+todo, missing = mig.plan_guide(parts, 11)
+check("the legacy shape is fully recognised", (len(todo), missing), (3, []))
+check("...with the FILTER found in the SHARED table, not the sheet",
+      sorted({t[0] for t in todo}),
+      ["xl/sharedStrings.xml", "xl/worksheets/sheet2.xml"])
+mig.apply_guide(parts, todo)
+lg = parts["xl/worksheets/sheet2.xml"].decode()
+check("the legacy tiles are repointed, keeping their escaping",
+      '<f>COUNTIF(Attendees!L2:L1000,&quot;*Speaker*&quot;)</f>' in lg
+      and '<f>COUNTIF(Attendees!L2:L1000,&quot;*Organizer*&quot;)</f>' in lg, True)
+check("...and no legacy tile still counts Status",
+      'Attendees!D2:D1000,&quot;Speaker&quot;' in lg, False)
+check("the shared-table live list is repointed",
+      "Attendees!H2:H" in parts["xl/sharedStrings.xml"].decode(), True)
+check("re-planning the migrated legacy shape proposes nothing",
+      mig.plan_guide(parts, 11)[0], [])
+
+
+# ---------------------------------------------------------------------------
+# End to end: migrate, then hand the result to the sync
+# ---------------------------------------------------------------------------
+# This is the test that matters. The migration and the sync are two scripts
+# that must agree on the exact bytes for every row, or --write never converges:
+# the sync re-proposes changes forever and the run reports "ops still pending",
+# indistinguishable from a real write failure.
+ROWS = [
+    row("Ada", "Organizer", "Intake: Organizer · Accepted · 2026-08-07", "ada@x.io"),
+    row("Bo", "Host", "Intake: Host · New · 2026-08-21", "bo@x.io"),
+    row("Cy", "Speaker", "Intake: Speaker · New · 2026-08-21", "cy@x.io"),
+    row("Dee", "Prospect", "Intake: Organizer · Tentative · 2026-08-21", "dee@x.io"),
+    row("Eve", "Declined", "Pitched from the floor.", "eve@x.io"),
+]
+names, parts, att = opened(rows_data=ROWS)
+p = mig.plan({"att": att, "parts": parts})
+check("the whole workbook is due", p["any"], True)
+check("...adding the column", p["add_column"], True)
+check("...backfilling four of the five rows", len(p["rows"]), 4)
+check("...moving three roles out of Status",
+      sum(1 for o in p["rows"] if "Status" in o["sets"]), 3)
+raw, refused = mig.apply_plan(
+    {"att": att, "parts": parts, "names": names, "part": sheet_part(parts, "Attendees")}, p)
+check("nothing was refused", refused, [])
+
+# Re-open through the SYNC's own reader, which demands the full header set.
+mig_names, mig_parts = load_parts(raw)
+post = Attendees(mig_parts, sheet_part(mig_parts, "Attendees"))
+check("every zip part survives", sorted(mig_names), sorted(names))
+check("the sync can now open the workbook", NEW_COLUMN in post.headers, True)
+check("the sync sees no stale dropdowns", check_dropdowns(post), [])
+check("the split, row by row",
+      [(post.value(r, "Full name"), post.value(r, "Status"), post.value(r, NEW_COLUMN))
+       for r in range(2, 7)],
+      [("Ada", "Accepted", "Organizer"),
+       ("Bo", "Prospect", "Host"),            # <- was a flat "Host"
+       ("Cy", "Prospect", "Speaker"),         # <- was a flat "Speaker"
+       ("Dee", "Prospect", "Organizer"),
+       ("Eve", "Declined", "")])              # <- a human's call, untouched
+check("no Notes (CRM) cell was rewritten",
+      post.value(3, "Notes (CRM)"), "Intake: Host · New · 2026-08-21")
+check("the dimension covers the new column",
+      ET.fromstring(mig_parts["xl/worksheets/sheet1.xml"]).find(X + "dimension").get("ref"),
+      "A1:L6")
+
+# Idempotency at the workbook level, through a real round-trip.
+check("a second migration pass proposes nothing",
+      mig.plan({"att": post, "parts": mig_parts})["any"], False)
+
+# And the sync agrees with what the migration wrote: for the people still on
+# the intake it proposes nothing, which is what makes --write converge.
+def _person(name, email, tab, status):
+    return {"row": 2, "tab": tab, "status": status, "name": name, "email": email,
+            "city": "Boston", "linkedin": "", "company": "", "title": "",
+            "expertise": "", "interest": ""}
+
+live = sync_crm.merge_people([
+    _person("Ada", "ada@x.io", "Organizers", "Accepted"),
+    _person("Bo", "bo@x.io", "Hosts", "Prospect"),
+    _person("Cy", "cy@x.io", "Speakers", "Prospect")])
+left = sync_crm.plan_workbook(post, live, "2026-08-26")
+check("the sync proposes no Status or role change over a migrated workbook",
+      [(o["rownum"], k) for o in left for k in o["sets"]
+       if k in ("Status", NEW_COLUMN)], [])
+
+# The sync must still be able to UPGRADE what the migration wrote — a blank
+# Status left by an unparsable note, and a Prospect that has since been
+# accepted. Both are in AUTO_STATUS; if either were not, the migration would
+# have frozen those people permanently.
+check("a migration-written Prospect is still auto-owned",
+      [v for v in ("", "Prospect", "Accepted", "Interviewing", "Tentative",
+                   "In progress") if v not in sync_crm.AUTO_STATUS], [])
+up = sync_crm.plan_workbook(post, sync_crm.merge_people(
+    [_person("Bo", "bo@x.io", "Hosts", "Accepted")]), "2026-08-26")
+check("acceptance upgrades a migrated row in place",
+      (up[0]["rownum"], up[0]["sets"].get("Status")), (3, "Accepted"))
+check("...without disturbing what they applied for",
+      NEW_COLUMN in up[0]["sets"], False)
+
+
+print()
+if fails:
+    print("FAILED %d check(s)" % fails)
+    sys.exit(1)
+print("All checks passed.")

--- a/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
@@ -254,13 +254,14 @@ check("a workbook with no <cols> is left alone rather than crashing",
 # ---------------------------------------------------------------------------
 names, parts, att = opened()
 check("the pre-split lists are both reported wrong",
-      sorted(h for h, _ in mig.dv_plan(att)), sorted(["Status", NEW_COLUMN]))
+      sorted(h for h, _ in mig.dv_plan(att)[0]), sorted(["Status", NEW_COLUMN]))
 check("...and the Status one is reported with what it currently holds",
-      dict(mig.dv_plan(att))["Status"], OLD_DV)
+      dict(mig.dv_plan(att)[0])["Status"], OLD_DV)
+check("...and nothing is blocked on a normal workbook", mig.dv_plan(att)[1], [])
 mig.add_column(att)
 check("apply_dropdowns refuses nothing on a normal workbook",
       mig.apply_dropdowns(att), [])
-check("both lists are now right", mig.dv_plan(att), [])
+check("both lists are now right", mig.dv_plan(att), ([], []))
 check("no role word is left on the Status list",
       [r for r in mig.ROLE_WORDS.values()
        if r in DV_EXPECTED["Status"].split(",")], [])
@@ -277,11 +278,43 @@ parts["xl/worksheets/sheet1.xml"] = parts["xl/worksheets/sheet1.xml"].replace(
     b'sqref="D2:D1000"', b'sqref="C2:D1000"')
 att_m = Attendees(parts, sheet_part(parts, "Attendees"), require=mig.PRE_SPLIT_HEADERS)
 mig.add_column(att_m)
+# Status is BLOCKED (its rule spans C:D and cannot be split safely) while
+# Interested in is still ordinary work. Separating the two is what stops a
+# blocked column pinning `plan()["any"]` true for ever.
+check("a merged sqref is reported BLOCKED while the other stays due",
+      mig.dv_plan(att_m), ([(NEW_COLUMN, None)], ["Status"]))
 check("a merged sqref is refused, not rewritten",
       mig.apply_dropdowns(att_m), ["Status"])
-check("...and the merged rule is left exactly as it was",
-      [dv.get("sqref") for dv in mig._dv_elements(att_m)
-       if dv.get("sqref") == "C2:D1000"], ["C2:D1000"])
+check("...and the merged rule keeps its sqref AND its list",
+      [(dv.get("sqref"), mig._dv_formula(dv)) for dv in mig._dv_elements(att_m)
+       if dv.get("sqref") == "C2:D1000"],
+      [("C2:D1000", OLD_DV)])
+
+# REGRESSION (found in review, after this had already run on 83 workbooks).
+# A workbook with NO <dataValidations> block got one via ET.SubElement, which
+# appends to the end of <worksheet> — after <pageMargins>. CT_Worksheet is a
+# fixed sequence, so Excel calls that file corrupt. And because apply_dropdowns
+# runs BEFORE apply_cf, the appended block then became the anchor apply_cf
+# searched for, dragging the colour rules after pageMargins too. Every fixture
+# ships a dropdown block, which is why nothing caught it.
+names, parts = make_pre_xlsx()
+_sheet = parts["xl/worksheets/sheet1.xml"].decode()
+_sheet = (_sheet[:_sheet.index("<dataValidations")]
+          + _sheet[_sheet.index("</dataValidations>") + len("</dataValidations>"):])
+parts["xl/worksheets/sheet1.xml"] = _sheet.encode()
+check("the fixture really has no dropdown block", "<dataValidations" in _sheet, False)
+_book = {"att": Attendees(parts, sheet_part(parts, "Attendees"),
+                          require=mig.PRE_SPLIT_HEADERS),
+         "parts": parts, "names": names, "part": sheet_part(parts, "Attendees")}
+mig.apply_plan(_book, mig.plan(_book))
+_kids = [k.tag.split("}")[1] for k in _book["att"].root]
+check("a created dropdown block lands before pageMargins",
+      _kids.index("dataValidations") < _kids.index("pageMargins"), True)
+check("...and the colour rules land before it",
+      max(i for i, k in enumerate(_kids) if k == "conditionalFormatting")
+      < _kids.index("dataValidations"), True)
+check("...and both dropdowns are correct on the rebuilt block",
+      mig.dv_plan(_book["att"]), ([], []))
 
 
 # ---------------------------------------------------------------------------

--- a/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
@@ -30,6 +30,9 @@ def check(label, got, want):
 # Fixture: the workbook as it was BEFORE the split
 # ---------------------------------------------------------------------------
 PRE = mig.PRE_SPLIT_HEADERS
+#: The header map as it stands once the column has been appended at L — what
+#: the Guide formulas are computed against.
+POST_SPLIT_HEADERS = dict({h: i for i, h in enumerate(PRE)}, **{NEW_COLUMN: 11})
 # The list every chapter carried until 2026-08-25 — roles and lifecycle values
 # in one column, which is the conflation being undone.
 OLD_DV = "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
@@ -91,6 +94,7 @@ def make_pre_xlsx(rows_data=(), headers=PRE, dv=OLD_DV, guide=GUIDE, cols=True,
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
         '<dimension ref="A1:K%d" />%s<sheetData>%s</sheetData>'
+        '<autoFilter ref="$A$1:$K$1" />'
         # conditionalFormatting must sit AFTER sheetData and BEFORE
         # dataValidations — CT_Worksheet fixes the order, and Excel calls the
         # file corrupt if a block lands after pageMargins.
@@ -362,7 +366,7 @@ check("the colour rules survive a serialize round-trip",
 # The Guide tab
 # ---------------------------------------------------------------------------
 names, parts = make_pre_xlsx()
-todo, missing = mig.plan_guide(parts, 11)
+todo, missing = mig.plan_guide(parts, POST_SPLIT_HEADERS)
 check("all three Guide formulas are due", len(todo), 3)
 check("...and none is unrecognised", missing, [])
 mig.apply_guide(parts, todo)
@@ -380,13 +384,13 @@ check("the live list no longer has a dangling reference",
       "Attendees!L2:L," in g and "Attendees!H2:H" in g, True)
 check("the live list's filter conditions are unchanged",
       "(Attendees!C2:C=&quot;Yes&quot;)+(Attendees!B2:B=&quot;High&quot;)" in g, True)
-check("re-planning a migrated Guide proposes nothing", mig.plan_guide(parts, 11)[0], [])
+check("re-planning a migrated Guide proposes nothing", mig.plan_guide(parts, POST_SPLIT_HEADERS)[0], [])
 
 # A Guide someone edited: report the miss rather than regex something we do not
 # understand into a formula.
 names, parts = make_pre_xlsx(
     guide=GUIDE.replace('COUNTIF(Attendees!D2:D1000,"Speaker")', 'COUNTIF(Foo!A1:A9,"x")'))
-todo, missing = mig.plan_guide(parts, 11)
+todo, missing = mig.plan_guide(parts, POST_SPLIT_HEADERS)
 check("an edited Guide formula is reported, not rewritten", len(missing), 1)
 check("...and the ones still recognised are still planned", len(todo), 2)
 
@@ -413,7 +417,7 @@ LEGACY_SST = (
     '</t></si></sst>')
 names, parts = make_pre_xlsx(guide=LEGACY_GUIDE)
 parts["xl/sharedStrings.xml"] = LEGACY_SST.encode()
-todo, missing = mig.plan_guide(parts, 11)
+todo, missing = mig.plan_guide(parts, POST_SPLIT_HEADERS)
 check("the legacy shape is fully recognised", (len(todo), missing), (3, []))
 check("...with the FILTER found in the SHARED table, not the sheet",
       sorted({t[0] for t in todo}),
@@ -428,7 +432,7 @@ check("...and no legacy tile still counts Status",
 check("the shared-table live list is repointed",
       "Attendees!H2:H" in parts["xl/sharedStrings.xml"].decode(), True)
 check("re-planning the migrated legacy shape proposes nothing",
-      mig.plan_guide(parts, 11)[0], [])
+      mig.plan_guide(parts, POST_SPLIT_HEADERS)[0], [])
 
 
 # ---------------------------------------------------------------------------

--- a/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_interested_in.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import migrate_interested_in as mig
 import sync_crm
 from sync_crm import (Attendees, DV_EXPECTED, NEW_COLUMN, X, check_dropdowns,
-                      cell_ref, col_of, load_parts, sheet_part)
+                      cell_ref, col_of, load_parts, save_parts, sheet_part)
 
 fails = 0
 def check(label, got, want):
@@ -33,6 +33,17 @@ PRE = mig.PRE_SPLIT_HEADERS
 # The list every chapter carried until 2026-08-25 — roles and lifecycle values
 # in one column, which is the conflation being undone.
 OLD_DV = "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
+
+# The conditional formatting every CRM already carries: Signal (B) and
+# Trusted/Regular (C). Nothing tested Status, which is why the split broke none
+# of it — and why the new rules have the column to themselves.
+SIGNAL_CF = (
+    '<conditionalFormatting sqref="B2:B1000">'
+    '<cfRule type="cellIs" priority="1" operator="equal" dxfId="0">'
+    '<formula>"High"</formula></cfRule></conditionalFormatting>'
+    '<conditionalFormatting sqref="A2:A1000">'
+    '<cfRule type="expression" priority="4" dxfId="2">'
+    '<formula>$B2="Non-grata"</formula></cfRule></conditionalFormatting>')
 
 # The Guide tab's real content, verbatim from the shipped template: two
 # dashboard COUNTIFs against the Status column and the live-list FILTER whose
@@ -58,7 +69,13 @@ def _c(ref, text, style=None):
     return '<c r="%s"%s t="inlineStr"><is><t>%s</t></is></c>' % (ref, s, text)
 
 
-def make_pre_xlsx(rows_data=(), headers=PRE, dv=OLD_DV, guide=GUIDE, cols=True):
+#: The three dxf styles every shipped CRM carries — green / amber / red. The
+#: count is what the colour rules check before referencing dxfId 0..2.
+STYLES = '<styleSheet><dxfs count="3"><dxf /><dxf /><dxf /></dxfs></styleSheet>'
+
+
+def make_pre_xlsx(rows_data=(), headers=PRE, dv=OLD_DV, guide=GUIDE, cols=True,
+                  styles=STYLES, cf=""):
     """A pre-split workbook. `rows_data` is [[cell, ...]] starting at row 2."""
     head = "".join(_c(cell_ref(i, 1), h, "2") for i, h in enumerate(headers))
     rows = ['<row r="1" ht="30" customHeight="1" s="20">%s</row>' % head]
@@ -74,13 +91,18 @@ def make_pre_xlsx(rows_data=(), headers=PRE, dv=OLD_DV, guide=GUIDE, cols=True):
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
         '<dimension ref="A1:K%d" />%s<sheetData>%s</sheetData>'
+        # conditionalFormatting must sit AFTER sheetData and BEFORE
+        # dataValidations — CT_Worksheet fixes the order, and Excel calls the
+        # file corrupt if a block lands after pageMargins.
+        '%s'
         '<dataValidations count="2">'
         '<dataValidation sqref="B2:B1000" type="list">'
         '<formula1>"High,Low,Non-grata,New"</formula1></dataValidation>'
         '<dataValidation sqref="D2:D1000" type="list">'
         '<formula1>"%s"</formula1></dataValidation>'
-        '</dataValidations></worksheet>'
-        % (1 + len(rows_data), colblock, "".join(rows), dv))
+        '</dataValidations><pageMargins left="0.75" /></worksheet>'
+        % (1 + len(rows_data), colblock, "".join(rows),
+           SIGNAL_CF + cf, dv))
     parts = {
         "[Content_Types].xml": "<Types />",
         "_rels/.rels": "<Relationships />",
@@ -96,6 +118,8 @@ def make_pre_xlsx(rows_data=(), headers=PRE, dv=OLD_DV, guide=GUIDE, cols=True):
         "xl/worksheets/sheet1.xml": sheet,
         "xl/worksheets/sheet2.xml": guide,
     }
+    if styles:
+        parts["xl/styles.xml"] = styles
     names = list(parts)
     return names, {n: v.encode() for n, v in parts.items()}
 
@@ -254,6 +278,84 @@ check("a merged sqref is refused, not rewritten",
 check("...and the merged rule is left exactly as it was",
       [dv.get("sqref") for dv in mig._dv_elements(att_m)
        if dv.get("sqref") == "C2:D1000"], ["C2:D1000"])
+
+
+# ---------------------------------------------------------------------------
+# Conditional formatting on Status
+# ---------------------------------------------------------------------------
+names, parts, att = opened()
+mig.add_column(att)
+check("the colour rules are due on a fresh workbook", mig.cf_plan(att, parts), "due")
+mig.apply_cf(att)
+check("...and satisfied once applied", mig.cf_plan(att, parts), "ok")
+before = [mig._cf_signature(e) for e in mig._cf_blocks(att)][:2]
+
+block = [e for e in mig._cf_blocks(att)
+         if e.get("sqref") == "D2:D1000" and len(e) > 1][0]
+check("the rules paint the Status column",
+      [(r.find(X + "formula").text.strip('"'), r.get("dxfId")) for r in block],
+      [("In progress", "1"), ("Interviewing", "1"), ("Tentative", "1"),
+       ("Accepted", "0"), ("Regular", "0"), ("Volunteer", "0"), ("Declined", "2")])
+check("...in the dropdown's own order",
+      [r.find(X + "formula").text.strip('"') for r in block],
+      [v for v in DV_EXPECTED["Status"].split(",")
+       if v in dict(mig.status_cf_rules())])
+check("Prospect and Attended are deliberately NOT painted",
+      [v for v in ("Prospect", "Attended") if v in mig.STATUS_DXF], [])
+check("a blank Status is not painted (it would light up 990 empty rows)",
+      "" in mig.STATUS_DXF, False)
+check("every painted value is a real Status dropdown value",
+      [v for v in mig.STATUS_DXF if v not in DV_EXPECTED["Status"].split(",")], [])
+check("no role word is painted — they are not statuses any more",
+      [v for v in mig.STATUS_DXF if v in mig.ROLE_WORDS.values()], [])
+check("only the three shipped dxf styles are referenced",
+      sorted(set(mig.STATUS_DXF.values())), [0, 1, 2])
+check("the Signal rules are untouched",
+      [mig._cf_signature(e) for e in mig._cf_blocks(att)][:2], before)
+
+# Schema order: conditionalFormatting must precede dataValidations, or Excel
+# calls the file corrupt. Appending to the end of the worksheet is the easy
+# mistake, and it puts the block after pageMargins.
+kids = [k.tag.split("}")[1] for k in att.root]
+check("the new block lands before dataValidations",
+      kids.index("conditionalFormatting") < kids.index("dataValidations"), True)
+check("...and before pageMargins",
+      max(i for i, k in enumerate(kids) if k == "conditionalFormatting")
+      < kids.index("pageMargins"), True)
+check("priorities are unique across every block",
+      len({r.get("priority") for e in mig._cf_blocks(att) for r in e}),
+      sum(len(e) for e in mig._cf_blocks(att)))
+
+# A workbook whose Status column someone already painted: their rules are not
+# ours to replace.
+_, fparts, fatt = opened(cf='<conditionalFormatting sqref="D2:D1000">'
+                            '<cfRule type="cellIs" priority="9" operator="equal" '
+                            'dxfId="1"><formula>"VIP"</formula></cfRule>'
+                            '</conditionalFormatting>')
+mig.add_column(fatt)
+check("a human's Status formatting is reported, not overwritten",
+      mig.cf_plan(fatt, fparts), "foreign")
+
+# Referencing dxfId 0..2 in a workbook that has fewer than three styles would
+# render as arbitrary formatting rather than as an error.
+_, nparts, natt = opened(styles='<styleSheet><dxfs count="1"><dxf /></dxfs></styleSheet>')
+mig.add_column(natt)
+check("a workbook without the three dxf styles is refused",
+      mig.cf_plan(natt, nparts), "no-dxfs")
+_, sparts, satt = opened(styles="")
+mig.add_column(satt)
+check("...as is one with no styles.xml at all", mig.cf_plan(satt, sparts), "no-dxfs")
+
+# The whole block must survive serialize(), which rewrites the sheet part from
+# the tree — the same trap that once discarded the dropdown patch.
+names, parts, att = opened()
+mig.add_column(att)
+mig.apply_cf(att)
+att.serialize()
+rt_names, rt_parts = load_parts(save_parts(names, parts))
+rt = Attendees(rt_parts, sheet_part(rt_parts, "Attendees"))
+check("the colour rules survive a serialize round-trip",
+      mig.cf_plan(rt, rt_parts), "ok")
 
 
 # ---------------------------------------------------------------------------

--- a/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_status_prospect.py
@@ -28,7 +28,6 @@ from migrate_status_prospect import (CF_TOKEN_NEW, CF_TOKEN_OLD, HOWTO_TEXTS,
                                      migrate_list, plan_crm, plan_howto,
                                      plan_intake_cells, runs_of, sqref_cols,
                                      tab_actionable, tab_changes)
-import sync_crm
 from sync_crm import cell_ref, load_parts, save_parts, sheet_part
 
 fails = 0
@@ -50,11 +49,19 @@ CRM_LIST = ["New", "Prospect", "Attended", "Regular", "Speaker", "Organizer",
             "Volunteer", "Host", "Declined"]
 SIGNAL_LIST = ["High", "Low", "Non-grata", "New"]
 
-check("the CRM fixture list IS sync_crm's dropdown (drift here breaks the "
-      "Host patch fleet-wide)",
-      ",".join(CRM_LIST), sync_crm.DV_STATUS_NEW)
-check("and migrating it yields exactly sync_crm's migrated list",
-      ",".join(migrate_list(CRM_LIST)), sync_crm.DV_STATUS_NEW_MIGRATED)
+# CRM_LIST is a HISTORICAL literal, not a copy of a live constant. It used to
+# be pinned to sync_crm.DV_STATUS_NEW, but the 2026-08-25 Status/role split
+# retired that list: `Speaker`, `Organizer` and `Host` moved out of Status into
+# the `Interested in` column, and sync_crm no longer defines the pre-split
+# spelling at all. This script is a finished one-shot whose job was to rewrite
+# the list ABOVE, so the fixture must keep describing the world it ran against
+# — re-pointing it at today's constant would test the wrong migration.
+check("the CRM fixture is the pre-split list this migration ran against",
+      ",".join(CRM_LIST),
+      "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined")
+check("and migrating it drops only the leading New",
+      ",".join(migrate_list(CRM_LIST)),
+      "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined")
 
 check("intake list: New is replaced in place (Prospect not yet offered)",
       migrate_list(INTAKE_LIST),

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -604,6 +604,60 @@ for before, want in (("", "Organizer"), ("Speaker", "Organizer"),
     check("%s %-22r -> %r" % (NEW_COLUMN, before, want),
           ops_r[0]["sets"].get(NEW_COLUMN) if ops_r else None, want)
 
+# Demotion visibility. AUTO_STATUS legitimately includes every lifecycle value,
+# so the intake CAN move someone backwards — a chapter that set `Accepted`
+# locally without the intake agreeing has no Drive access anyway, so correcting
+# it is the point. But it is still an edit to a human's cell, and the report
+# used to print only the destination, making it typographically identical to
+# filling a blank. These pin that it is now visible.
+_, _, adem = book(sample_row=SAMPLE)
+adem.write(3, "Email", "ada@x.io")
+adem.write(3, "Status", "Accepted")
+_pipe = merge_people([person("Ada", "ada@x.io", "Boston", "Organizers", "Prospect")])
+ops_d = plan_workbook(adem, _pipe, TODAY)
+check("the old value is recorded on the op", ops_d[0]["was"].get("Status"), "Accepted")
+check("...and the demotion is detected",
+      [(h, o, n) for _, h, o, n in sync_crm.demotions(ops_d)],
+      [("Status", "Accepted", "Prospect")])
+_, _, aup = book(sample_row=SAMPLE)
+aup.write(3, "Email", "ada@x.io")
+aup.write(3, "Status", "Prospect")
+check("...Prospect -> Accepted is silent", sync_crm.demotions(plan_workbook(aup, people, TODAY)), [])
+_, _, ahum = book(sample_row=SAMPLE)
+ahum.write(3, "Email", "ada@x.io")
+ahum.write(3, "Status", "Declined")
+check("a human-only status is never touched, so never a demotion",
+      (plan_workbook(ahum, _pipe, TODAY)[0]["sets"].get("Status"),
+       sync_crm.demotions(plan_workbook(ahum, _pipe, TODAY))), (None, []))
+check("filling a BLANK cell is not a demotion",
+      sync_crm.demotions(plan_workbook(book(sample_row=SAMPLE)[2], _pipe, TODAY)), [])
+
+# The invariants that make the file's prose promises structural. Each has a
+# plausible one-line edit that would break it silently.
+check("no human-only status is auto-owned",
+      sorted(set(sync_crm.HUMAN_ONLY_STATUSES) & sync_crm.AUTO_STATUS), [])
+check("...and all four are on the dropdown, so a human can still set them",
+      [v for v in sync_crm.HUMAN_ONLY_STATUSES if v not in sync_crm.DV_STATUS_VALUES], [])
+check("every writable column is a real CRM column",
+      sorted(set(sync_crm.CRM_WRITTEN) - set(CRM_HEADERS)), [])
+check("every auto-owned column is writable",
+      sorted(set(sync_crm.AUTO_OWNED) - set(sync_crm.CRM_WRITTEN)), [])
+check("every dropdown column is a real CRM column",
+      sorted(set(sync_crm.DV_EXPECTED) - set(CRM_HEADERS)), [])
+check("the ladder covers every lifecycle value",
+      sorted(sync_crm.LIFECYCLE_ORDER), sorted(set(sync_crm.CRM_LIFECYCLE.values())))
+
+# col_of and the $-anchored refs that made three call sites fail OPEN.
+for ref, want in (("D2", 3), ("$D$2", 3), ("$D2", 3), ("AB12", 27),
+                  ("2", -1), ("", -1), ("$", -1)):
+    check("col_of(%-7r)" % ref, col_of(ref), want)
+check("an anchored sqref is attributed to its real column",
+      sync_crm.dv_lists(b'<dataValidation sqref="$D$2:$D$1000" type="list">'
+                        b'<formula1>"a,b"</formula1></dataValidation>'), {3: "a,b"})
+check("a sqref with no column letter is not filed under column A",
+      sync_crm.dv_lists(b'<dataValidation sqref="2:1000" type="list">'
+                        b'<formula1>"a,b"</formula1></dataValidation>'), {})
+
 # The self-serve lifecycle end-to-end: a Prospect synced while in the pipeline
 # is upgraded in place once the chapter accepts them — Status is in AUTO_STATUS
 # and the blank Trusted/Regular cell fills.
@@ -896,12 +950,36 @@ finally:
 
 sync_crm.REDACT = True
 try:
-    check("redact_sets shows column names but masks every value except role/status-like ones",
+    check("redact_sets shows column names but masks every personal value",
           sync_crm.redact_sets({"Email": "ada@x.com", "Full name": "Ada Lovelace",
                                 "Company": "Acme", "Status": "Accepted",
+                                "Interested in": "Organizer",
                                 "Role / title": "CTO", "What brings you here?": "my friend Ada"}),
           {"Email": "…", "Full name": "…", "Company": "…", "Status": "Accepted",
-           "Role / title": "CTO", "What brings you here?": "…"})
+           "Interested in": "Organizer",
+           "Role / title": "…", "What brings you here?": "…"})
+    # The regression this pins. The whitelist WAS a substring test against the
+    # tag "Role", which was harmless only while no written column contained
+    # that word — and this suite asserted `"Role / title": "CTO"` as CORRECT.
+    # Then `Role / title` joined CRM_WRITTEN and a free-text job title started
+    # printing in full under --redact, which defaults ON in CI because a CI log
+    # on a public repo is permanent. Enumerating every written column means a
+    # column added later is masked by default and has to be whitelisted on
+    # purpose, rather than leaking because of how its name happens to be spelt.
+    _person = merge_people([person(
+        "Ada", "ada@x.io", "Boston", "Organizers", "Accepted",
+        linkedin="https://li/ada", company="Acme", title="Head of ML at Acme",
+        expertise="agents")])[0]
+    _shown = sorted(k for k, v in
+                    sync_crm.redact_sets(crm_fields(_person, TODAY)).items()
+                    if v not in ("…", ""))
+    check("only categorical columns survive redaction — no free text, ever",
+          _shown, sorted(["Status", NEW_COLUMN, "Trusted/Regular"]))
+    check("...and the whitelist itself names no free-text column",
+          [h for h in sync_crm.SHOWN_UNDER_REDACT
+           if h in ("Full name", "Email", "Notes (CRM)", "LinkedIn URL", "Company",
+                    "Role / title", "Technical expertise", "What brings you here?")],
+          [])
 finally:
     sync_crm.REDACT = False
 

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -13,12 +13,12 @@ from xml.etree import ElementTree as ET
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import sync_chapters
 import sync_crm
-from sync_crm import (Attendees, CRM_HEADERS, DV_STATUS_NEW, DV_STATUS_OLD,
+from sync_crm import (Attendees, CRM_HEADERS, DV_EXPECTED, NEW_COLUMN,
                       SELF_SERVE_MIN, X,
-                      apply_ops, cell_ref, clean_text, col_of, crm_fields,
-                      fold_email, gate_pipeline_organizers, is_aaif_ops,
-                      join_distinct, load_parts, match_chapters,
-                      merge_people, patch_status_dropdown, plan_workbook,
+                      apply_ops, cell_ref, check_dropdowns, clean_text, col_of,
+                      crm_fields, dv_lists, fold_email, gate_pipeline_organizers,
+                      is_aaif_ops, is_auto_role, join_distinct, load_parts,
+                      match_chapters, merge_people, plan_workbook,
                       save_parts, sheet_part, valid_email)
 
 TODAY = "2026-08-06"
@@ -44,8 +44,15 @@ def _c(ref, text, style=None):
 
 
 def make_xlsx(sample_row=None, blank_rows=8, headers=CRM_HEADERS,
-              shared=False, dv=DV_STATUS_OLD):
-    """A two-sheet workbook whose 'Attendees' tab mirrors the shipped template."""
+              shared=False, dv=None, dv_role=None):
+    """A two-sheet workbook whose 'Attendees' tab mirrors the shipped template.
+
+    `dv` / `dv_role` override the Status and `Interested in` dropdown lists;
+    both default to what a migrated workbook holds, so a fixture built with no
+    arguments is the post-2026-08-25 shape the sync expects to find.
+    """
+    dv = DV_EXPECTED["Status"] if dv is None else dv
+    dv_role = DV_EXPECTED[NEW_COLUMN] if dv_role is None else dv_role
     head = "".join(_c(cell_ref(i, 1), h, "2") for i, h in enumerate(headers))
     rows = ['<row r="1" ht="30" customHeight="1" s="20">%s</row>' % head]
     if sample_row:
@@ -57,13 +64,20 @@ def make_xlsx(sample_row=None, blank_rows=8, headers=CRM_HEADERS,
     for r in range(3, 3 + blank_rows):
         rows.append('<row r="%d">%s</row>'
                     % (r, "".join(_c(cell_ref(i, r), None, "5") for i in (1, 2, 3))))
+    # Status sits at D and `Interested in` at L, exactly as the migrated
+    # workbooks carry them — the dropdown checker resolves both by column
+    # index, so a fixture that put them anywhere else would not exercise it.
     sheet = (
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
-        '<dimension ref="A1:K%d" /><sheetData>%s</sheetData>'
-        '<dataValidations count="1"><dataValidation sqref="D2:D1000" type="list">'
-        '<formula1>"%s"</formula1></dataValidation></dataValidations>'
-        '</worksheet>' % (2 + blank_rows, "".join(rows), dv))
+        '<dimension ref="A1:L%d" /><sheetData>%s</sheetData>'
+        '<dataValidations count="2">'
+        '<dataValidation sqref="D2:D1000" type="list">'
+        '<formula1>"%s"</formula1></dataValidation>'
+        '<dataValidation sqref="L2:L1000" type="list">'
+        '<formula1>"%s"</formula1></dataValidation>'
+        '</dataValidations>'
+        '</worksheet>' % (2 + blank_rows, "".join(rows), dv, dv_role))
     parts = {
         "[Content_Types].xml": "<Types />",
         "_rels/.rels": "<Relationships />",
@@ -97,12 +111,12 @@ def make_xlsx(sample_row=None, blank_rows=8, headers=CRM_HEADERS,
 # human" tests were quietly running against a row the cleaner deletes.
 SAMPLE = ["Ravi Menon", "High", "Yes", "Regular",
           "Brought three friends to the Feb event.", "ravi@vendor.co", "", "Vendor Inc.",
-          "Sales", "—", "Community regular"]
+          "Sales", "—", "Community regular", ""]
 
 # The template's shipped fixture row, which every chapter CRM carries.
 DUMMY = ["Sam Taylor", "Non-grata", "No", "Declined",
          "Pitched from the floor. Do not invite.", "sam@example.com", "", "Vendor Inc.",
-         "Sales", "—", "Wanted to pitch"]
+         "Sales", "—", "Wanted to pitch", "Speaker"]
 
 
 def book(**kw):
@@ -175,25 +189,59 @@ check("without a blocked list the row is still refused",
                     person("M", "ada@x.io", "B", "Speakers", "New")])[0]["tabs"],
       ["Organizers"])
 
+# --- the Status / Interested-in split (2026-08-25) --------------------------
+# Every check below exists because ONE column used to answer both questions.
+# The invariant, stated once: `Interested in` is a fact about the APPLICATION
+# and never moves; `Status` is the DECISION and never names a role.
 f_acc = crm_fields(both[0], TODAY)
-check("accepted organizer -> Organizer", f_acc["Status"], "Organizer")
+check("accepted organizer -> Status Accepted", f_acc["Status"], "Accepted")
+check("...and Interested in carries every role applied for",
+      f_acc[NEW_COLUMN], "Organizer/Speaker")
 check("accepted organizer -> Trusted", f_acc["Trusted/Regular"], "Yes")
 check("note carries every role, statuses deduped",
       f_acc["Notes (CRM)"], "Intake: Organizer/Speaker · Accepted · 2026-08-06")
 
 f_host = crm_fields(merge_people([person("Bo", "bo@x.io", "B", "Hosts", "Accepted")])[0], TODAY)
-check("accepted host -> Host", f_host["Status"], "Host")
+check("accepted host -> Status Accepted", f_host["Status"], "Accepted")
+check("...and Interested in Host", f_host[NEW_COLUMN], "Host")
 check("accepted host is not auto-Trusted", f_host["Trusted/Regular"], "")
 
-# Pipeline (not-yet-accepted) people, per the self-serve policy.
+# Pipeline (not-yet-accepted) people. Status mirrors the intake verbatim.
 f_pipe = crm_fields(merge_people([person("Cy", "cy@x.io", "B", "Organizers", "Tentative")])[0], TODAY)
-check("pipeline organizer -> Prospect", f_pipe["Status"], "Prospect")
+check("pipeline organizer keeps its real intake status", f_pipe["Status"], "Tentative")
+check("...and still reads Interested in Organizer", f_pipe[NEW_COLUMN], "Organizer")
 check("pipeline organizer is not Trusted", f_pipe["Trusted/Regular"], "")
 check("pipeline note carries the intake status",
       f_pipe["Notes (CRM)"], "Intake: Organizer · Tentative · 2026-08-06")
-f_pspk = crm_fields(merge_people([person("Dee", "dee@x.io", "B", "Speakers", "New")])[0], TODAY)
-check("pipeline speaker -> Speaker (not Prospect)", f_pspk["Status"], "Speaker")
-check("pipeline speaker is not Trusted", f_pspk["Trusted/Regular"], "")
+
+# THE REGRESSION. A speaker/host sitting at Prospect used to be written as a
+# flat `Speaker`/`Host` in Status — the CRM announced a settled speaker where
+# triage had settled nothing, and only organizers were spared. Both halves are
+# asserted: the decision is Prospect AND the application is still visible.
+for tab, role in (("Speakers", "Speaker"), ("Hosts", "Host")):
+    f_p = crm_fields(merge_people(
+        [person("Dee", "dee@x.io", "B", tab, "Prospect")])[0], TODAY)
+    check("pipeline %s -> Status Prospect, not %r" % (role.lower(), role),
+          f_p["Status"], "Prospect")
+    check("...and Interested in %r" % role, f_p[NEW_COLUMN], role)
+    check("...and not Trusted", f_p["Trusted/Regular"], "")
+
+check("no role word can ever reach the Status column",
+      sorted(set(sync_crm.CRM_LIFECYCLE.values()) & set(sync_crm.CRM_ROLE.values())),
+      [])
+check("...nor be offered by the Status dropdown",
+      [r for r in sync_crm.CRM_ROLE.values() if r in sync_crm.DV_STATUS_VALUES],
+      [])
+
+# Every intake status the sync accepts must map to a CRM status, or the first
+# person carrying it crashes the run mid-sweep.
+check("every syncable intake status has a lifecycle mapping",
+      [st for st in sync_crm.SYNC_STATUSES + sync_crm.PIPELINE_STATUSES
+       if st not in sync_crm.CRM_LIFECYCLE], [])
+check("both accepted-ish statuses land on Accepted",
+      sorted({sync_crm.CRM_LIFECYCLE[st] for st in sync_crm.SYNC_STATUSES}),
+      ["Accepted"])
+
 # The 2026-08-22 rename transition: an intake row still saying the legacy "New"
 # behaves identically to one saying "Prospect".
 check("both the legacy and current spellings are pipeline statuses",
@@ -201,24 +249,52 @@ check("both the legacy and current spellings are pipeline statuses",
       ["New", "Prospect"])
 f_leg = crm_fields(merge_people([person("Lee", "lee@x.io", "B", "Organizers", "New")])[0], TODAY)
 f_cur = crm_fields(merge_people([person("Lee", "lee@x.io", "B", "Organizers", "Prospect")])[0], TODAY)
-check("a legacy-New organizer lands as Prospect, exactly like a Prospect one",
-      (f_leg["Status"], f_leg["Trusted/Regular"]),
-      (f_cur["Status"], f_cur["Trusted/Regular"]))
+check("a legacy-New organizer lands exactly like a Prospect one",
+      (f_leg["Status"], f_leg[NEW_COLUMN], f_leg["Trusted/Regular"]),
+      (f_cur["Status"], f_cur[NEW_COLUMN], f_cur["Trusted/Regular"]))
 check("...and that Status is Prospect", f_cur["Status"], "Prospect")
-# Accepted in one role while still in the pipeline for another: the accepted
-# role wins the Status, and the organizer application alone earns no trust.
+
+# Accepted in one role while still in the pipeline for another: acceptance
+# anywhere decides the Status, both applications stay visible, and an organizer
+# application alone earns no trust.
 f_mix = crm_fields(merge_people([
     person("Eve", "eve@x.io", "B", "Organizers", "Interviewing"),
     person("Eve", "eve@x.io", "B", "Speakers", "Accepted")])[0], TODAY)
-check("accepted speaker beats pipeline organizer", f_mix["Status"], "Speaker")
+check("accepted in any role -> Accepted", f_mix["Status"], "Accepted")
+check("...and BOTH applications are still named", f_mix[NEW_COLUMN], "Organizer/Speaker")
 check("...and does not become Trusted", f_mix["Trusted/Regular"], "")
 
-# Minimal by construction: the automation must not touch Signal or any of the
-# detail columns, so they are absent from the mapping rather than written blank.
-check("only the minimal columns are produced",
+# The detail columns the intake collects. They were parsed, merged and then
+# dropped on the floor for months, leaving the sheet's most useful columns
+# blank in every chapter.
+f_det = crm_fields(merge_people([person(
+    "Ann", "ann@x.io", "B", "Speakers", "Accepted", linkedin="https://li/ann",
+    company="Acme", title="Staff Eng", expertise="Agents, MCP")])[0], TODAY)
+check("the survey detail reaches the CRM",
+      [f_det["LinkedIn URL"], f_det["Company"], f_det["Role / title"],
+       f_det["Technical expertise"]],
+      ["https://li/ann", "Acme", "Staff Eng", "Agents, MCP"])
+check("an unanswered detail question writes nothing",
+      crm_fields(merge_people([person("Zed", "z@x.io", "B")])[0], TODAY)["Company"], "")
+
+# is_auto_role: what the sync may rewrite in `Interested in`.
+for value, want in (("", True), ("Host", True), ("Organizer/Speaker", True),
+                    ("organizer/host", True), ("Organizer / Speaker", True),
+                    ("Organizer/Speaker/Host", True),
+                    ("Sponsor", False), ("Organizer (co-lead)", False),
+                    ("Host — offered the Acme office", False)):
+    check("is_auto_role(%r)" % value, is_auto_role(value), want)
+check("every value the sync writes is one it may later rewrite",
+      [v for v in sync_crm.DV_INTERESTED_VALUES if not is_auto_role(v)], [])
+
+# `Signal` is the chapter's own private judgement of a person and the one
+# column no form answer can supply, so it is absent from the mapping rather
+# than written blank. Every OTHER column is now filled from the intake.
+check("exactly the writable columns are produced",
       sorted(f_acc), sorted(sync_crm.CRM_WRITTEN))
-for col in ("Signal", "LinkedIn URL", "Company", "Role / title", "Technical expertise"):
-    check("%r is never written" % col, col in f_acc, False)
+check("'Signal' is never written", "Signal" in f_acc, False)
+check("'Signal' is the only CRM column the automation leaves alone",
+      [h for h in CRM_HEADERS if h not in sync_crm.CRM_WRITTEN], ["Signal"])
 
 
 # ---------------------------------------------------------------------------
@@ -375,8 +451,10 @@ check("new person lands on the first free row", ops[0]["rownum"], 3)
 check("new person is flagged as an add", ops[0]["kind"], "add")
 check("the interest field reaches the CRM cell",
       ops[0]["sets"]["What brings you here?"], "I want to be an organizer/volunteer")
-check("the survey's detail columns are not written",
-      [c for c in ("Technical expertise", "LinkedIn URL", "Company") if c in ops[0]["sets"]], [])
+check("the survey's detail columns reach the CRM",
+      [ops[0]["sets"].get(c) for c in ("Technical expertise", "LinkedIn URL")],
+      ["Agents, MCP", "https://li/ada"])
+check("...and an unanswered one is not written blank", "Company" in ops[0]["sets"], False)
 
 apply_ops(att, ops)
 check("write landed in the sheet", att.value(3, "Email"), "ada@x.io")
@@ -486,11 +564,15 @@ check("the expected-person filter is email-based, not row-based",
       [r["row"] for r in sync_crm.preexisting(atts, [], [])], [2, 3])
 
 # Status: upgrade what the automation wrote, never what a human wrote.
-# Speaker/Host -> Organizer is the case the AUTO_STATUS rule exists for ("a
-# person's role is corrected after re-triage") and was the one it never covered.
-for before, want in (("", "Organizer"), ("New", "Organizer"), ("Prospect", "Organizer"),
-                     ("Speaker", "Organizer"), ("Host", "Organizer"),
-                     ("Organizer", None),
+# The three ROLE values are the pre-split leftovers sitting in ~62 workbooks;
+# they must upgrade like any other automation value, or the migration is the
+# only thing that could ever repair them.
+for before, want in (("", "Accepted"), ("New", "Accepted"), ("Prospect", "Accepted"),
+                     ("In progress", "Accepted"), ("Interviewing", "Accepted"),
+                     ("Tentative", "Accepted"),
+                     ("Speaker", "Accepted"), ("Host", "Accepted"),
+                     ("Organizer", "Accepted"),
+                     ("Accepted", None),
                      ("Attended", None), ("Declined", None), ("Regular", None),
                      ("Volunteer", None)):
     _, _, a = book(sample_row=SAMPLE)
@@ -499,11 +581,28 @@ for before, want in (("", "Organizer"), ("New", "Organizer"), ("Prospect", "Orga
         a.write(3, "Status", before)
     ops_s = plan_workbook(a, people, TODAY)
     # Assert an op exists at all: for the protected values the expected result
-    # is None, which an EMPTY ops list also yields — so four of these checks
-    # would pass vacuously if planning stopped emitting ops entirely.
-    check("Status %-10r -> op kinds" % before, [o["kind"] for o in ops_s], ["fill"])
+    # is None, which an EMPTY ops list also yields — so those checks would pass
+    # vacuously if planning stopped emitting ops entirely.
+    check("Status %-12r -> op kinds" % before, [o["kind"] for o in ops_s], ["fill"])
     got = ops_s[0]["sets"].get("Status") if ops_s else None
-    check("Status %-10r -> %r" % (before, want), got, want)
+    check("Status %-12r -> %r" % (before, want), got, want)
+
+# The same rule on the new column, and the reason it needs its own predicate:
+# "Organizer/Speaker" is not a member of any value set, so a frozenset test
+# would freeze every multi-role person at whatever was written first.
+for before, want in (("", "Organizer"), ("Speaker", "Organizer"),
+                     ("Speaker/Host", "Organizer"),
+                     ("Organizer", None),
+                     ("Sponsor", None), ("Organizer (co-lead)", None)):
+    _, _, a = book(sample_row=SAMPLE)
+    a.write(3, "Email", "ada@x.io")
+    if before:
+        a.write(3, NEW_COLUMN, before)
+    ops_r = plan_workbook(a, people, TODAY)
+    check("%s %-22r -> op kinds" % (NEW_COLUMN, before),
+          [o["kind"] for o in ops_r], ["fill"])
+    check("%s %-22r -> %r" % (NEW_COLUMN, before, want),
+          ops_r[0]["sets"].get(NEW_COLUMN) if ops_r else None, want)
 
 # The self-serve lifecycle end-to-end: a Prospect synced while in the pipeline
 # is upgraded in place once the chapter accepts them — Status is in AUTO_STATUS
@@ -512,12 +611,16 @@ _, _, alc = book(sample_row=SAMPLE)
 pipe = merge_people([person("Ada", "ada@x.io", "Boston", "Organizers", "Tentative",
                             linkedin="https://li/ada", expertise="Agents, MCP")])
 apply_ops(alc, plan_workbook(alc, pipe, TODAY))
-check("a prospect lands untrusted",
-      [alc.value(3, "Status"), alc.value(3, "Trusted/Regular")], ["Prospect", ""])
+check("a prospect lands with its real intake status, untrusted",
+      [alc.value(3, "Status"), alc.value(3, NEW_COLUMN),
+       alc.value(3, "Trusted/Regular")],
+      ["Tentative", "Organizer", ""])
 up = plan_workbook(alc, people, TODAY)
 check("acceptance upgrades the prospect in place",
       (up[0]["kind"], up[0]["sets"].get("Status"), up[0]["sets"].get("Trusted/Regular")),
-      ("fill", "Organizer", "Yes"))
+      ("fill", "Accepted", "Yes"))
+check("...and does not restate the unchanged Interested in",
+      NEW_COLUMN in up[0]["sets"], False)
 
 
 # ---------------------------------------------------------------------------
@@ -534,7 +637,7 @@ check("the new person reads back", rt.value(3, "Full name"), "Ada")
 check("the sample row is untouched", rt.value(2, "Notes (CRM)"), SAMPLE[4])
 check("dimension covers the written rows",
       ET.fromstring(rt_parts["xl/worksheets/sheet1.xml"]).find(X + "dimension").get("ref"),
-      "A1:K10")
+      "A1:L10")
 check("rows stay in ascending order",
       [int(r.get("r")) for r in rt.data.findall(X + "row")], list(range(1, 11)))
 check("re-serialized XML keeps the default namespace",
@@ -554,90 +657,78 @@ check("rows are created past the end of the grid",
 
 
 # ---------------------------------------------------------------------------
-# The Status dropdown patch
+# The dropdowns — CHECKED here, written by migrate_interested_in.py
 # ---------------------------------------------------------------------------
 names, parts, att = book(sample_row=SAMPLE)
-part = sheet_part(parts, "Attendees")
-check("dropdown patch reports a change", patch_status_dropdown(parts, part), "patched")
-check('dropdown now offers "Host"', DV_STATUS_NEW.encode() in parts[part], True)
-check("dropdown patch is idempotent", patch_status_dropdown(parts, part), "already")
-names, parts, _ = book(sample_row=SAMPLE, dv=DV_STATUS_NEW)
-check("an already-patched workbook is left alone",
-      patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "already")
-check('"Host" is the only difference from the shipped list',
-      DV_STATUS_NEW.replace("Host,", ""), DV_STATUS_OLD)
+check("a migrated workbook reports no stale dropdowns", check_dropdowns(att), [])
+check("the lists are found at the right columns",
+      {c: v for c, v in dv_lists(parts[sheet_part(parts, "Attendees")]).items()},
+      {3: DV_EXPECTED["Status"], 11: DV_EXPECTED[NEW_COLUMN]})
 
-# The legacy CRMs escape the formula quotes; matching only `"…"` left every one
-# of them un-patched while the run still reported success.
+# The pre-split list, which is what the whole fleet carried until 2026-08-25.
+# Its role values are exactly the conflation the split removed, so a workbook
+# still offering them must be reported every run.
+LEGACY_STATUS_DV = "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"
+_, _, a_old = book(sample_row=SAMPLE, dv=LEGACY_STATUS_DV)
+check("a pre-split Status list is reported stale", check_dropdowns(a_old), ["Status"])
+_, _, a_nr = book(sample_row=SAMPLE, dv_role="Yes,No")
+check("a wrong Interested-in list is reported stale",
+      check_dropdowns(a_nr), [NEW_COLUMN])
+_, _, a_both = book(sample_row=SAMPLE, dv=LEGACY_STATUS_DV, dv_role="Yes,No")
+check("both are reported together",
+      sorted(check_dropdowns(a_both)), sorted(["Status", NEW_COLUMN]))
+
+# The legacy CRMs escape the formula quotes. Matching only `"…"` is what once
+# left every one of them silently unpatched while the run reported success, so
+# the reader handles both encodings — and a checker that only saw one would
+# report the whole legacy estate as stale forever.
 names, parts, _ = book(sample_row=SAMPLE)
 part = sheet_part(parts, "Attendees")
-parts[part] = parts[part].replace(('"%s"' % DV_STATUS_OLD).encode(),
-                                  ("&quot;%s&quot;" % DV_STATUS_OLD).encode())
-check("patches the &quot;-escaped legacy spelling",
-      patch_status_dropdown(parts, part), "patched")
-check("legacy patch keeps the escaping",
-      ("&quot;%s&quot;" % DV_STATUS_NEW).encode() in parts[part], True)
-check("legacy patch is idempotent", patch_status_dropdown(parts, part), "already")
-
-names, parts, _ = book(sample_row=SAMPLE, dv="Yes,No")
-check("a workbook with no Status list is reported, not guessed at",
-      patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "absent")
-
-# The status-rename migration (migrate_status_prospect.py) removes the legacy
-# "New" from a workbook's Status list; the Host patch must still recognise the
-# migrated spellings rather than reporting the list absent.
-check("the migrated lists differ from the shipped ones only by the leading New",
-      (sync_crm.DV_STATUS_OLD_MIGRATED, sync_crm.DV_STATUS_NEW_MIGRATED),
-      (DV_STATUS_OLD.replace("New,", "", 1), DV_STATUS_NEW.replace("New,", "", 1)))
-names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_OLD_MIGRATED)
-part = sheet_part(parts, "Attendees")
-check("a migrated Host-less workbook is still patched",
-      patch_status_dropdown(parts, part), "patched")
-check('...gaining "Host" in the migrated spelling',
-      sync_crm.DV_STATUS_NEW_MIGRATED.encode() in parts[part], True)
-check("...and never re-gaining the legacy New",
-      DV_STATUS_NEW.encode() in parts[part], False)
-check("the migrated patch is idempotent", patch_status_dropdown(parts, part), "already")
-names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_NEW_MIGRATED)
-check("a migrated, already-Host workbook is left alone",
-      patch_status_dropdown(parts, sheet_part(parts, "Attendees")), "already")
-
-# The real post-migration fleet shape: a LEGACY workbook (&quot;-escaped) whose
-# Status list has been migrated. Every migrated-list case above uses the `"`
-# encoding, so this combination — the likeliest one in the estate — is the one
-# the restructured two-pass loop never exercised.
-names, parts, _ = book(sample_row=SAMPLE, dv=sync_crm.DV_STATUS_OLD_MIGRATED)
-part = sheet_part(parts, "Attendees")
 parts[part] = parts[part].replace(
-    ('"%s"' % sync_crm.DV_STATUS_OLD_MIGRATED).encode(),
-    ("&quot;%s&quot;" % sync_crm.DV_STATUS_OLD_MIGRATED).encode())
-check("a &quot;-escaped MIGRATED workbook is patched, not reported absent",
-      patch_status_dropdown(parts, part), "patched")
-check("...keeping the escaping and the migrated spelling",
-      ("&quot;%s&quot;" % sync_crm.DV_STATUS_NEW_MIGRATED).encode() in parts[part],
-      True)
-check("...and it stays idempotent", patch_status_dropdown(parts, part), "already")
+    ('"%s"' % DV_EXPECTED["Status"]).encode(),
+    ("&quot;%s&quot;" % DV_EXPECTED["Status"]).encode())
+check("the &quot;-escaped spelling reads back identically",
+      dv_lists(parts[part])[3], DV_EXPECTED["Status"])
+check("...so a &quot;-escaped migrated workbook is not reported stale",
+      check_dropdowns(Attendees(parts, part)), [])
 
-# The four dropdown literals are DERIVED from one tuple; pin what they derive to
-# so a future edit to DV_STATUS_VALUES cannot silently change the wire format.
-check("the derived literals are exactly the four the patcher matches",
-      (sync_crm.DV_STATUS_OLD, sync_crm.DV_STATUS_NEW,
-       sync_crm.DV_STATUS_OLD_MIGRATED, sync_crm.DV_STATUS_NEW_MIGRATED),
-      ("New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined",
-       "New,Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined",
-       "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Declined",
-       "Prospect,Attended,Regular,Speaker,Organizer,Volunteer,Host,Declined"))
-
-# Regression: serialize() rewrites the sheet part from the element tree, so a
-# dropdown patch applied BEFORE it is silently discarded — the run reports the
-# patch as applied and the uploaded workbook still has the eight-value list.
-# finalize() is the only supported write path precisely to fix the ordering.
-names, parts, att = book(sample_row=SAMPLE)
+# A validation spanning several columns cannot be attributed to one header, so
+# it is skipped rather than guessed at — guessing would report a correct
+# workbook as broken, or hide a genuinely stale list behind a neighbour's.
+names, parts, _ = book(sample_row=SAMPLE)
 part = sheet_part(parts, "Attendees")
-patch_status_dropdown(parts, part)
-att.serialize()
-check("serialize-then-patch is the bug this guards",
-      DV_STATUS_NEW.encode() in parts[part], False)
+parts[part] = parts[part].replace(b'sqref="D2:D1000"', b'sqref="C2:D1000"')
+check("a multi-column sqref is not attributed to a header",
+      3 in dv_lists(parts[part]), False)
+check("...and the column then reads as having no list",
+      check_dropdowns(Attendees(parts, part)), ["Status"])
+
+# Pin the wire format: both lists are DERIVED from CRM_LIFECYCLE / CRM_ROLE, so
+# an edit to either would otherwise change what lands in ~62 workbooks silently.
+check("the derived dropdown literals",
+      (DV_EXPECTED["Status"], DV_EXPECTED[NEW_COLUMN]),
+      ("Prospect,In progress,Interviewing,Tentative,Accepted,Attended,Regular,"
+       "Volunteer,Declined",
+       "Organizer,Speaker,Host,Organizer/Speaker,Organizer/Host,Speaker/Host,"
+       "Organizer/Speaker/Host"))
+check("the Interested-in list can express everything crm_fields writes",
+      sorted(sync_crm.DV_INTERESTED_VALUES),
+      sorted({crm_fields(m, TODAY)[NEW_COLUMN] for m in [
+          merge_people([person("a", "a@x.io", "B", t)])[0] for t in sync_crm.ROLE_TABS]
+          } | {"Organizer/Speaker", "Organizer/Host", "Speaker/Host",
+               "Organizer/Speaker/Host"}))
+
+# A workbook that predates the split has no `Interested in` column at all.
+# Refusing to open it is correct — nothing is written by column letter — but
+# the message has to name the migration, not read as a corrupt workbook.
+try:
+    _, pre_parts = make_xlsx(sample_row=SAMPLE[:-1],
+                             headers=tuple(h for h in CRM_HEADERS if h != NEW_COLUMN))
+    Attendees(pre_parts, sheet_part(pre_parts, "Attendees"))
+    check("a pre-split workbook is refused", "opened", "refused")
+except ValueError as e:
+    check("a pre-split workbook is refused, naming the migration",
+          ("migrate_interested_in" in str(e), NEW_COLUMN in str(e)), (True, True))
 
 names, parts, att = book(sample_row=SAMPLE)
 b = sync_crm.Book(folder={"name": "Boston"}, crm={"id": "x", "name": "Boston CRM.xlsx"},
@@ -646,9 +737,8 @@ b = sync_crm.Book(folder={"name": "Boston"}, crm={"id": "x", "name": "Boston CRM
 raw = sync_crm.finalize(b, plan_workbook(att, people, TODAY))
 fin_names, fin_parts = load_parts(raw)
 fin = Attendees(fin_parts, sheet_part(fin_parts, "Attendees"))
-check("finalize keeps the dropdown patch",
-      DV_STATUS_NEW.encode() in fin_parts[sheet_part(fin_parts, "Attendees")], True)
 check("finalize keeps the row writes", fin.value(3, "Email"), "ada@x.io")
+check("finalize leaves the dropdowns alone", check_dropdowns(fin), [])
 check("finalize returns a complete zip", sorted(fin_names), sorted(names))
 
 
@@ -678,7 +768,7 @@ check("generic tokens do not create a near-miss (San Diego / San Francisco)",
 # Write guards: the promises that are now structural rather than documented
 # ---------------------------------------------------------------------------
 _, _, attw = book(sample_row=SAMPLE)
-for col in ("Signal", "LinkedIn URL", "Company", "Role / title", "Technical expertise"):
+for col in ("Signal",):
     try:
         attw.write(3, col, "x")
         check("write(%r) is refused" % col, "no error", "ValueError")


### PR DESCRIPTION
## The bug

The chapter CRMs had one `Status` column, and `sync_crm` wrote the person's
**role** into it, taken from whichever intake role tab they came from. A venue
host whose intake row still said `Prospect` appeared in their chapter's CRM as a
flat `Host`; a speaker awaiting triage as `Speaker`. A chapter organizer
scanning the list saw settled people where central triage had settled nothing.

Pipeline **organizers** were the one role spared — special-cased to `Prospect` —
which is what made it easy to miss. `Notes (CRM)` had carried both facts
correctly the whole time; they were just being flattened into a cell the eye
reads as a decision.

## The split

Two columns, filled independently:

| Column | Answers |
|---|---|
| `Status` | the **decision** — `Prospect` / `In progress` / `Interviewing` / `Tentative` / `Accepted`, plus the human-only `Attended` / `Regular` / `Volunteer` / `Declined` |
| `Interested in` (new, col L) | what they **applied for** — `Organizer` / `Speaker` / `Host`, `/`-joined |

`Interested in` is a fact about the application and a decision never changes it.
Accepted in *any* role makes `Status` = `Accepted`; otherwise `Status` mirrors
the intake's own pipeline value. No role word can reach `Status` or its
dropdown any more — both facts derive from `CRM_ROLE` / `CRM_LIFECYCLE`,
asserted by the tests.

## Also in here

- **The four detail columns now fill.** `LinkedIn URL`, `Company`,
  `Role / title` and `Technical expertise` were parsed, merged across role tabs,
  carried all the way to `crm_fields()` — and then discarded, leaving the
  sheet's most useful columns blank in every chapter. The rule they were
  withheld under dated from when the Chapters folder was public-link; it is now
  92 per-chapter organizer grants. `Signal` is now the only column the
  automation never authors.
- **`Status` gets colour rules** — green `Accepted`/`Regular`/`Volunteer`, amber
  `In progress`/`Interviewing`/`Tentative`, red `Declined`. `Prospect` (the
  commonest value) and blank are deliberately unpainted; the range is `D2:D1000`
  and the template pre-creates 1000 empty rows, so a blank rule would light up
  the whole column. The three shipped `dxf` styles are **referenced, not added**
  — `dxfId` is a positional index into `<dxfs>`.
- **Schema moves out of the sync.** `sync_crm` now *checks* the dropdowns and
  reports drift; `migrate_interested_in.py` writes them. That removes the
  load-bearing ordering inside `finalize()` that once threw a dropdown patch
  away while reporting it applied.
- **`sync_crm` refuses to open a pre-split workbook** rather than writing by
  column letter, and names the migration in the error.

## Two Guide-tab landmines found on the way

Both were live in all 83 chapters:

- The dashboard counted `COUNTIF(Attendees!D2:D1000,"Speaker")` (and
  `"Organizer"`). Those would read **0 in every chapter** the moment roles left
  `Status`. Repointed at the new column with `*…*` wildcards, since a cell can
  say `Organizer/Speaker`.
- The "Live list" `FILTER` already referenced `Attendees!L2:L` — a column that
  **did not exist** on the 11-column layout. It had been returning a blank
  column since the columns were last renumbered. Pre-existing bug, repointed.

Five chapters (Austin, Dallas, Kampala, London, Tatooine) store that content
`&quot;`-escaped in `sharedStrings.xml` rather than inline. My first pass
silently missed all five and reported them as unrecognised; both shapes are
handled now.

## Verification

- All 10 skill tests + 210 library tests pass; `pre-commit` and
  `claude plugin validate` clean.
- **Mutation-tested**: writing the role into `Status`, inventing a status
  instead of blanking, overwriting a human's `Declined`, narrowing the shared
  `<cols>` run, leaving the dashboard pointed at `Status`, appending the
  conditional-format block after `pageMargins` (schema-illegal), and painting
  `Prospect` — each mutation was caught by the tests.
- The end-to-end test is the one that matters: migrate a pre-split fixture, hand
  the result to `sync_crm`'s own strict reader, and assert it proposes nothing.
  The two scripts must agree on the exact bytes or `--write` never converges.

## Already applied to Drive

`migrate_interested_in.py --write` has run against all **83** workbooks
(TemplateCity included, so new chapters are born split). Exit 0; 0 skipped,
0 failed, 0 refused dropdowns, 0 unrecognised Guide tabs. An independent re-run
reports *"Nothing to do — every chapter CRM already has the split."*

`sync_crm.py` reconciliation against the live intake is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ena3r61jqeiLfFxvQttZFS
