### PR TITLE
fix(sync-chapters): unrewritable Attendees refs, quoted sheet names, and audit applicant split

### DIFF
--- a/skills/aaif-audit-slack/scripts/audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/audit_organizers.py
@@ -66,6 +66,11 @@ INTAKE_TAB = "Organizers"
 #: "Existing" alone would miss every MLOps row, so keep the full value.
 ACCEPTED = ("Accepted", "Existing (from MLOps)")
 
+#: Intake statuses that are a decided NO. Someone in an organizers room carrying
+#: one of these is not "awaiting a decision" — the decision was made, and their
+#: presence in a private channel is the thing to look at.
+DECIDED_NO = ("Denied", "Inactive", "Duplicate")
+
 e = html.escape
 
 
@@ -264,6 +269,23 @@ def read_intake():
     idx = header_index(headers, INTAKE_TAB, "Status", "Full name", "Email",
                        "City (Existing)", "City (New)", "Chapter")
     people, seen, dupes, saw = [], set(), 0, set()
+    # Every intake row by email, ACCEPTED OR NOT. The audit's job is to explain
+    # who is in an organizers room, and "we never accepted them" collapses two
+    # very different people into one line: a stranger, and someone who applied
+    # and is waiting on us. The second is the actionable case — they are in the
+    # private room doing the work, and because acceptance is what triggers the
+    # Drive grant, they are locked out of their own chapter's folder.
+    # Bengaluru 2026-08-27 was exactly this: the chapter's de-facto lead, first
+    # invited the minute the room was created, sitting at Prospect and asking
+    # in-channel why he got an access-denied page.
+    applicants = {}
+    for row in rows[1:]:
+        e_any = cell(row, idx["Email"]).lower()
+        if e_any:
+            applicants.setdefault(e_any, {
+                "status": cell(row, idx["Status"]),
+                "name": cell(row, idx["Full name"]),
+                "city": cell(row, idx["Chapter"]) or cell(row, idx["City (New)"])})
     for row in rows[1:]:
         status = cell(row, idx["Status"])
         if status:
@@ -298,7 +320,7 @@ def read_intake():
             "design, so a trailing space or a new label breaks it."
             % (len(rows) - 1, INTAKE_TAB, list(ACCEPTED),
                ", ".join(sorted(saw)) or "(none)"))
-    return people, dupes
+    return people, dupes, applicants
 
 
 # --------------------------------------------------------------------------
@@ -577,13 +599,19 @@ def check_membership_floor(membership, chans, chans_cached, refetch, note=print)
     return chans
 
 
-def build_audit(rows, people, slack_ids, membership, directory, staff_domain):
+def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
+                applicants=None):
     """Join the sheet data to the Slack data, per chapter.
 
     Each chapter record gains `accepted` (people, each with `slack_id`,
     `slack_account`, `in_public`, `in_organizers`) and `unaccounted` (everyone in
     the organizers channel we never accepted, each with `is_staff` and
-    `unresolved`). Every key from match_channels() survives unchanged.
+    `unresolved`, and — when their email matches an intake row — `intake_status`
+    and `intake_city`). Every key from match_channels() survives unchanged.
+
+    `intake_status` is what separates "a stranger is in the private room" from
+    "someone we are still deciding on is in the private room, doing the work,
+    and locked out of the Drive folder because acceptance is what grants it".
     """
     lookup = {}
     for r in rows:
@@ -628,13 +656,18 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain):
                 # rather than filing them under a group whose label asserts a
                 # judgement we never made about them.
                 extras.append({"id": uid, "name": uid, "email": "",
-                               "is_staff": False, "unresolved": True})
+                               "is_staff": False, "unresolved": True,
+                               "intake_status": "", "intake_city": ""})
                 continue
+            addr = (u.get("email") or "").lower()
+            app = (applicants or {}).get(addr) or {}
             extras.append({"id": uid,
                            "name": u.get("real_name") or u.get("name") or uid,
                            "email": u.get("email", ""),
-                           "is_staff": (u.get("email") or "").endswith("@" + staff_domain),
-                           "unresolved": False})
+                           "is_staff": addr.endswith("@" + staff_domain),
+                           "unresolved": False,
+                           "intake_status": app.get("status", ""),
+                           "intake_city": app.get("city", "")})
         out.append({**r, "accepted": accepted, "unaccounted": extras})
     return out, dict(orphans)
 
@@ -729,13 +762,24 @@ def render(audit, orphans, dupes, today):
         absent = [p for p in c["accepted"] if not p["in_organizers"]]
         unresolved = [x for x in c["unaccounted"] if x["unresolved"]]
         staff = [x for x in c["unaccounted"] if not x["unresolved"] and x["is_staff"]]
+        # Split the not-accepted into two, because they call for opposite
+        # actions. Someone with a live intake row APPLIED and is waiting on a
+        # decision — they are in the private room doing the work and, since
+        # acceptance is what grants Drive, locked out of their own folder.
+        # Someone with no intake row at all is a stranger in a private channel.
+        # One line reading "not an accepted organizer" hid both.
+        pending = [x for x in c["unaccounted"]
+                   if not x["unresolved"] and not x["is_staff"]
+                   and x.get("intake_status") and x["intake_status"] not in DECIDED_NO]
         others = [x for x in c["unaccounted"]
-                  if not x["unresolved"] and not x["is_staff"]]
+                  if not x["unresolved"] and not x["is_staff"] and x not in pending]
         groups = []
         for items, pill, label, cls in (
                 (present, "ok", "accepted organizer", ""),
                 (staff, "mute", "staff", "plist-x"),
-                (others, "warn", "not an accepted organizer", "plist-x"),
+                (pending, "warn", "APPLIED — awaiting a decision, no Drive access",
+                 "plist-x"),
+                (others, "warn", "no intake row at all", "plist-x"),
                 (absent, "bad", "accepted but absent", "plist-x"),
                 # Distinct from "not an accepted organizer": we could not look
                 # these accounts up, so we know nothing about them. Saying so is
@@ -1048,7 +1092,7 @@ def main():
     # reintroduced JSON table could not shadow what the chapters' own rows say.
     chapters, tables = read_chapters()
     cfg.update(tables)
-    people, dupes = read_intake()
+    people, dupes, applicants = read_intake()
     print("  %d chapters, %d accepted organizers (%d duplicate rows dropped)"
           % (len(chapters), len(people), dupes))
     print("  channel map from the sheet: %d own, %d organizers, %d regional"
@@ -1162,7 +1206,7 @@ def main():
                      ", ".join(sorted({err for _, err in failed}))), file=sys.stderr)
 
     audit, orphans = build_audit(rows, people, slack_ids, membership, directory,
-                                 cfg["staff_email_domain"])
+                                 cfg["staff_email_domain"], applicants)
     write_cache(os.path.join(args.cache, "audit.json"),
                 {"chapters": audit, "orphan_cities": orphans, "duplicates": dupes},
                 team_id)

--- a/skills/aaif-audit-slack/scripts/test_audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/test_audit_organizers.py
@@ -154,7 +154,7 @@ def test_status_filter_is_exact_after_stripping():
             ["Accepted ✅", "D", "d@x.com", "", "Boston", ""],
             ["Denied", "E", "e@x.com", "", "Boston", ""],
             ["Interviewing", "F", "f@x.com", "", "Boston", ""]]
-    people, _ = _intake(rows)
+    people, _, _ = _intake(rows)
     check("only exact statuses sync", sorted(p["name"] for p in people), ["A", "B", "C"])
 
 
@@ -164,7 +164,7 @@ def test_city_precedence_chapter_beats_new_beats_existing():
             ["Accepted", "B", "b@x.com", "Old", "New", ""],
             ["Accepted", "C", "c@x.com", "Old", "", ""],
             ["Accepted", "D", "d@x.com", "Other (please specify)", "", ""]]
-    people, _ = _intake(rows)
+    people, _, _ = _intake(rows)
     check("city precedence", [p["city"] for p in people],
           ["Assigned", "New", "Old", ""])
 
@@ -175,7 +175,7 @@ def test_duplicate_rows_dedupe_on_email_but_blanks_stay_distinct():
             ["Accepted", "A again", "a@x.com", "", "Boston", ""],
             ["Accepted", "No email 1", "", "", "Boston", ""],
             ["Accepted", "No email 2", "", "", "Boston", ""]]
-    people, dupes = _intake(rows)
+    people, dupes, _ = _intake(rows)
     check("emailless people are not collapsed",
           (sorted(p["name"] for p in people), dupes),
           (["A", "No email 1", "No email 2"], 1))
@@ -408,7 +408,53 @@ def test_folding_matches_accent_and_punctuation_variants():
 
 #: A floor, not a target. Without it, renaming the `test_` prefix or losing the
 #: functions in a bad merge prints "all checks passed" having run nothing.
-MIN_TESTS = 42
+def test_an_applicant_in_the_room_is_distinguished_from_a_stranger():
+    """"We never accepted them" collapsed two opposite situations into one line.
+
+    Bengaluru 2026-08-27: the chapter's de-facto lead — first invited the minute
+    the organizers room was created, running the venue/date planning since July
+    — sat at Prospect on the intake. Acceptance is what triggers the Drive
+    grant, so he was locked out of his own chapter's folder and said so in the
+    channel. The audit DID list him, under the same label as a total stranger.
+    """
+    rows = [_row("Boston", org="boston-organizers")]
+    directory = {"U7": {"real_name": "Ada", "email": "ada@x.io"},
+                 "U8": {"real_name": "Zed", "email": "zed@x.io"},
+                 "U9": {"real_name": "Cy", "email": "cy@x.io"}}
+    applicants = {"ada@x.io": {"status": "Prospect", "name": "Ada", "city": "Boston"},
+                  "cy@x.io": {"status": "Denied", "name": "Cy", "city": "Boston"}}
+    audit, _ = ao.build_audit(rows, [], {},
+                              {"boston-organizers": ["U7", "U8", "U9"]},
+                              directory, "staff.org", applicants)
+    by_email = {x["email"]: x for x in audit[0]["unaccounted"]}
+    check("an applicant carries their intake status",
+          by_email["ada@x.io"]["intake_status"], "Prospect")
+    check("a stranger carries none", by_email["zed@x.io"]["intake_status"], "")
+    check("a decided-no carries theirs too",
+          by_email["cy@x.io"]["intake_status"], "Denied")
+    # The render splits on exactly this, and a decided NO is not "awaiting".
+    pend = [x for x in audit[0]["unaccounted"]
+            if x.get("intake_status") and x["intake_status"] not in ao.DECIDED_NO]
+    check("only the live applicant counts as awaiting a decision",
+          [x["email"] for x in pend], ["ada@x.io"])
+    check("Denied is not awaiting", "cy@x.io" in [x["email"] for x in pend], False)
+
+
+def test_applicants_map_covers_every_row_not_just_accepted_ones():
+    """read_intake's third return is the whole sheet — the accepted filter is
+    what made a pending organizer indistinguishable from a stranger."""
+    rows = [["Status", "Full name", "Email", "City (Existing)", "City (New)", "Chapter"],
+            ["Accepted", "Ada", "ada@x.io", "", "", "Boston"],
+            ["Prospect", "Bo", "bo@x.io", "", "", "Boston"],
+            ["Denied", "Cy", "cy@x.io", "", "", "Boston"]]
+    people, _, applicants = _intake(rows)
+    check("only the accepted reach `people`", [p["email"] for p in people], ["ada@x.io"])
+    check("but every row reaches `applicants`",
+          sorted(applicants), ["ada@x.io", "bo@x.io", "cy@x.io"])
+    check("with its real status", applicants["bo@x.io"]["status"], "Prospect")
+
+
+MIN_TESTS = 45
 
 
 def test_regional_alias_that_no_longer_resolves_aborts():

--- a/skills/aaif-sync-chapters/scripts/migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_column_order.py
@@ -101,14 +101,15 @@ _REF_RE = re.compile(r"(\$?)([A-Z]{1,3})(\$?)(\d+)")
 
 #: A cross-sheet reference the remapper CAN rewrite — ONE definition, used both
 #: to do the rewriting (remap_formula) and to find what it did not claim
-#: (guide_misses). Two regexes encoding the same knowledge would drift: teach
+#: (unrewritten_refs). Two regexes encoding the same knowledge would drift: teach
 #: one a new form and the other reports it as unfixed, a false alarm in the
 #: single output a human is meant to act on by hand.
-#: The leading lookbehind is load-bearing in BOTH directions: without it a
-#: sheet whose name merely ENDS in the CRM sheet's name — `PastAttendees!D2`,
-#: `Old_Attendees!A:A` — matches on the substring, so the rewriter would
-#: renumber a reference to somebody else's tab and the reporter would raise a
-#: phantom "fix by hand" line about it.
+#: The leading lookbehind stops a sheet whose name merely ENDS in the CRM
+#: sheet's name — `PastAttendees!D2`, `Old_Attendees!A:A` — from matching on
+#: the substring and having somebody else's tab renumbered. That was live in
+#: the shipped rewriter until 2026-08-27. (_SHEET_MENTION carries its own copy
+#: for the mirror-image reason: without it, the same reference raises a phantom
+#: "fix by hand" line.)
 _HANDLED_REF = re.compile(
     r"(?<![A-Za-z0-9_])(%s!)((?:\$?[A-Z]{1,3}\$?\d+)(?::\$?[A-Z]{1,3}(?:\$?\d+)?)?)"
     % re.escape(CRM_SHEET))
@@ -117,7 +118,14 @@ _HANDLED_REF = re.compile(
 #: The complement of _HANDLED_REF over this is the report, which is what makes
 #: the check closed: a form nobody has thought of is reported rather than
 #: silently left pointing at the pre-move layout.
-_SHEET_MENTION = re.compile(r"(?<![A-Za-z0-9_])'?%s'?\s*!" % re.escape(CRM_SHEET))
+#: The apostrophe has three spellings in the estate — literal, `&apos;` and
+#: `&#39;`. migrate_interested_in._both_quotings documents the same trap one
+#: character over for `"` vs `&quot;`; older third-party-written workbooks
+#: escape differently, and a mention this pattern cannot see is neither
+#: rewritten nor reported, which is the one outcome the design rules out.
+_Q = r"(?:'|&apos;|&#39;)?"
+_SHEET_MENTION = re.compile(
+    r"(?<![A-Za-z0-9_])%s%s%s\s*!" % (_Q, re.escape(CRM_SHEET), _Q))
 
 
 def remap_ref(ref, mapping):
@@ -304,8 +312,55 @@ def unmovable(att):
     return out
 
 
-def guide_misses(parts):
-    """Every mention of the CRM sheet that `remap_formula` does NOT claim.
+#: What a snippet may contain. Bounded to characters that can be part of an A1
+#: reference, deliberately: the previous version took a raw 24-char window,
+#: and `xl/sharedStrings.xml` is the workbook-GLOBAL string table. A CRM cell
+#: reading "Great turnout, loved the Attendees! Ada L, ada@x.com is co-hosting"
+#: printed as `Attendees! Ada L, ada@x.` — a member's name and a truncated
+#: email, echoed to the operator's terminal under a "Fix by hand" heading, from
+#: a script with no --redact flag. Stopping at whitespace and separators makes
+#: that structurally impossible while keeping `Attendees!L:L` and
+#: `'Attendees'!D2` fully actionable.
+#: `&` is NOT excluded — the entity spellings of the apostrophe (`&apos;`,
+#: `&#39;`) start with one, and excluding it made those snippets empty, which
+#: is the least actionable possible report line. Prose spill is bounded by the
+#: WHITESPACE exclusion, not by `&`.
+_SNIPPET_CHARS = re.compile(r"[^\s<>,()\"]{0,32}")
+
+
+def _snippet(raw, at):
+    return _SNIPPET_CHARS.match(raw, at).group(0)
+
+
+#: After the `!`, a real reference starts with a column letter or a `$`. A `"`
+#: means the reference is being BUILT as a string (`INDIRECT("Attendees!" & x)`)
+#: — unanalyzable by construction, so it must be reported too. Anything else is
+#: prose: "See the Attendees! tab for the roster" is a sentence, not a
+#: reference, and a fix-by-hand list padded with sentence fragments is a list
+#: operators stop reading — which would make every finding below it invisible.
+_REF_STARTS = re.compile(r'[$A-Z"]')
+
+
+def scan_parts(parts):
+    """Every zip part that can hold a reference to the CRM sheet.
+
+    WIDER than guide_parts on purpose. guide_parts is what the rewriter edits;
+    this is what the reporter reads, and a reporter has no reason to be narrow.
+    A chapter's own "Stats" tab holding `COUNTA(Attendees!L2:L1000)`, or a
+    `<definedName>` in workbook.xml (which is how Sheets exports a named
+    range), is rewritten by nothing here — and was reported by nothing either,
+    so the column moved out from under it in silence. `unmovable()` does not
+    cover it: that counts `<f>` on the Attendees sheet alone.
+    """
+    out = [n for n in parts if n.startswith("xl/worksheets/") and n.endswith(".xml")]
+    for extra in ("xl/workbook.xml", "xl/sharedStrings.xml"):
+        if extra in parts:
+            out.append(extra)
+    return sorted(out)
+
+
+def unrewritten_refs(parts):
+    """Every mention of the CRM sheet that will NOT be correctly rewritten.
 
     Derived, not enumerated. The first version of this listed the two shapes
     known to slip through (`Attendees!L:L`, `'Attendees'!D2`) in a second
@@ -323,19 +378,33 @@ def guide_misses(parts):
     the pre-move layout looks exactly like a correctly migrated one, and the
     verify only ever compares Attendees cell values.
 
-    NOTE `xl/sharedStrings.xml` is workbook-global, so a reference living on
-    some other tab is reported here too. That is the honest direction — the
-    rewriter edits that same global table.
+    A part the rewriter does not touch at all (any sheet but Guide, and
+    workbook.xml) has EVERY mention reported, claimed or not — being claimable
+    is irrelevant when nothing will run the rewrite over it.
+
+    NOT closed, and the docstring must not pretend otherwise. `_SHEET_MENTION`
+    is case-sensitive and literal, so a lowercase `attendees!`, a name built by
+    concatenation (`"Attend"&"ees!"`), or an R1C1-style `Attendees!R2C4` are
+    still neither rewritten nor reported. What this does close is every form
+    spelled the ordinary way, in every part that can hold one.
     """
     out = set()
-    for part in guide_parts(parts):
+    rewritable = set(guide_parts(parts))
+    for part in scan_parts(parts):
         raw = parts[part].decode("utf-8", "replace")
-        claimed = {m.start() for m in _HANDLED_REF.finditer(raw)}
+        # Anchored on the BANG, not on either match's start. The two patterns
+        # do not always begin at the same character — an unbalanced leading
+        # quote (`X('Attendees!D2)`) puts _SHEET_MENTION one earlier — so
+        # comparing starts reported a reference the rewriter had just fixed.
+        # The `!` is the one position both patterns must agree on.
+        claimed = ({m.start(1) + len(CRM_SHEET) for m in _HANDLED_REF.finditer(raw)}
+                   if part in rewritable else set())
         for m in _SHEET_MENTION.finditer(raw):
-            if m.start() not in claimed:
-                # Enough trailing text to name the column, so the report line
-                # is actionable rather than just "something, somewhere".
-                out.add(raw[m.start():m.start() + 24].split("<")[0].strip())
+            if m.end() - 1 in claimed:
+                continue
+            if not _REF_STARTS.match(raw, m.end()):
+                continue                      # prose, not a reference
+            out.add(_snippet(raw, m.start()))
     return sorted(out)
 
 
@@ -434,6 +503,12 @@ def _run(args, workdir):
             skipped.append((folder["name"], why))
             print("  %-18s SKIPPED — %s" % (folder["name"], why))
             continue
+        # Scanned BEFORE the unmovable gate: a workbook refused for a merged
+        # cell can also carry an unrewritable reference, and skipping the scan
+        # meant that chapter contributed nothing to the verdict at all.
+        misses = unrewritten_refs(book["parts"])
+        if misses:
+            guide_gaps.append((folder["name"], misses))
         blockers = unmovable(book["att"])
         if blockers:
             skipped.append((folder["name"],
@@ -442,9 +517,6 @@ def _run(args, workdir):
                             % " and ".join(blockers)))
             print("  %-18s SKIPPED — %s" % (folder["name"], skipped[-1][1]))
             continue
-        misses = guide_misses(book["parts"])
-        if misses:
-            guide_gaps.append((folder["name"], sorted({r for _, r in misses})))
         mapping = move_mapping(book["att"].headers)
         if mapping is None:
             continue
@@ -465,9 +537,15 @@ def _run(args, workdir):
             print("  %-28s %s" % (name, why))
     if not touched:
         if skipped or guide_gaps:
-            print("\nNo column move is due — but %d chapter(s) were SKIPPED and %d "
-                  "have a reference this move cannot rewrite. Nothing here will "
-                  "fix them." % (len(skipped), len(guide_gaps)))
+            # Name only the conditions that actually occurred — printing
+            # "0 have a reference this move cannot rewrite" alongside a real
+            # skip invites the reader to scan for a gap section that isn't there.
+            why = [w for w, n in (("SKIPPED", len(skipped)),
+                                  ("carry a reference this move cannot rewrite",
+                                   len(guide_gaps))) if n]
+            print("\nNo column move is due — but %d chapter(s) %s. Nothing here "
+                  "will fix them."
+                  % (len(skipped) + len(guide_gaps), " and ".join(why)))
             return 1
         print("\nNothing to do — %r already sits before %r everywhere."
               % (MOVE, BEFORE))
@@ -475,7 +553,13 @@ def _run(args, workdir):
     if not args.write:
         print("\n%d workbook(s) would change. Re-run with --write to apply."
               % len(touched))
-        return 1 if guide_gaps else 2
+        # Still 2, not 1. 2 means "work is pending, re-run with --write"; 1 is
+        # failure. A gap cannot be cleared by --write, so folding it into 1
+        # here would abort a wrapper on a condition --write does not address —
+        # and one unrewritable reference anywhere in the estate would then mask
+        # every real column move behind it. The gap is loud in the text above
+        # and reaches the verdict on the paths where nothing else is pending.
+        return 2
 
     print("\nWriting %d workbook(s)..." % len(touched))
     backup_dir = backup_root("crm-order-before")
@@ -535,22 +619,22 @@ def _run(args, workdir):
                 r for r in before if before[r] != after.get(r)]
             stale.append((folder["name"], "%d row(s) changed value across the "
                           "move — DATA MOVED, restore from the backup" % len(rows)))
-    if failed or stale or changed:
+    # `skipped` belongs here too: a chapter refused before the move is not
+    # written, not verified, and not fixed — reporting "Verified" and exiting 0
+    # over it is the same false success this whole section exists to prevent.
+    if failed or stale or changed or skipped or guide_gaps:
         if failed or stale:
             print("VERIFY FAILED:")
             for name, why in failed + stale:
                 print("  %s — %s" % (name, why))
-        return 1
-    if guide_gaps:
-        # A gap is real and unfixed whether or not any column moved, so it must
-        # reach the verdict on BOTH paths. It used to change the exit code only
-        # when nothing was due — so a run that moved columns printed a clean
-        # "Verified" over a list of chapters whose Guide still points at the
-        # pre-move layout, and any wrapper reading the code saw success.
-        print("Verified: every written workbook has %r before %r, and every row "
-              "holds exactly the values it held before — but %d chapter(s) carry "
-              "a reference listed above that was NOT rewritten."
-              % (MOVE, BEFORE, len(guide_gaps)))
+        # A gap or a skip is real and unfixed whether or not any column moved,
+        # so both reach the verdict. Without this a run that moved columns
+        # printed a clean "Verified" over a list of chapters that were never
+        # written, and a wrapper reading the code saw success.
+        if skipped or guide_gaps:
+            print("NOT fully migrated: %d chapter(s) SKIPPED, %d carrying a "
+                  "reference this move cannot rewrite — see above."
+                  % (len(skipped), len(guide_gaps)))
         return 1
     print("Verified: every written workbook has %r before %r, and every row "
           "holds exactly the values it held before." % (MOVE, BEFORE))

--- a/skills/aaif-sync-chapters/scripts/migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_column_order.py
@@ -59,6 +59,7 @@ import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from sync_chapters import download, fold_city, fresh_if_unchanged, upload  # noqa: E402
+from migrate_interested_in import guide_parts  # noqa: E402
 from sync_crm import (CRM_SHEET, NEW_COLUMN, X, XLSX,  # noqa: E402
                       Attendees, backup_root, cell_ref, cleanup_workdir,
                       col_of, find_crm, list_chapter_folders, load_parts,
@@ -66,8 +67,6 @@ from sync_crm import (CRM_SHEET, NEW_COLUMN, X, XLSX,  # noqa: E402
 
 #: The column being moved, and the one it must sit immediately before.
 MOVE, BEFORE = NEW_COLUMN, "Status"
-
-GUIDE_SHEET = "Guide"
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +99,26 @@ def move_mapping(headers, move=MOVE, before=BEFORE):
 # ---------------------------------------------------------------------------
 _REF_RE = re.compile(r"(\$?)([A-Z]{1,3})(\$?)(\d+)")
 
+#: A cross-sheet reference the remapper CAN rewrite — ONE definition, used both
+#: to do the rewriting (remap_formula) and to find what it did not claim
+#: (guide_misses). Two regexes encoding the same knowledge would drift: teach
+#: one a new form and the other reports it as unfixed, a false alarm in the
+#: single output a human is meant to act on by hand.
+#: The leading lookbehind is load-bearing in BOTH directions: without it a
+#: sheet whose name merely ENDS in the CRM sheet's name — `PastAttendees!D2`,
+#: `Old_Attendees!A:A` — matches on the substring, so the rewriter would
+#: renumber a reference to somebody else's tab and the reporter would raise a
+#: phantom "fix by hand" line about it.
+_HANDLED_REF = re.compile(
+    r"(?<![A-Za-z0-9_])(%s!)((?:\$?[A-Z]{1,3}\$?\d+)(?::\$?[A-Z]{1,3}(?:\$?\d+)?)?)"
+    % re.escape(CRM_SHEET))
+
+#: ANY mention of the CRM sheet, however spelled — quoted, spaced, whatever.
+#: The complement of _HANDLED_REF over this is the report, which is what makes
+#: the check closed: a form nobody has thought of is reported rather than
+#: silently left pointing at the pre-move layout.
+_SHEET_MENTION = re.compile(r"(?<![A-Za-z0-9_])'?%s'?\s*!" % re.escape(CRM_SHEET))
+
 
 def remap_ref(ref, mapping):
     """'D2:D1000' -> 'E2:E1000'. Preserves $ anchors and the row numbers."""
@@ -112,10 +131,10 @@ def remap_ref(ref, mapping):
     return _REF_RE.sub(one, ref)
 
 
-def remap_formula(text, mapping, prefix=""):
+def remap_formula(text, mapping, cross_sheet=False):
     """Rewrite A1-style column letters in a formula.
 
-    `prefix` scopes the rewrite to cross-sheet references ("Attendees!"): on the
+    `cross_sheet` scopes the rewrite to `Attendees!`-prefixed references: on the
     Guide tab a bare `B5` is a cell of the GUIDE and must not move, while
     `Attendees!B2:B` must. Without the scope the dashboard's own layout would be
     rewritten along with the references it makes.
@@ -124,7 +143,7 @@ def remap_formula(text, mapping, prefix=""):
     handled too — the trailing bare column has no row number, so it needs its
     own pass.
     """
-    if not prefix:
+    if not cross_sheet:
         return _REF_RE.sub(lambda m: remap_ref(m.group(0), mapping), text)
 
     def one(m):
@@ -148,8 +167,7 @@ def remap_formula(text, mapping, prefix=""):
         return m.group(1) + body
 
     # One reference at a time, each still carrying its sheet prefix.
-    return re.sub(r"(%s)((?:\$?[A-Z]{1,3}\$?\d+)(?::\$?[A-Z]{1,3}(?:\$?\d+)?)?)"
-                  % re.escape(prefix), one, text)
+    return _HANDLED_REF.sub(one, text)
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +304,41 @@ def unmovable(att):
     return out
 
 
+def guide_misses(parts):
+    """Every mention of the CRM sheet that `remap_formula` does NOT claim.
+
+    Derived, not enumerated. The first version of this listed the two shapes
+    known to slip through (`Attendees!L:L`, `'Attendees'!D2`) in a second
+    regex — which duplicated the rewriter's own knowledge of what a handled
+    reference looks like, and still left the class open: a THIRD shape nobody
+    had thought of would be neither rewritten nor reported, which is precisely
+    the silent failure this check exists to prevent.
+
+    Now `_HANDLED_REF` is the single definition of "handled", and this is its
+    residue over `_SHEET_MENTION`. The day the rewriter learns a new form, it
+    drops out of this report on its own; a form it never learns shows up here
+    without anyone having to predict it.
+
+    A miss matters because it is invisible otherwise: a Guide left pointing at
+    the pre-move layout looks exactly like a correctly migrated one, and the
+    verify only ever compares Attendees cell values.
+
+    NOTE `xl/sharedStrings.xml` is workbook-global, so a reference living on
+    some other tab is reported here too. That is the honest direction — the
+    rewriter edits that same global table.
+    """
+    out = set()
+    for part in guide_parts(parts):
+        raw = parts[part].decode("utf-8", "replace")
+        claimed = {m.start() for m in _HANDLED_REF.finditer(raw)}
+        for m in _SHEET_MENTION.finditer(raw):
+            if m.start() not in claimed:
+                # Enough trailing text to name the column, so the report line
+                # is actionable rather than just "something, somewhere".
+                out.add(raw[m.start():m.start() + 24].split("<")[0].strip())
+    return sorted(out)
+
+
 def move_guide(parts, mapping):
     """Rewrite `Attendees!<col>` references wherever the Guide keeps them.
 
@@ -293,11 +346,9 @@ def move_guide(parts, mapping):
     and the shared string table for the workbooks that use one.
     """
     changed = []
-    targets = [p for p in (sheet_part(parts, GUIDE_SHEET), "xl/sharedStrings.xml")
-               if p and p in parts]
-    for part in targets:
+    for part in guide_parts(parts):
         raw = parts[part].decode("utf-8", "replace")
-        out = remap_formula(raw, mapping, prefix="%s!" % CRM_SHEET)
+        out = remap_formula(raw, mapping, cross_sheet=True)
         if out != raw:
             parts[part] = out.encode()
             changed.append(part)
@@ -376,7 +427,7 @@ def _run(args, workdir):
             sys.exit("ABORT: no chapter folder matches %r." % args.city)
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 
-    touched, skipped = [], []
+    touched, skipped, guide_gaps = [], [], []
     for folder in folders:
         book, why = open_crm(folder, workdir)
         if book is None:
@@ -391,6 +442,9 @@ def _run(args, workdir):
                             % " and ".join(blockers)))
             print("  %-18s SKIPPED — %s" % (folder["name"], skipped[-1][1]))
             continue
+        misses = guide_misses(book["parts"])
+        if misses:
+            guide_gaps.append((folder["name"], sorted({r for _, r in misses})))
         mapping = move_mapping(book["att"].headers)
         if mapping is None:
             continue
@@ -399,14 +453,21 @@ def _run(args, workdir):
                  re.sub(r"\d+$", "", cell_ref(mapping[book["att"].headers[MOVE]], 1))))
         touched.append({"book": book, "mapping": mapping})
 
+    if guide_gaps:
+        print("\nReference(s) to the %s sheet this move cannot rewrite — they "
+              "still point at the PRE-move layout and are NOT corrected. Fix by "
+              "hand:" % CRM_SHEET)
+        for name, refs in guide_gaps:
+            print("  %-28s %s" % (name, ", ".join(refs)))
     if skipped:
         print("\nChapters SKIPPED — not reordered, fix the workbook and re-run:")
         for name, why in skipped:
             print("  %-28s %s" % (name, why))
     if not touched:
-        if skipped:
-            print("\nNothing due for the chapters that could be opened — but %d "
-                  "was/were SKIPPED above." % len(skipped))
+        if skipped or guide_gaps:
+            print("\nNo column move is due — but %d chapter(s) were SKIPPED and %d "
+                  "have a reference this move cannot rewrite. Nothing here will "
+                  "fix them." % (len(skipped), len(guide_gaps)))
             return 1
         print("\nNothing to do — %r already sits before %r everywhere."
               % (MOVE, BEFORE))
@@ -414,7 +475,7 @@ def _run(args, workdir):
     if not args.write:
         print("\n%d workbook(s) would change. Re-run with --write to apply."
               % len(touched))
-        return 2
+        return 1 if guide_gaps else 2
 
     print("\nWriting %d workbook(s)..." % len(touched))
     backup_dir = backup_root("crm-order-before")
@@ -479,6 +540,17 @@ def _run(args, workdir):
             print("VERIFY FAILED:")
             for name, why in failed + stale:
                 print("  %s — %s" % (name, why))
+        return 1
+    if guide_gaps:
+        # A gap is real and unfixed whether or not any column moved, so it must
+        # reach the verdict on BOTH paths. It used to change the exit code only
+        # when nothing was due — so a run that moved columns printed a clean
+        # "Verified" over a list of chapters whose Guide still points at the
+        # pre-move layout, and any wrapper reading the code saw success.
+        print("Verified: every written workbook has %r before %r, and every row "
+              "holds exactly the values it held before — but %d chapter(s) carry "
+              "a reference listed above that was NOT rewritten."
+              % (MOVE, BEFORE, len(guide_gaps)))
         return 1
     print("Verified: every written workbook has %r before %r, and every row "
           "holds exactly the values it held before." % (MOVE, BEFORE))

--- a/skills/aaif-sync-chapters/scripts/migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_column_order.py
@@ -110,20 +110,28 @@ _REF_RE = re.compile(r"(\$?)([A-Z]{1,3})(\$?)(\d+)")
 #: the shipped rewriter until 2026-08-27. (_SHEET_MENTION carries its own copy
 #: for the mirror-image reason: without it, the same reference raises a phantom
 #: "fix by hand" line.)
-_HANDLED_REF = re.compile(
-    r"(?<![A-Za-z0-9_])(%s!)((?:\$?[A-Z]{1,3}\$?\d+)(?::\$?[A-Z]{1,3}(?:\$?\d+)?)?)"
-    % re.escape(CRM_SHEET))
-
-#: ANY mention of the CRM sheet, however spelled — quoted, spaced, whatever.
-#: The complement of _HANDLED_REF over this is the report, which is what makes
-#: the check closed: a form nobody has thought of is reported rather than
-#: silently left pointing at the pre-move layout.
 #: The apostrophe has three spellings in the estate — literal, `&apos;` and
 #: `&#39;`. migrate_interested_in._both_quotings documents the same trap one
 #: character over for `"` vs `&quot;`; older third-party-written workbooks
 #: escape differently, and a mention this pattern cannot see is neither
 #: rewritten nor reported, which is the one outcome the design rules out.
 _Q = r"(?:'|&apos;|&#39;)?"
+
+#: Group 1 is the whole prefix INCLUDING any quoting, kept verbatim; group 2 is
+#: the reference, which is what gets remapped. Quoted forms are handled because
+#: `_xlnm._FilterDatabase` — Excel's hidden record of the autoFilter range, which
+#: every one of these workbooks carries — spells the sheet name `'Attendees'!`.
+#: Leaving it unrewritten made the defined name disagree with the sheet's own
+#: <autoFilter ref> on all 83 chapters.
+_HANDLED_REF = re.compile(
+    r"(?<![A-Za-z0-9_])(%s%s%s!)"
+    r"((?:\$?[A-Z]{1,3}\$?\d+)(?::\$?[A-Z]{1,3}(?:\$?\d+)?)?)"
+    % (_Q, re.escape(CRM_SHEET), _Q))
+
+#: ANY mention of the CRM sheet, however spelled — quoted, spaced, whatever.
+#: The complement of _HANDLED_REF over this is the report, which is what makes
+#: the check closed: a form nobody has thought of is reported rather than
+#: silently left pointing at the pre-move layout.
 _SHEET_MENTION = re.compile(
     r"(?<![A-Za-z0-9_])%s%s%s\s*!" % (_Q, re.escape(CRM_SHEET), _Q))
 
@@ -383,13 +391,13 @@ def unrewritten_refs(parts):
     is irrelevant when nothing will run the rewrite over it.
 
     NOT closed, and the docstring must not pretend otherwise. `_SHEET_MENTION`
-    is case-sensitive and literal, so a lowercase `attendees!`, a name built by
+    is case-sensitive, so a lowercase `attendees!`, a name built by
     concatenation (`"Attend"&"ees!"`), or an R1C1-style `Attendees!R2C4` are
     still neither rewritten nor reported. What this does close is every form
     spelled the ordinary way, in every part that can hold one.
     """
     out = set()
-    rewritable = set(guide_parts(parts))
+    rewritable = set(rewritable_parts(parts))
     for part in scan_parts(parts):
         raw = parts[part].decode("utf-8", "replace")
         # Anchored on the BANG, not on either match's start. The two patterns
@@ -397,7 +405,10 @@ def unrewritten_refs(parts):
         # quote (`X('Attendees!D2)`) puts _SHEET_MENTION one earlier — so
         # comparing starts reported a reference the rewriter had just fixed.
         # The `!` is the one position both patterns must agree on.
-        claimed = ({m.start(1) + len(CRM_SHEET) for m in _HANDLED_REF.finditer(raw)}
+        # end(1)-1 is the bang: group 1 now has a variable-length prefix
+        # (quotes, and three spellings of them), so a fixed offset from the
+        # start would drift the moment a quoted form appeared.
+        claimed = ({m.end(1) - 1 for m in _HANDLED_REF.finditer(raw)}
                    if part in rewritable else set())
         for m in _SHEET_MENTION.finditer(raw):
             if m.end() - 1 in claimed:
@@ -408,14 +419,29 @@ def unrewritten_refs(parts):
     return sorted(out)
 
 
-def move_guide(parts, mapping):
-    """Rewrite `Attendees!<col>` references wherever the Guide keeps them.
+def rewritable_parts(parts):
+    """Parts move_refs edits: the Guide's two storage forms, plus workbook.xml.
 
-    Both storage forms again: the sheet part for inline strings and formulas,
-    and the shared string table for the workbooks that use one.
+    workbook.xml is here for `<definedName>` — a Sheets-exported named range,
+    and `_xlnm._FilterDatabase`, which every one of these workbooks carries.
+    Rewriting it cannot touch a sheet NAME: `<sheet name="Attendees">` has no
+    `!` after it, and _HANDLED_REF requires one.
+    """
+    out = list(guide_parts(parts))
+    if "xl/workbook.xml" in parts:
+        out.append("xl/workbook.xml")
+    return out
+
+
+def move_refs(parts, mapping):
+    """Rewrite `Attendees!<col>` references in every part we own.
+
+    Both Guide storage forms — the sheet part for inline strings and formulas,
+    and the shared string table for the workbooks that use one — plus the
+    workbook-level defined names.
     """
     changed = []
-    for part in guide_parts(parts):
+    for part in rewritable_parts(parts):
         raw = parts[part].decode("utf-8", "replace")
         out = remap_formula(raw, mapping, cross_sheet=True)
         if out != raw:
@@ -466,7 +492,7 @@ def apply_move(book, mapping):
     # headers must be re-derived before serialize() sizes the dimension.
     att.headers = {h: mapping.get(c, c) for h, c in att.headers.items()}
     att.serialize()
-    move_guide(book["parts"], mapping)
+    move_refs(book["parts"], mapping)
     return save_parts(book["names"], book["parts"]), before
 
 

--- a/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
+++ b/skills/aaif-sync-chapters/scripts/migrate_interested_in.py
@@ -506,7 +506,12 @@ def guide_parts(parts):
     """
     out = []
     part = sheet_part(parts, "Guide")
-    if part:
+    # `part in parts` as well as `part`: sheet_part resolves through
+    # workbook.xml.rels and returns whatever Target says, without checking the
+    # zip actually holds it. Callers index parts[part] directly, so a workbook
+    # whose rel points at a missing part would raise KeyError in the middle of
+    # an 83-workbook loop instead of being skipped.
+    if part and part in parts:
         out.append(part)
     if "xl/sharedStrings.xml" in parts:
         out.append("xl/sharedStrings.xml")

--- a/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
@@ -349,7 +349,11 @@ def _book_with_guide(text):
 # someone predicted — so a form nobody has thought of is reported too.
 for text, hits in (("COUNTA(Attendees!L:L)", 1),          # whole-column ref
                    ("COUNTA(Attendees!$L:$L)", 1),
-                   ("SUM('Attendees'!D2:D9)", 1),         # quoted sheet name
+                   # Quoted sheet names ARE rewritten now — `_xlnm._FilterDatabase`
+                   # spells the sheet that way in every one of these workbooks —
+                   # so they must NOT appear in the report.
+                   ("SUM('Attendees'!D2:D9)", 0),
+                   ("SUM(&apos;Attendees&apos;!D2:D9)", 0),
                    ("INDIRECT(\"Attendees!\" &amp; x)", 1),   # not predicted anywhere
                    ("SUM(Attendees !D2)", 1),             # space before the bang
                    # ...and every form it DOES handle must stay silent.
@@ -435,11 +439,21 @@ check("a formula on a chapter's own tab is reported",
 check("...even though that shape IS one the rewriter could handle",
       mo.remap_formula("COUNTA(Attendees!L2:L1000)", MAP, cross_sheet=True),
       "COUNTA(Attendees!D2:D1000)")
-check("a definedName in workbook.xml is reported",
+# workbook.xml is REWRITABLE (that is where `_xlnm._FilterDatabase` lives), so a
+# defined name in the handled shape is fixed rather than reported...
+check("a handled definedName is rewritten, not reported",
       mo.unrewritten_refs(_book_with_extra_sheet(
           "<worksheet><sheetData/></worksheet>",
-          '<definedName name="live">Attendees!$L$2:$L$1000</definedName>')),
-      ["Attendees!$L$2:$L$1000"])
+          '<definedName name="live">Attendees!$L$2:$L$1000</definedName>')), [])
+check("...and the rewrite is correct",
+      mo.remap_formula("'Attendees'!$A$1:$K$1", MAP, cross_sheet=True),
+      "'Attendees'!$A$1:$L$1")
+# ...while an UNhandled one still is.
+check("an unhandled definedName is reported",
+      mo.unrewritten_refs(_book_with_extra_sheet(
+          "<worksheet><sheetData/></worksheet>",
+          '<definedName name="live">Attendees!L:L</definedName>')),
+      ["Attendees!L:L"])
 
 # Prose is not a reference. A fix-by-hand list padded with sentence fragments
 # is a list operators stop reading, which would bury every real finding in it.
@@ -450,8 +464,9 @@ for text, want in (("See the Attendees! tab for the roster", []),
                    # reported — the snippet stops at the quote, which is less
                    # specific than a real ref but still points at the spot.
                    ('INDIRECT("Attendees!" & col)', ["Attendees!"]),
-                   ("&apos;Attendees&apos;!D2", ["&apos;Attendees&apos;!D2"]),
-                   ("&#39;Attendees&#39;!D2", ["&#39;Attendees&#39;!D2"])):
+                   ("&apos;Attendees&apos;!D2", []),
+                   ("&#39;Attendees&#39;!D2", []),
+                   ("&apos;Attendees&apos;!L:L", ["&apos;Attendees&apos;!L:L"])):
     check("prose/ref %-42r" % text[:40],
           mo.unrewritten_refs(_book_with_guide(text)), want)
 

--- a/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
@@ -8,7 +8,8 @@ against. It is built from migrate_interested_in's own fixture, put through
 that migration, so the input here is literally what the previous script
 produces rather than a hand-written guess at it.
 """
-import os, re, sys
+import os, re, sys, tempfile
+from unittest import mock
 from xml.etree import ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -357,23 +358,23 @@ for text, hits in (("COUNTA(Attendees!L:L)", 1),          # whole-column ref
                    ("FILTER({Attendees!A2:A, Attendees!L2:L})", 0),
                    ("no references at all", 0)):
     check("guide_misses %-40r -> %d" % (text[:38], hits),
-          len(mo.guide_misses(_book_with_guide(text))), hits)
+          len(mo.unrewritten_refs(_book_with_guide(text))), hits)
 check("a reported miss names the column, so it is actionable",
-      mo.guide_misses(_book_with_guide("COUNTA(Attendees!L:L)"))[0].startswith("Attendees!L:L"),
+      mo.unrewritten_refs(_book_with_guide("COUNTA(Attendees!L:L)"))[0].startswith("Attendees!L:L"),
       True)
 # A sheet whose NAME merely ends in "Attendees" is not ours.
 check("a lookalike sheet name is not reported",
-      mo.guide_misses(_book_with_guide("COUNTA(PastAttendees!L:L)")), [])
+      mo.unrewritten_refs(_book_with_guide("COUNTA(PastAttendees!L:L)")), [])
 # The shared-string table is searched too — five live chapters keep their Guide
 # text there rather than inline.
 _ps = _book_with_guide("clean")
 _ps["xl/sharedStrings.xml"] = b"<sst><si><t>COUNTA(Attendees!L:L)</t></si></sst>"
-check("...including the shared string table", len(mo.guide_misses(_ps)), 1)
+check("...including the shared string table", len(mo.unrewritten_refs(_ps)), 1)
 # The invariant the whole design rests on: the two patterns cannot disagree.
 check("nothing remap_formula rewrites is ever reported as a miss",
       [t for t in ("Attendees!D2", "Attendees!$D$2", "Attendees!D2:D9",
                    "Attendees!D2:D", "Attendees!$D$2:$D$1000")
-       if mo.guide_misses(_book_with_guide("X(%s)" % t))], [])
+       if mo.unrewritten_refs(_book_with_guide("X(%s)" % t))], [])
 
 
 # ---------------------------------------------------------------------------
@@ -396,6 +397,158 @@ check("...and its dropdown/colour checks still pass",
 check("the sync can open the reordered workbook", check_dropdowns(post), [])
 check("...and reads every column back by name",
       sorted(post.headers), sorted(WANTED))
+
+
+# The REWRITER half of the lookbehind. The lookalike test above uses a
+# whole-column ref, which _HANDLED_REF never matches — so removing the
+# lookbehind from _HANDLED_REF alone produced ZERO failures while corrupting
+# data: `PastAttendees!D2` was renumbered to `PastAttendees!E2`, silently
+# repointing a formula on somebody else's tab.
+check("a lookalike sheet's own reference is never renumbered",
+      mo.remap_formula("PastAttendees!D2+Old_Attendees!$L$2:$L$9", MAP, cross_sheet=True),
+      "PastAttendees!D2+Old_Attendees!$L$2:$L$9")
+check("...while the real sheet beside it still is",
+      mo.remap_formula("PastAttendees!D2+Attendees!D2", MAP, cross_sheet=True),
+      "PastAttendees!D2+Attendees!E2")
+
+# Parts the rewriter never edits. A chapter's own tab, or a Sheets-exported
+# named range, is rewritten by NOTHING here — so every mention in one is a
+# miss, claimable or not. Neither was scanned before; the column moved out from
+# under them in silence, and `unmovable` does not cover it (it counts <f> on
+# the Attendees sheet alone).
+def _book_with_extra_sheet(sheet3_xml, workbook_extra=""):
+    _n, _p = fx.make_pre_xlsx(headers=tuple(WANTED))
+    _p["xl/workbook.xml"] = _p["xl/workbook.xml"].decode().replace(
+        "<sheets>", "%s<sheets>" % workbook_extra).replace(
+        "</sheets>", '<sheet name="Stats" sheetId="3" r:id="rId5" /></sheets>').encode()
+    _p["xl/_rels/workbook.xml.rels"] = _p["xl/_rels/workbook.xml.rels"].decode().replace(
+        "</Relationships>",
+        '<Relationship Id="rId5" Target="worksheets/sheet3.xml" /></Relationships>').encode()
+    _p["xl/worksheets/sheet3.xml"] = sheet3_xml.encode()
+    return _p
+
+check("a formula on a chapter's own tab is reported",
+      mo.unrewritten_refs(_book_with_extra_sheet(
+          '<worksheet><sheetData><row r="2"><c r="B2">'
+          "<f>COUNTA(Attendees!L2:L1000)</f><v>7</v></c></row></sheetData></worksheet>")),
+      ["Attendees!L2:L1000"])
+check("...even though that shape IS one the rewriter could handle",
+      mo.remap_formula("COUNTA(Attendees!L2:L1000)", MAP, cross_sheet=True),
+      "COUNTA(Attendees!D2:D1000)")
+check("a definedName in workbook.xml is reported",
+      mo.unrewritten_refs(_book_with_extra_sheet(
+          "<worksheet><sheetData/></worksheet>",
+          '<definedName name="live">Attendees!$L$2:$L$1000</definedName>')),
+      ["Attendees!$L$2:$L$1000"])
+
+# Prose is not a reference. A fix-by-hand list padded with sentence fragments
+# is a list operators stop reading, which would bury every real finding in it.
+for text, want in (("See the Attendees! tab for the roster", []),
+                   ("Great turnout, loved the Attendees! Ada L, ada@x.com", []),
+                   ("COUNTA(Attendees!L:L)", ["Attendees!L:L"]),
+                   # A reference BUILT as a string is unanalyzable, so it is
+                   # reported — the snippet stops at the quote, which is less
+                   # specific than a real ref but still points at the spot.
+                   ('INDIRECT("Attendees!" & col)', ["Attendees!"]),
+                   ("&apos;Attendees&apos;!D2", ["&apos;Attendees&apos;!D2"]),
+                   ("&#39;Attendees&#39;!D2", ["&#39;Attendees&#39;!D2"])):
+    check("prose/ref %-42r" % text[:40],
+          mo.unrewritten_refs(_book_with_guide(text)), want)
+
+# PII. xl/sharedStrings.xml is the workbook-GLOBAL string table — it holds
+# organizer names, emails and free-text survey answers. The snippet used to be
+# a raw 24-char window, which printed `Attendees! Ada L, ada@x.` under a
+# "Fix by hand" heading from a script that has no --redact flag.
+_pii = _book_with_guide("clean")
+_pii["xl/sharedStrings.xml"] = (
+    b"<sst><si><t>Loved the Attendees! Ada Lovelace ada@x.io joins as co-host</t>"
+    b"</si></sst>")
+check("a member's name and email can never reach the report",
+      [r for r in mo.unrewritten_refs(_pii) if "Ada" in r or "@" in r], [])
+
+# The two patterns must agree on where a reference begins. They do NOT always
+# start at the same character — an unbalanced leading quote puts the mention
+# one earlier — so the residue anchors on the `!`, which both must contain.
+check("an unbalanced quote is rewritten and NOT double-reported",
+      (mo.remap_formula("X('Attendees!D2)", MAP, cross_sheet=True),
+       mo.unrewritten_refs(_book_with_guide("X('Attendees!D2)"))),
+      ("X('Attendees!E2)", []))
+
+# The handled <-> reported invariant, over the cross product rather than five
+# hand-picked strings.
+_shapes = ["Attendees!%s%s%s" % (a, c, r)
+           for a in ("", "$") for c in ("A", "D", "L", "AAA") for r in ("2", "$2")]
+_shapes += ["Attendees!%s2:%s9" % (c, c) for c in ("A", "D", "L")]
+_shapes += ["Attendees!%s2:%s" % (c, c) for c in ("A", "D", "L")]
+check("handled <=> not reported, across %d reference shapes" % len(_shapes),
+      [t for t in _shapes if bool(mo.unrewritten_refs(_book_with_guide("X(%s)" % t)))], [])
+
+
+# ---------------------------------------------------------------------------
+# _run's report path — the layer that let a type change through untested
+# ---------------------------------------------------------------------------
+# guide_misses' return type changed from [(part, ref)] to [ref], and the caller
+# in _run kept unpacking pairs: `sorted({r for _, r in misses})`. Every direct
+# guide_misses test still passed, because none of them went through _run — so
+# the whole reporting path was dead, and would have raised ValueError on the
+# first real chapter carrying exactly the reference this PR exists to catch.
+# These drive _run itself with Drive stubbed.
+import contextlib as _ctx  # noqa: E402
+import io as _io  # noqa: E402
+
+
+def _run_report(guide_text):
+    """Run _run() in report mode over one stubbed chapter; return (code, stdout).
+
+    Headers are the POST-move order, so open_crm's strict reader succeeds and
+    move_mapping returns None — the chapter is already ordered and the ONLY
+    thing left to exercise is the gap report. `download` is patched in
+    migrate_column_order's namespace, not sync_chapters': open_crm calls the
+    name bound at import, so patching the source module leaves the real one in
+    place and every chapter reports as SKIPPED on a 404.
+    """
+    _n, _p = fx.make_pre_xlsx(
+        headers=tuple(WANTED),
+        guide=('<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+               '<sheetData><row r="1"><c r="B1" t="inlineStr"><is><t>%s</t></is></c>'
+               "</row></sheetData></worksheet>" % guide_text))
+    raw = save_parts(_n, _p)
+    buf = _io.StringIO()
+    # A raise inside _run is a FAILURE, not a reason to abort the suite: the
+    # tuple-unpack bug this harness exists to catch propagated out of _run and
+    # killed the whole script, which hid every check after it. Turn it into a
+    # value the assertions can inspect.
+    try:
+        with mock.patch.object(mo, "list_chapter_folders",
+                               lambda: [{"id": "f1", "name": "Boston"}]), \
+             mock.patch.object(mo, "find_crm",
+                               lambda fid: ({"id": "c1", "name": "Boston CRM.xlsx"}, None)), \
+             mock.patch.object(mo, "download", lambda fid, path: raw), \
+             _ctx.redirect_stdout(buf):
+            code = mo._run(mock.Mock(city=None, write=False),
+                           tempfile.mkdtemp(prefix="t-"))
+    except Exception as e:
+        return "RAISED %s: %s" % (type(e).__name__, e), buf.getvalue()
+    return code, buf.getvalue()
+
+
+_code, _out = _run_report("COUNTA(Attendees!L:L)")
+check("_run does not raise on a workbook WITH a gap",
+      str(_code).startswith("RAISED"), False)
+check("the stub opens cleanly — no chapter is SKIPPED", "SKIPPED" in _out, False)
+check("_run survives a workbook WITH a miss (the ValueError regression)",
+      "Traceback" not in _out, True)
+check("...and names the unrewritable reference in the report",
+      "Attendees!L:L" in _out, True)
+check("...and says which chapter", "Boston" in _out, True)
+check("...and does not print a clean verdict over it",
+      "Nothing to do —" in _out, False)
+check("...and the gap reaches the exit code", _code, 1)
+
+_code2, _out2 = _run_report('COUNTIF(Attendees!D2:D1000,"x")')
+check("a workbook with NO miss is silent and exits 0",
+      (_code2, "cannot rewrite" in _out2, "Nothing to do —" in _out2),
+      (0, False, True))
 
 
 print()

--- a/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
+++ b/skills/aaif-sync-chapters/scripts/test_migrate_column_order.py
@@ -115,11 +115,11 @@ for f, want in (("Attendees!$L$2:$L$1000", "Attendees!$D$2:$D$1000"),
                 ("Attendees!$A$1:$K$1",    "Attendees!$A$1:$L$1"),
                 ("Attendees!L2:L1000",     "Attendees!D2:D1000"),
                 ("Attendees!L2:L",         "Attendees!D2:D")):
-    got = mo.remap_formula(f, MAP, prefix="Attendees!")
+    got = mo.remap_formula(f, MAP, cross_sheet=True)
     check("absolute/relative range %-24r" % f, got, want)
 check("no remapped range ever spans two columns",
       [g for g in (mo.remap_formula("Attendees!$%s$2:$%s$1000" % (c, c), MAP,
-                                    prefix="Attendees!")
+                                    cross_sheet=True)
                    for c in "ABCDEFGHIJKL")
        if len(set(re.findall(r"\$([A-Z]+)\$", g))) != 1], [])
 
@@ -129,25 +129,25 @@ GUIDE_FILTER = ("=FILTER({Attendees!A2:A, Attendees!L2:L, Attendees!H2:H, "
                 '(Attendees!C2:C="Yes")+(Attendees!B2:B="High"), '
                 'Attendees!B2:B<>"Non-grata")')
 check("the live list is remapped, open-ended ranges included",
-      mo.remap_formula(GUIDE_FILTER, MAP, prefix="Attendees!"),
+      mo.remap_formula(GUIDE_FILTER, MAP, cross_sheet=True),
       "=FILTER({Attendees!A2:A, Attendees!D2:D, Attendees!I2:I, "
       "Attendees!J2:J, Attendees!L2:L, Attendees!B2:B, Attendees!F2:F}, "
       '(Attendees!C2:C="Yes")+(Attendees!B2:B="High"), '
       'Attendees!B2:B<>"Non-grata")')
 check("the dashboard tiles follow the column",
       mo.remap_formula('COUNTIF(Attendees!L2:L1000,"*Speaker*")', MAP,
-                       prefix="Attendees!"),
+                       cross_sheet=True),
       'COUNTIF(Attendees!D2:D1000,"*Speaker*")')
 check("an unrelated Attendees column is still remapped",
-      mo.remap_formula("COUNTA(Attendees!A2:A1000)", MAP, prefix="Attendees!"),
+      mo.remap_formula("COUNTA(Attendees!A2:A1000)", MAP, cross_sheet=True),
       "COUNTA(Attendees!A2:A1000)")
 # THE trap: the Guide has its own cells, and they must not move with the
 # Attendees layout. Without the prefix scope the dashboard rewrites itself.
 check("a Guide-LOCAL reference is left alone",
-      mo.remap_formula("B5+Attendees!E2", MAP, prefix="Attendees!"),
+      mo.remap_formula("B5+Attendees!E2", MAP, cross_sheet=True),
       "B5+Attendees!F2")
 check("...even when it names a column that moves",
-      mo.remap_formula("SUM(D2:D9)", MAP, prefix="Attendees!"), "SUM(D2:D9)")
+      mo.remap_formula("SUM(D2:D9)", MAP, cross_sheet=True), "SUM(D2:D9)")
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +326,54 @@ _p3["xl/worksheets/sheet1.xml"] = _d3.encode()
 _a3 = Attendees(_p3, sheet_part(_p3, "Attendees"), require=mig.PRE_SPLIT_HEADERS)
 check("unmovable detects a chapter's own cell formula",
       mo.unmovable(_a3), ["1 cell formula(s)"])
+
+
+# ---------------------------------------------------------------------------
+# Guide references the remapper cannot rewrite are REPORTED, not skipped
+# ---------------------------------------------------------------------------
+# remap_formula's prefix pass needs a bare `Attendees!` and a row number on the
+# first half. A whole-column ref or a quoted sheet name slips through — and a
+# Guide left pointing at the PRE-move layout looks exactly like one correctly
+# migrated, because the verify never reads the Guide at all. Unlike
+# migrate_interested_in.plan_guide, which reports an unrecognised formula, this
+# used to be completely silent.
+def _book_with_guide(text):
+    _n, _p = fx.make_pre_xlsx(guide=(
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        '<sheetData><row r="1"><c r="B1" t="inlineStr"><is><t>%s</t></is></c></row>'
+        "</sheetData></worksheet>" % text))
+    return _p
+
+# The report is the RESIDUE of what remap_formula claims, not a list of shapes
+# someone predicted — so a form nobody has thought of is reported too.
+for text, hits in (("COUNTA(Attendees!L:L)", 1),          # whole-column ref
+                   ("COUNTA(Attendees!$L:$L)", 1),
+                   ("SUM('Attendees'!D2:D9)", 1),         # quoted sheet name
+                   ("INDIRECT(\"Attendees!\" &amp; x)", 1),   # not predicted anywhere
+                   ("SUM(Attendees !D2)", 1),             # space before the bang
+                   # ...and every form it DOES handle must stay silent.
+                   ('COUNTIF(Attendees!D2:D1000,"x")', 0),
+                   ('COUNTIF(Attendees!$D$2:$D$1000,"x")', 0),
+                   ("FILTER({Attendees!A2:A, Attendees!L2:L})", 0),
+                   ("no references at all", 0)):
+    check("guide_misses %-40r -> %d" % (text[:38], hits),
+          len(mo.guide_misses(_book_with_guide(text))), hits)
+check("a reported miss names the column, so it is actionable",
+      mo.guide_misses(_book_with_guide("COUNTA(Attendees!L:L)"))[0].startswith("Attendees!L:L"),
+      True)
+# A sheet whose NAME merely ends in "Attendees" is not ours.
+check("a lookalike sheet name is not reported",
+      mo.guide_misses(_book_with_guide("COUNTA(PastAttendees!L:L)")), [])
+# The shared-string table is searched too — five live chapters keep their Guide
+# text there rather than inline.
+_ps = _book_with_guide("clean")
+_ps["xl/sharedStrings.xml"] = b"<sst><si><t>COUNTA(Attendees!L:L)</t></si></sst>"
+check("...including the shared string table", len(mo.guide_misses(_ps)), 1)
+# The invariant the whole design rests on: the two patterns cannot disagree.
+check("nothing remap_formula rewrites is ever reported as a miss",
+      [t for t in ("Attendees!D2", "Attendees!$D$2", "Attendees!D2:D9",
+                   "Attendees!D2:D", "Attendees!$D$2:$D$1000")
+       if mo.guide_misses(_book_with_guide("X(%s)" % t))], [])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #28. The column-move migration silently ignored `Attendees!` references it could not rewrite, so a Guide left pointing at the pre-move layout was indistinguishable from a correctly migrated one. It now reports them — and the report is *derived* from the rewriter rather than enumerated beside it, so a form nobody predicted surfaces on its own.

Running that widened scan against the live fleet then found two real defects the migration had already caused. Both are repaired on all 83 workbooks; the code changes here are what stop them recurring.

## Changesets

### 1. `fix(sync-chapters): report Attendees refs the column move cannot rewrite`
`remap_formula`'s cross-sheet pass required a bare `Attendees!` **and** a row number, so `COUNTA(Attendees!L:L)` and `SUM('Attendees'!D2:D9)` slipped through untouched — silent, because the verify compares Attendees *cell values* and never reads the Guide.

Also fixed a **pre-existing bug in the shipped rewriter**, caught by a new lookalike test: neither pattern guarded its left edge, so `PastAttendees!D2` was renumbered to `PastAttendees!E2` — corrupting a reference to a different sheet.

### 2. `fix: address self-review findings`
Six review agents; four independently found the same crash.

- **The report path could never run.** A refactor changed `guide_misses` from `[(part, ref)]` to `[ref]` and left the caller unpacking pairs. The first chapter carrying exactly the reference this PR exists to catch would have aborted the run with a bare traceback. Every unit test passed — none went through `_run`.
- **A third worksheet was invisible to everything.** The scan read only the Guide part + sharedStrings, the rewriter edits only those, and `unmovable()` checks the Attendees sheet alone. A chapter's own "Stats" tab counting `Attendees!L2:L1000` had the column moved out from under it in silence. The **scan** is now every worksheet part plus `workbook.xml`.
- **PII.** The report took a raw 24-char window over the workbook-**global** string table. A CRM note reading `loved the Attendees! Ada L, ada@x.com` printed under a "Fix by hand" heading, from a script with no `--redact`. Bounded to reference characters.
- Residue anchored on the `!` rather than match starts (an unbalanced quote made the two patterns disagree); prose filtered; `guide_parts` regained its `p in parts` guard; `skipped` reaches the write-path verdict; dry-run keeps exit `2`.

### 3. `fix(sync-chapters): rewrite quoted sheet refs and workbook-level defined names`
Found by the widened scan against the live fleet. **All 83 chapters disagreed with themselves:**

```
sheet    <autoFilter ref="$A$1:$L$1">        <- the move widened this
wb.xml   _xlnm._FilterDatabase  $A$1:$K$1    <- it never touched this
```

Invisible for two reasons, both fixed: `workbook.xml` was not a rewritable part, and the defined name spells the sheet `'Attendees'!` — the quoted form the rewriter couldn't match. Group 1 is now the whole prefix including quoting, which also covers the `&apos;` / `&#39;` spellings the older workbooks use.

### 4. `feat(audit-slack): separate a pending applicant from a stranger in the room`

Unrelated to the migration, bundled here by request. The organizers-channel roster had one bucket for everyone not accepted, labelled *"not an accepted organizer"* — collapsing two situations that call for opposite actions:

- someone with a **live intake row** applied and is waiting on a decision. They're in the private room doing the work and, because acceptance is what triggers the Drive grant, locked out of their own chapter's folder. → make a decision.
- someone with **no intake row at all** is a stranger in a private channel. → find out who they are.

Bengaluru 2026-08-27 prompted this: the chapter's de-facto lead was the first person invited to `#bengaluru-organizers`, the same minute it was created, and had run venue/date planning since July. His intake row said `Prospect`, so `sync_access` correctly withheld the grant and he asked in-channel why he got an access-denied page. **The audit had listed him for five weeks — under the same label as a stranger.**

`read_intake()` now returns every row keyed by email alongside the accepted roster; the accepted-only filter was exactly what made the two indistinguishable. A decided NO (`Denied`/`Inactive`/`Duplicate`) is not "awaiting" — that's its own question, and `DECIDED_NO` names them so the split can't quietly re-merge.


## Live repairs (done, verified, outside this PR)

| Defect | Chapters | Status |
|---|---|---|
| Hyperlinks left on the vacated column — a LinkedIn URL sitting on the Email cell | 2 (Dallas, Kampala) | repaired, re-verified |
| Stale `_xlnm._FilterDatabase` | 82 (+1 already correct) | repaired, re-verified |

The FilterDatabase repair copies each sheet's own `<autoFilter ref>` into its defined name rather than re-applying the column mapping — the mapping had already been applied to the sheet and not the defined name, so remapping blindly would be right once and wrong on every re-run.

## Honest limit

The check is **not closed**, and the docstring now says so instead of claiming otherwise. `_SHEET_MENTION` is case-sensitive, so a lowercase `attendees!`, a name built by concatenation (`"Attend"&"ees!"`), or an R1C1 `Attendees!R2C4` are still neither rewritten nor reported.

## Test Plan

- [x] 11 skill suites + 210 library tests; pre-commit and pre-push clean
- [x] Report run over all **83 live workbooks**: exit 0, zero gaps
- [x] Every agent mutation fails the suite — including the one that previously produced **zero** failures while corrupting `PastAttendees!D2` → `E2`
- [x] `_run`-level harness added (the layer that let the crash through), which turns a raise into a clean failure rather than aborting the suite
- [x] handled ⇔ reported invariant over 30 generated reference shapes
- [x] 45 audit checks, including the three-way split (applicant / stranger / decided-no in one room)

## Related

Follows #28. No Drive writes from this PR — the migration reports `Nothing to do` fleet-wide.

_Generated using hero-skills._
