### PR TITLE
Put the AAIF lockup in the event logo footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ plugin version is the `version` field in `.claude-plugin/plugin.json`.
   carries the **AAIF lockup** (AAIF hosts these events; the slot used to say
   `HOST VENUE CO.`), and unfilled slots are muted `LOGO 1`, `LOGO 2`, …
   placeholders rather than the misleading `MEMBER LOGO`. The lockup is drawn
-  from the mark image each slide already embeds for its own header, so it cannot
-  drift from it.
+  from the mark image each slide already embeds for its own header — identified
+  by name, not by being the first picture on the slide — so it cannot drift from
+  it. The templates live in Drive, so a chapter sees this only once the backfill
+  below has swept it, and new chapters only once the sweep has reached
+  TemplateCity.
 
 ### Added
 - **`skills/aaif-create-chapter/scripts/backfill_host_footer.py`** applies that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the **AAIF Community Events Toolkit** plugin are document
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 plugin version is the `version` field in `.claude-plugin/plugin.json`.
 
+## [Unreleased]
+
+### Changed
+- **The event templates' "HOSTED BY / WITH" logo footer is no longer boxed.**
+  Each logo slot used to be a bordered, filled rounded-rect button holding
+  centred bold text, which read as a control and fought the flat rule-and-type
+  language of the rest of the deck. The boxes are gone, the host slot now
+  carries the **AAIF lockup** (AAIF hosts these events; the slot used to say
+  `HOST VENUE CO.`), and unfilled slots are muted `LOGO 1`, `LOGO 2`, …
+  placeholders rather than the misleading `MEMBER LOGO`. The lockup is drawn
+  from the mark image each slide already embeds for its own header, so it cannot
+  drift from it.
+
+### Added
+- **`skills/aaif-create-chapter/scripts/backfill_host_footer.py`** applies that
+  rework to templates that already exist — all chapters, the online series, and
+  the shared Templates folder. Read-only by default; `--write` applies, and a
+  file already reworked has no chips left to find, so re-running is a no-op.
+
 ## [0.5.0]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ line-length = 100
 select = ["F", "E9"]
 
 [tool.codespell]
-ignore-words-list = "aaif,luma,lu,ba,tre"
+# "lins" is codespell reading the OOXML attribute lIns (a text body's left inset).
+ignore-words-list = "aaif,luma,lu,ba,tre,lins"

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -147,6 +147,57 @@ production decks in place. Read a plan run first.
 The script imports the projection and the OOXML surgery from `create_chapter.py`
 — do not reimplement either of those inside the backfill script.
 
+## Backfilling the host footer
+
+`scripts/backfill_host_footer.py` reworks the **"HOSTED BY / WITH" logo footer**
+in the event templates. The footer used to draw each logo as a bordered, filled
+rounded-rect button holding centred bold text; the current design has no boxes,
+puts the **AAIF lockup** in the host slot, and leaves the remaining slots as
+muted `LOGO 1`, `LOGO 2`, … placeholders, with the row packed left on one even
+gap.
+
+The lockup is built from the mark image the slide **already embeds for its own
+header**, plus the wordmark set in Space Grotesk bold. No media and no
+relationship is added, so the footer lockup cannot drift from the header's.
+
+Three cases the script keeps apart, and they are not interchangeable: an
+**unfilled slot** (`MEMBER LOGO`, `HOST VENUE CO.`) is renumbered `LOGO n` and
+muted; a **real name** (the carousel's founding-member grid) keeps its text, ink
+and position and its grid keeps its columns; the old **`AAIF · SF` badge** beside
+the host is dropped, because the lockup now says the same thing. The script's
+own docstring explains why each rule is drawn where it is.
+
+Scope is **templates**, not the copies organizers have already made for a given
+event: every `.pptx` under a folder matching `Event Templates…` / `Event Name`,
+across all chapters, the online series, and the shared Templates folder. That set
+includes **TemplateCity** — the folder `create_chapter.py` clones for every new
+chapter — so a full sweep is what stops new chapters being minted on the old
+footer. A run that never reaches TemplateCity, or that finds a chapter folder
+contributing no template at all (what a folder rename looks like), prints an
+`ATTENTION` block and exits non-zero rather than reading as finished. A file
+whose footer has already been reworked has no chips left to find, so it is not
+re-uploaded and **re-running is a no-op**.
+
+```bash
+# Plan (default) — list every template and its footer, writes nothing:
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_host_footer.py
+
+# Apply across the estate:
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_host_footer.py --write
+
+# One chapter (matches anywhere in the Drive path, case-insensitive):
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_host_footer.py \
+    --chapter "New York City" --write
+
+# Test the XML engine on a local file, no Drive at all:
+python3 ${CLAUDE_SKILL_DIR}/scripts/backfill_host_footer.py \
+    --rework-local ./Event-Hero-Square.pptx
+```
+
+There is **no undo** beyond Drive's revision history, and `--write` replaces
+every template the scan finds, in place — a plan run prints that count. Read one
+first.
+
 ## Procedure
 
 1. **Confirm the city name and slug with the user.** Ask for the exact display

--- a/skills/aaif-create-chapter/SKILL.md
+++ b/skills/aaif-create-chapter/SKILL.md
@@ -161,10 +161,12 @@ header**, plus the wordmark set in Space Grotesk bold. No media and no
 relationship is added, so the footer lockup cannot drift from the header's.
 
 Three cases the script keeps apart, and they are not interchangeable: an
-**unfilled slot** (`MEMBER LOGO`, `HOST VENUE CO.`) is renumbered `LOGO n` and
-muted; a **real name** (the carousel's founding-member grid) keeps its text, ink
-and position and its grid keeps its columns; the old **`AAIF · SF` badge** beside
-the host is dropped, because the lockup now says the same thing. The script's
+**unfilled slot** (`MEMBER LOGO`, `HOST VENUE CO.`, `VENUE NAME`, `SPONSOR`, or
+anything containing the word `LOGO`) is renumbered `LOGO n` and muted; a **real
+name** (the carousel's founding-member grid) keeps its text and ink always, and
+keeps its position too unless it sits in the host's own row, which is the one row
+re-packed; the old **`AAIF · SF` badge** beside the host is dropped, because the
+lockup now says the same thing. The script's
 own docstring explains why each rule is drawn where it is.
 
 Scope is **templates**, not the copies organizers have already made for a given
@@ -172,9 +174,12 @@ event: every `.pptx` under a folder matching `Event Templates…` / `Event Name`
 across all chapters, the online series, and the shared Templates folder. That set
 includes **TemplateCity** — the folder `create_chapter.py` clones for every new
 chapter — so a full sweep is what stops new chapters being minted on the old
-footer. A run that never reaches TemplateCity, or that finds a chapter folder
-contributing no template at all (what a folder rename looks like), prints an
-`ATTENTION` block and exits non-zero rather than reading as finished. A file
+footer. A full-estate run that never reaches TemplateCity, that finds a chapter
+folder contributing no template, that sees a `.pptx`-bearing folder the name
+regex declined (all three are what a rename looks like), or that removes a
+file's boxes without drawing its lockup, prints an `ATTENTION` block and exits
+non-zero rather than reading as finished. A `--chapter` run checks only that
+last one — it is scoped by design and cannot speak for the estate. A file
 whose footer has already been reworked has no chips left to find, so it is not
 re-uploaded and **re-running is a no-op**.
 

--- a/skills/aaif-create-chapter/scripts/backfill_host_footer.py
+++ b/skills/aaif-create-chapter/scripts/backfill_host_footer.py
@@ -27,17 +27,21 @@ host slot is dropped outright, because the lockup now says the same thing.
 A chip is found *structurally* — a roundRect with a text shape at exactly the
 same geometry — but telling an unfilled slot from a real member name exists
 only in the text, because the slots were never given distinguishing shape names
-or fills. `PLACEHOLDER_RE` and `BADGE_RE` are therefore a **closed vocabulary
-for this migration**, not a general design rule: they are safe here because the
-whole estate was cloned from one template, the run has a plan mode, and every
-file's chips are printed for an operator to read.
+or fills. `PLACEHOLDER_RE` and `BADGE_RE` are therefore a vocabulary fixed **for
+this migration**, not a general design rule — three exact strings plus one
+deliberate `\bLOGO\b` wildcard, which will demote any member whose name
+contains the standalone word "Logo". They are safe here because the whole estate
+was cloned from one template and the run has a plan mode; a chip's text is not
+echoed, so the per-file chip counts and the NO LOCKUP flag are what an operator
+reads.
 
 Scope is **templates**, not the copies organizers have already made for a given
-event: every `.pptx` under a folder named `Event Templates…` / `Event Name`,
+event: every `.pptx` directly in a folder named `Event Templates…` / `Event Name`,
 across all chapters, the online series, and the shared Templates folder. That
 set includes **TemplateCity**, the folder `create_chapter.py` clones for every
 new chapter — so a full sweep is what stops new chapters being minted with the
-old footer, and a run that does not reach it says so and exits non-zero. A file
+old footer, and a full-estate run that does not reach it says so and exits
+non-zero. A `--chapter` run skips the estate-coverage checks by design. A file
 whose footer has already been reworked has no chips left to find, so a re-run is
 a no-op and the file is not re-uploaded.
 
@@ -78,8 +82,14 @@ TEMPLATE_CITY = "TemplateCity"
 # already — so main() reports any chapter that contributed no template at all,
 # which is what a future rename would look like.
 TEMPLATE_FOLDER_RE = re.compile(r"^(event templates?\b.*|event name)$", re.I)
+SERIES_FOLDER = "Online"         # its children are the online series
 
-MUTED = "9A978F"     # the grey the HOSTED BY / WITH labels are set in
+# Deck constants sampled from the templates themselves, NOT design-system tokens:
+# MUTED is the grey the decks' own HOSTED BY / WITH label runs use (it is not
+# design/aaif-tokens.css's --ink-4), and Space Grotesk is the face the templates
+# embed for the wordmark, not DESIGN.md's Instrument Sans. Retuning either to a
+# token would desync the footer from the labels beside it.
+MUTED = "9A978F"
 INK = "0A0A0A"
 # Advance width as a fraction of the point size. JetBrains Mono is monospaced so
 # 0.60 is exact; Space Grotesk Bold is proportional and 0.62 is a deliberate
@@ -88,6 +98,8 @@ MONO_EM, PROP_EM = 0.60, 0.62
 EMU_PER_PT = 12700
 # Fractions of the footer band's height. Together these set the lockup's
 # proportions and the one gap the row is packed on.
+# MARK_H is applied to both axes: the mark is drawn into a SQUARE box, which is
+# also what find_mark falls back on to identify it.
 MARK_H, MARK_GAP, ROW_GAP = 0.78, 0.13, 0.55
 LOCKUP_PT_DIVISOR = 3.2          # band height -> wordmark point size
 
@@ -96,16 +108,24 @@ LOCKUP_PT_DIVISOR = 3.2          # band height -> wordmark point size
 # Google Slides. A private copy of this regex silently drops those shapes.
 OFF_RE = cc.OFF_RE
 EXT_RE = re.compile(r'<a:ext cx="(\d+)" cy="(\d+)"\s*/>')
-# Widened from create_chapter's SP_RE to cover <p:pic> as well, and to accept a
-# tag carrying attributes (a re-saved slide writes <p:sp ...>, not <p:sp>).
+# Widened from create_chapter's SP_RE to cover <p:pic> as well; the backreference
+# stops the two kinds matching across each other. The `[^>]*` attribute tolerance
+# is inherited from SP_RE, not added here — a re-saved slide writes <p:sp ...>.
+# Like SP_RE this assumes a flat spTree: a shape nested in a <p:grpSp> would be
+# matched with group-relative offsets. These templates have none.
 SHAPE_RE = re.compile(r"<p:(sp|pic)\b[^>]*>.*?</p:\1>", re.S)
 TEXT_RE = re.compile(r"<a:t>(.*?)</a:t>", re.S)
 GEOM_RE = re.compile(r'<a:prstGeom prst="(\w+)"')
 EMBED_RE = re.compile(r'<a:blip r:embed="([^"]+)"')
 ID_RE = re.compile(r'<p:cNvPr[^>]*id="(\d+)"')
+LOCKUP_NAME = "AAIF Lockup"          # the name given to the two shapes below
 SZ_RE = re.compile(r'<a:rPr\b[^>]*\bsz="(\d+)"')
+# The header mark's picture carries its source filename in descr (or its name),
+# e.g. descr="assets/logo_black.png" — that is what identifies it as the mark.
+MARK_NAME_RE = re.compile(r'<p:cNvPr[^>]*(?:descr|name)="[^"]*logo[^"]*"', re.I)
 SLIDE_RE = re.compile(r"ppt/slides/slide\d+\.xml$")
 BOLD_RE = re.compile(r'(<a:rPr\b[^>]*?)\bb="1"')
+INK_FILL_RE = re.compile(r'<a:srgbClr val="%s"\s*/>' % INK, re.I)
 CENTRE_RE = re.compile(r'(<a:pPr\b[^>]*?)algn="ctr"')
 
 # See the docstring: a closed vocabulary for this migration, not a design rule.
@@ -120,8 +140,14 @@ Shape = collections.namedtuple("Shape", "kind body span box text geom")
 # Slide XML engine (pure, unit-testable — no Drive, no filesystem)
 # ----------------------------------------------------------------------------
 def shape_text(body):
-    """The shape's visible text, runs concatenated and entities resolved."""
-    return " ".join(html.unescape(t) for t in TEXT_RE.findall(body)).strip()
+    """The shape's visible text: runs concatenated, entities resolved, internal
+    whitespace collapsed. OOXML runs join with NO separator — PowerPoint and
+    Slides split a run mid-phrase for a spell-check or a language tag, so
+    joining on " " would turn a split "HOSTED BY" into "HOSTED  BY" and defeat
+    every exact-match test below. Collapsing then absorbs a run that legitimately
+    carries its own trailing space."""
+    joined = "".join(html.unescape(t) for t in TEXT_RE.findall(body))
+    return re.sub(r"\s+", " ", joined).strip()
 
 
 def shapes(xml):
@@ -216,26 +242,60 @@ def unbox(body, label=None):
     body = BOLD_RE.sub(r'\1b="0"', body)
     body = CENTRE_RE.sub(r'\1algn="l"', body)
     if label:
-        body = body.replace('<a:srgbClr val="%s"/>' % INK, '<a:srgbClr val="%s"/>' % MUTED)
+        # A regex, not a literal replace: Google Slides re-serializes this as
+        # `<a:srgbClr val="0A0A0A" />`, and a literal match would silently leave
+        # every relabelled slot in full ink — the exact outcome the muting exists
+        # to prevent, and invisible in the run's own output.
+        body = INK_FILL_RE.sub('<a:srgbClr val="%s"/>' % MUTED, body)
         body = retext(body, label)
     return body
 
 
-def find_chips(shp):
-    """[(box index, text index)] for every logo chip — a filled roundRect with a
-    text shape at exactly the same geometry sitting on top of it. `boxes` only
-    holds empty shapes and the second pass only takes shapes with text, so the
-    two can never be the same index."""
+def button_boxes(shp):
+    """{geometry: [indices]} for every empty roundRect — the button plate a chip
+    was drawn on. A list, not a single index: two plates stacked at identical
+    geometry both have to go, and keying one out would leave the other behind.
+    Both returned index sets have a non-None `box`, which is what lets callers
+    dereference `shp[i].box` unguarded."""
     boxes = {}
     for i, s in enumerate(shp):
         if s.kind == "sp" and s.geom == "roundRect" and s.box and not s.text:
-            boxes[s.box] = i
-    return [(boxes[s.box], i) for i, s in enumerate(shp)
-            if s.kind == "sp" and s.text and s.box in boxes]
+            boxes.setdefault(s.box, []).append(i)
+    return boxes
+
+
+def find_chips(shp, boxes=None):
+    """[(box index, text index)] for every logo chip — a roundRect plate with a
+    text shape at exactly the same geometry sitting on top of it. The plate is
+    matched on geometry and emptiness, not fill. "Empty" relies on shape_text
+    stripping: the real plates carry a whitespace run, so dropping that strip
+    would make every chip undiscoverable — silently, as a clean estate. `boxes` only
+    holds shapes with no text and the second pass only takes shapes with text,
+    so a shape can never be both halves of a pair."""
+    boxes = button_boxes(shp) if boxes is None else boxes
+    return [(b, i) for i, s in enumerate(shp)
+            if s.kind == "sp" and s.text and s.box in boxes
+            for b in boxes[s.box]]
+
+
+def find_mark(shp):
+    """The relationship id of the AAIF mark the slide already embeds for its
+    header, or None. Identified, not guessed: the first picture in DOCUMENT
+    order is whatever the deck happens to draw first — a background plate, a
+    speaker photo, a partner logo — and promoting that to the footer would
+    render it at mark size beside the AAIF wordmark. Match on the image's own
+    name/descr, then fall back to a SQUARE picture (the mark's defining shape,
+    since it is drawn into a square box), and give up rather than guess."""
+    pics = [s for s in shp if s.kind == "pic" and EMBED_RE.search(s.body)]
+    named = [s for s in pics if MARK_NAME_RE.search(s.body)]
+    if not named:
+        named = [s for s in pics if s.box and s.box.cx == s.box.cy]
+    return EMBED_RE.search(named[0].body).group(1) if named else None
 
 
 def find_host(shp, chips):
-    """The chip index that should become the AAIF lockup: the one the HOSTED BY
+    """The `shapes()` index of the *text* shape whose slot should become the
+    AAIF lockup — not an index into `chips`. It is the slot the HOSTED BY
     label introduces. Prefer the nearest chip to the label's right *in its own
     band* — the hero layout, where label and chips share a row. Fall back to
     document order for the deck and carousel layouts, where the label is stacked
@@ -256,19 +316,32 @@ def find_host(shp, chips):
 def rework_slide(xml):
     """Return (new xml, chips found, whether the host slot became the lockup)."""
     shp = shapes(xml)
-    chips = find_chips(shp)
-    if not chips:
+    boxes = button_boxes(shp)
+    chips = find_chips(shp, boxes)
+    # A zero-width plate is never a design element: it is residue from an
+    # earlier sweep that left an unpaired plate in the row and then resized it
+    # to the width of its own empty text. Clean it whether or not this slide
+    # still has chips, otherwise an already-migrated file keeps its hairline
+    # forever — a re-run finds no chips and returns before reaching the row.
+    strays = [i for plates in boxes.values() for i in plates if shp[i].box.cx == 0]
+    if not chips and not strays:
         return xml, 0, False
+    # An already-drawn lockup counts: a repair-only pass must not report the
+    # file as having lost its host slot.
+    had_lockup = LOCKUP_NAME in xml
 
     host = find_host(shp, chips)
-    # Reuse the header mark's image rather than embedding a second copy.
-    embed = next((EMBED_RE.search(s.body).group(1) for s in shp
-                  if s.kind == "pic" and EMBED_RE.search(s.body)), None)
+    embed = find_mark(shp)
     if embed is None:
+        # No identifiable mark: draw nothing rather than promote whatever image
+        # happened to be first. The chips still lose their boxes; the host slot
+        # is skipped below and keeps its own text.
         host = None
-    first_id = max(int(m) for m in ID_RE.findall(xml)) + 1
+    # `default` matters: a slide can legitimately carry no numeric cNvPr id, and
+    # max() would raise ValueError -- surfacing as an unactionable FAILED line.
+    first_id = max((int(m) for m in ID_RE.findall(xml)), default=1000) + 1
 
-    edits, slot = {}, 0
+    edits, slot = {i: "" for i in strays}, 0
     for box_i, text_i in chips:
         edits[box_i] = ""                       # the button box goes away
         chip_text = shp[text_i].text
@@ -286,9 +359,18 @@ def rework_slide(xml):
     # member grid elsewhere on the carousel keeps its columns.
     if host is not None:
         band = shp[host].box
+        # A plate whose text shape was authored separately (or deleted) has no
+        # chip partner, so the loop above never blanked it. Left in place it
+        # would join the row below and be resized to the width of its own empty
+        # text -- a zero-width bordered rect, which renders as a stray hairline.
+        # It is a button plate in the footer band: it goes, like the others.
+        for plates in boxes.values():
+            for i in plates:
+                if shp[i].box.y == band.y and shp[i].box.cy == band.cy:
+                    edits.setdefault(i, "")
         row = sorted((i for i, s in enumerate(shp)
                       if s.box and s.box.y == band.y and s.box.cy == band.cy
-                      and edits.get(i, s.body) != ""),
+                      and s.geom != "roundRect" and edits.get(i, s.body) != ""),
                      key=lambda i: shp[i].box.x)
         gap = int(band.cy * ROW_GAP)
         x = min(shp[i].box.x for i in row)
@@ -311,22 +393,27 @@ def rework_slide(xml):
         out.append(edits[i])
         cursor = end
     out.append(xml[cursor:])
-    return "".join(out), len(chips), host is not None
+    return "".join(out), len(chips) + len(strays), host is not None or had_lockup
 
 
 def rework_pptx(src, dst):
     """Rework every slide of `src`, writing `dst` only when there is something to
-    upload. Returns {slide part: chip count} — empty when the file has no footer,
-    in which case `dst` is never created and no deflate is paid. A plan run and
-    a re-run over an already-reworked estate are therefore read-only and cheap."""
+    upload. Returns {slide part: (chip count, lockup drawn)} — empty when the
+    file has no footer, in which case `dst` is never created and no deflate is
+    paid, so a re-run over an already-reworked estate costs one download each.
+    A plan run over a file it WOULD change still repacks locally and throws the
+    result away: `--write` gates the upload, not the repack."""
     report, new_parts = {}, {}
     with zipfile.ZipFile(src) as zin:
         for name in zin.namelist():
             if not SLIDE_RE.match(name):
                 continue
-            new, n, _host = rework_slide(zin.read(name).decode("utf-8"))
+            new, n, host = rework_slide(zin.read(name).decode("utf-8"))
             if n:
-                report[name] = n
+                # Carry `host`, don't discard it: a slide whose boxes came off
+                # but whose lockup was never drawn is half-migrated, and without
+                # this it reports identically to a perfect one.
+                report[name] = (n, host)
                 new_parts[name] = new.encode("utf-8")
     if report:
         # create_chapter's repacker: it preserves each member's compression and
@@ -341,10 +428,15 @@ def rework_pptx(src, dst):
 # Drive
 # ----------------------------------------------------------------------------
 def walk_templates(root, jobs=8):
-    """([{id, name, path}] for every .pptx in a template folder, {chapter names
-    seen}). The chapter set is what lets main() tell "this chapter has no footer
-    left" from "this chapter's template folder was renamed and never scanned"."""
-    found, chapters, level, seen = [], set(), [(root, "Community Events")], set()
+    """(templates, chapter names, online-series names, names owning any .pptx).
+    The name sets are how
+    main() tells "this chapter has no footer left" from "this chapter's template
+    folder was renamed and never scanned" — a distinction the file counts alone
+    cannot make, since both look like a clean estate. Dated per-event folders are
+    not counted: those copies are deliberately out of scope, so reporting them
+    would bury the real signal in noise."""
+    found, chapters, series, with_decks = [], set(), set(), set()
+    level, seen = [(root, "Community Events")], set()
     with ThreadPoolExecutor(max_workers=jobs) as pool:
         while level:
             level = [(f, p) for f, p in level if f not in seen]
@@ -353,16 +445,33 @@ def walk_templates(root, jobs=8):
             for path, kids in pool.map(lambda t: (t[1], cc.list_children(t[0])), level):
                 leaf = path.rsplit("/", 1)[-1]
                 is_template = bool(TEMPLATE_FOLDER_RE.match(leaf))
+                owner = path.split("/")[2] if len(path.split("/")) > 2 else None
                 for k in kids:
                     if k["mimeType"] == cc.FOLDER:
                         nxt.append((k["id"], path + "/" + k["name"]))
                         if leaf == CHAPTERS_FOLDER:
                             chapters.add(k["name"])
-                    elif k["mimeType"] == cc.PPTX and is_template:
-                        found.append({"id": k["id"], "name": k["name"],
-                                      "path": path + "/" + k["name"]})
+                    elif k["mimeType"] == cc.PPTX:
+                        # Remember which chapter/series owns ANY .pptx, at any
+                        # depth. A renamed template folder still leaves decks
+                        # behind; a folder that simply has no decks (a podcast
+                        # series, say) is not a rename and must not cry wolf.
+                        if owner:
+                            with_decks.add(owner)
+                        if is_template:
+                            found.append({"id": k["id"], "name": k["name"],
+                                          "path": path + "/" + k["name"]})
+                if leaf == SERIES_FOLDER:
+                    series.update(k["name"] for k in kids if k["mimeType"] == cc.FOLDER)
             level = nxt
-    return found, chapters
+    # Dedup by Drive id: a file reachable under two parents would otherwise be
+    # handed to two workers that share a scratch filename and race.
+    seen_ids, unique = set(), []
+    for f in found:
+        if f["id"] not in seen_ids:
+            seen_ids.add(f["id"])
+            unique.append(f)
+    return unique, chapters, series, with_decks
 
 
 def process(entry, tmpdir, write):
@@ -374,8 +483,9 @@ def process(entry, tmpdir, write):
     dst = os.path.join(tmpdir, "out-%s.pptx" % entry["id"])
     try:
         cc.gws_download(entry["id"], src)
-        # gws_download discards stdout, so an error body written at exit 0 would
-        # otherwise surface as a BadZipFile blaming the OOXML engine.
+        # gws writes the response body to --output even when the API returned an
+        # error at exit 0, so a JSON error page would reach zipfile and surface
+        # as a BadZipFile blaming the OOXML engine.
         if not os.path.exists(src) or os.path.getsize(src) == 0:
             raise RuntimeError("download wrote no file")
         if not zipfile.is_zipfile(src):
@@ -386,7 +496,12 @@ def process(entry, tmpdir, write):
             cc.gws_upload(entry["id"], dst, cc.PPTX)
         return entry, report, None
     except Exception as e:                       # one bad file must not stop the run
-        return entry, {}, str(e)[:200]
+        # Prefix the class: this catch spans the XML engine as well as the two
+        # transfers, and a bare message makes a ValueError in the reflow read as
+        # a network blip. Never return a bare str() — an exception whose str() is
+        # empty (MemoryError, a bare raise) would be falsy and the caller would
+        # count the file as already clean, printing nothing at all.
+        return entry, {}, "%s: %s" % (type(e).__name__, str(e)[:200])
     finally:
         for p in (src, dst):
             if os.path.exists(p):
@@ -401,9 +516,10 @@ def rework_local(path):
         print("%s: no logo footer found — nothing to rework" % path)
         return 0
     print("%s -> %s" % (path, dst))
-    for part in sorted(report):
-        print("   %s: %d chips" % (part, report[part]))
-    return 0
+    for part, (n, host) in sorted(report.items()):
+        print("   %s: %d chips, %s"
+              % (part, n, "lockup drawn" if host else "NO LOCKUP DRAWN"))
+    return 0 if all(host for _n, host in report.values()) else 1
 
 
 def main():
@@ -424,7 +540,8 @@ def main():
         return rework_local(args.rework_local)
 
     print("Scanning the Community Events tree for event templates...")
-    entries, chapters = walk_templates(COMMUNITY_ROOT, max(args.jobs, 8))
+    entries, chapters, series, with_decks = walk_templates(COMMUNITY_ROOT,
+                                                            max(args.jobs, 8))
     scanned = entries
     if args.chapter:
         needle = args.chapter.lower()
@@ -437,18 +554,24 @@ def main():
           % (len(entries), "" if args.write else "  PLAN ONLY — nothing will be written."))
 
     changed = clean = failed = 0
+    no_lockup = []
     with tempfile.TemporaryDirectory() as tmpdir, \
             ThreadPoolExecutor(max_workers=args.jobs) as pool:
         for entry, report, err in pool.map(lambda e: process(e, tmpdir, args.write), entries):
-            if err:
+            if err is not None:
                 failed += 1
                 print("  FAILED  %s\n            %s" % (entry["path"], err))
             elif report:
                 changed += 1
-                print("  %s  %s  (%s)"
+                missing = sorted(p for p, (_n, host) in report.items() if not host)
+                if missing:
+                    no_lockup.append((entry["path"], missing))
+                print("  %s  %s  (%s)%s"
                       % ("REWORKED" if args.write else "would rework", entry["path"],
-                         ", ".join("%s:%d" % (p.rsplit("/", 1)[-1], n)
-                                   for p, n in sorted(report.items()))))
+                         ", ".join("%s:%d chips %s" % (p.rsplit("/", 1)[-1], n,
+                                                       "+lockup" if host else "NO LOCKUP")
+                                   for p, (n, host) in sorted(report.items())),
+                         "   <-- NO LOCKUP" if missing else ""))
             else:
                 clean += 1
 
@@ -458,14 +581,31 @@ def main():
     # A folder-name match that stops matching looks exactly like a clean estate,
     # so name what the scan could not see instead of letting it read as done.
     attention = []
+    for path, slides in no_lockup if args.chapter else []:
+        attention.append("%s: boxes removed but no lockup drawn on %s"
+                         % (path, ", ".join(s.rsplit("/", 1)[-1] for s in slides)))
     if not args.chapter:
         covered = set()
         for e in scanned:
             parts = e["path"].split("/")
             if len(parts) > 2 and parts[1] == CHAPTERS_FOLDER:
                 covered.add(parts[2])
-        for missing in sorted(chapters - covered):
-            attention.append("chapter %r contributed no template — folder renamed?" % missing)
+        for missing in sorted((chapters - covered) & with_decks):
+            attention.append("chapter %r holds decks but contributed no template — "
+                             "template folder renamed?" % missing)
+        covered_series = {e["path"].split("/")[2] for e in scanned
+                          if len(e["path"].split("/")) > 2
+                          and e["path"].split("/")[1] == SERIES_FOLDER}
+        for missing in sorted((series - covered_series) & with_decks):
+            attention.append("online series %r holds decks but contributed no "
+                             "template — template folder renamed?" % missing)
+        if not chapters:
+            attention.append("no chapter folders found under %r — has it been renamed? "
+                             "the per-chapter coverage check is disabled without it"
+                             % CHAPTERS_FOLDER)
+        for path, slides in no_lockup:
+            attention.append("%s: boxes removed but no lockup drawn on %s"
+                             % (path, ", ".join(s.rsplit("/", 1)[-1] for s in slides)))
         if not any("/%s/" % TEMPLATE_CITY in e["path"] for e in scanned):
             attention.append("%s was never reached — new chapters would still be cloned "
                              "from the OLD footer" % TEMPLATE_CITY)

--- a/skills/aaif-create-chapter/scripts/backfill_host_footer.py
+++ b/skills/aaif-create-chapter/scripts/backfill_host_footer.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Rework the "HOSTED BY / WITH" logo footer in every EXISTING event template.
+
+The footer used to draw each logo as a *button*: a rounded rectangle with a
+1px border and a fill, holding centred bold text. Three things were wrong with
+it, and this script fixes all three in one pass:
+
+- **The boxes.** A bordered chip reads as a control you can press, and a row of
+  them fights the flat, rule-and-type language the rest of the deck is drawn in.
+  They go; the logo slot is just its text.
+- **The host.** The slot said `HOST VENUE CO.` — the venue was the host and AAIF
+  appeared only in the header. AAIF hosts these events, so the slot now carries
+  the AAIF lockup, drawn from the mark image the slide *already* embeds for its
+  header plus the wordmark set in Space Grotesk bold. No new media is added and
+  no relationship is rewritten, so the lockup cannot drift from the header's.
+- **The spacing.** Slot widths were sized for the buttons, so with the buttons
+  gone the row was strung out across gaps that no longer meant anything. The
+  host row is re-packed left on one even gap.
+
+Remaining slots become `LOGO 1`, `LOGO 2`, … in the same muted grey as their
+`HOSTED BY` / `WITH` labels: an unfilled slot should read as empty, not as a
+member called "MEMBER LOGO". Chips holding a *real* name (the founding-member
+grid on the carousel: AWS, Anthropic, Block, …) keep their ink and their
+position — only the box comes off. The old `AAIF · SF` chapter badge beside the
+host slot is dropped outright, because the lockup now says the same thing.
+
+A chip is found *structurally* — a roundRect with a text shape at exactly the
+same geometry — but telling an unfilled slot from a real member name exists
+only in the text, because the slots were never given distinguishing shape names
+or fills. `PLACEHOLDER_RE` and `BADGE_RE` are therefore a **closed vocabulary
+for this migration**, not a general design rule: they are safe here because the
+whole estate was cloned from one template, the run has a plan mode, and every
+file's chips are printed for an operator to read.
+
+Scope is **templates**, not the copies organizers have already made for a given
+event: every `.pptx` under a folder named `Event Templates…` / `Event Name`,
+across all chapters, the online series, and the shared Templates folder. That
+set includes **TemplateCity**, the folder `create_chapter.py` clones for every
+new chapter — so a full sweep is what stops new chapters being minted with the
+old footer, and a run that does not reach it says so and exits non-zero. A file
+whose footer has already been reworked has no chips left to find, so a re-run is
+a no-op and the file is not re-uploaded.
+
+Read-only by default: it prints what each file would lose and gain and changes
+nothing. There is no undo beyond Drive's own revision history, so read a plan
+run before passing --write.
+
+Usage:
+  # Plan (default) — list every template and its footer, write nothing:
+  python backfill_host_footer.py
+
+  # Apply to the whole estate:
+  python backfill_host_footer.py --write
+
+  # One chapter (matches the Drive folder name, case-insensitive):
+  python backfill_host_footer.py --chapter "New York City" --write
+
+  # Test the XML engine on a local .pptx, no Drive at all:
+  python backfill_host_footer.py --rework-local ./Event-Hero-Square.pptx
+"""
+import argparse, collections, html, os, re, shutil, sys, tempfile, zipfile
+from concurrent.futures import ThreadPoolExecutor
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import create_chapter as cc      # Drive plumbing + the shared OOXML primitives
+
+COMMUNITY_ROOT = "1Z1M-xk0S16sksS1IBNm9OG6Ia22Yql6f"   # the "Community Events" folder
+CHAPTERS_FOLDER = "Chapters"     # its child holding one folder per chapter
+# The folder create_chapter.py clones for every new chapter. It is the single
+# most important target in the sweep — miss it and every chapter created after
+# this migration is minted with the old footer — so main() asserts it was
+# reached rather than trusting it to fall out of the walk.
+TEMPLATE_CITY = "TemplateCity"
+# The folders that hold a *template* rather than one event's copy of it. The
+# chapter tree names them "Event Templates (Copy for Each Event)", the online
+# series "Event Template", and the shared Templates folder "Event Name".
+# Matching on a folder NAME is fragile — that folder has been renamed once
+# already — so main() reports any chapter that contributed no template at all,
+# which is what a future rename would look like.
+TEMPLATE_FOLDER_RE = re.compile(r"^(event templates?\b.*|event name)$", re.I)
+
+MUTED = "9A978F"     # the grey the HOSTED BY / WITH labels are set in
+INK = "0A0A0A"
+# Advance width as a fraction of the point size. JetBrains Mono is monospaced so
+# 0.60 is exact; Space Grotesk Bold is proportional and 0.62 is a deliberate
+# over-estimate — erring wide only ever opens a gap, never collides two shapes.
+MONO_EM, PROP_EM = 0.60, 0.62
+EMU_PER_PT = 12700
+# Fractions of the footer band's height. Together these set the lockup's
+# proportions and the one gap the row is packed on.
+MARK_H, MARK_GAP, ROW_GAP = 0.78, 0.13, 0.55
+LOCKUP_PT_DIVISOR = 3.2          # band height -> wordmark point size
+
+# Reuse create_chapter's offset pattern rather than restating it: its `\s*`
+# tolerates a re-saved " />", which Drive emits after anyone opens a deck in
+# Google Slides. A private copy of this regex silently drops those shapes.
+OFF_RE = cc.OFF_RE
+EXT_RE = re.compile(r'<a:ext cx="(\d+)" cy="(\d+)"\s*/>')
+# Widened from create_chapter's SP_RE to cover <p:pic> as well, and to accept a
+# tag carrying attributes (a re-saved slide writes <p:sp ...>, not <p:sp>).
+SHAPE_RE = re.compile(r"<p:(sp|pic)\b[^>]*>.*?</p:\1>", re.S)
+TEXT_RE = re.compile(r"<a:t>(.*?)</a:t>", re.S)
+GEOM_RE = re.compile(r'<a:prstGeom prst="(\w+)"')
+EMBED_RE = re.compile(r'<a:blip r:embed="([^"]+)"')
+ID_RE = re.compile(r'<p:cNvPr[^>]*id="(\d+)"')
+SZ_RE = re.compile(r'<a:rPr\b[^>]*\bsz="(\d+)"')
+SLIDE_RE = re.compile(r"ppt/slides/slide\d+\.xml$")
+BOLD_RE = re.compile(r'(<a:rPr\b[^>]*?)\bb="1"')
+CENTRE_RE = re.compile(r'(<a:pPr\b[^>]*?)algn="ctr"')
+
+# See the docstring: a closed vocabulary for this migration, not a design rule.
+PLACEHOLDER_RE = re.compile(r"^(.*\bLOGO\b.*|HOST VENUE CO\.?|VENUE NAME|SPONSOR)$", re.I)
+BADGE_RE = re.compile(r"^AAIF\s*[·.\-]\s*\S+$", re.I)
+
+Box = collections.namedtuple("Box", "x y cx cy")
+Shape = collections.namedtuple("Shape", "kind body span box text geom")
+
+
+# ----------------------------------------------------------------------------
+# Slide XML engine (pure, unit-testable — no Drive, no filesystem)
+# ----------------------------------------------------------------------------
+def shape_text(body):
+    """The shape's visible text, runs concatenated and entities resolved."""
+    return " ".join(html.unescape(t) for t in TEXT_RE.findall(body)).strip()
+
+
+def shapes(xml):
+    """Every top-level shape, in document order. `box` is None for a shape with
+    no xfrm of its own (it inherits placeholder geometry we must not move)."""
+    out = []
+    for m in SHAPE_RE.finditer(xml):
+        b = m.group(0)
+        off, ext = OFF_RE.search(b), EXT_RE.search(b)
+        box = Box(int(off.group(1)), int(off.group(2)),
+                  int(ext.group(1)), int(ext.group(2))) if off and ext else None
+        geom = GEOM_RE.search(b)
+        out.append(Shape(m.group(1), b, m.span(), box, shape_text(b),
+                         geom.group(1) if geom else ""))
+    return out
+
+
+def font_size(body, default=1100):
+    """The shape's first run size, in hundredths of a point."""
+    m = SZ_RE.search(body)
+    return int(m.group(1)) if m else default
+
+
+def text_width(text, sz, em=MONO_EM):
+    return int(len(text) * em * sz / 100 * EMU_PER_PT)
+
+
+def _move(body, x):
+    return OFF_RE.sub(lambda m: '<a:off x="%d" y="%s"/>' % (x, m.group(2)), body, count=1)
+
+
+def _resize(body, cx):
+    return EXT_RE.sub(lambda m: '<a:ext cx="%d" cy="%s"/>' % (cx, m.group(2)), body, count=1)
+
+
+def lockup(x, y, cy, embed, first_id):
+    """The AAIF mark + wordmark drawn from (x, y) at height cy. Returns
+    (markup, total width). `embed` is a relationship id already present in the
+    slide — the header mark's — so no media and no rels entry is added."""
+    mark = int(cy * MARK_H)
+    gap = int(cy * MARK_GAP)
+    sz = max(700, int(round(cy / EMU_PER_PT / LOCKUP_PT_DIVISOR * 100)))
+    word_cx = max(text_width("Agentic AI", sz, PROP_EM),
+                  text_width("Foundation", sz, PROP_EM))
+    run = ('<a:r><a:rPr b="1" i="0" lang="en-US" sz="%d" u="none" cap="none" strike="noStrike">'
+           '<a:solidFill><a:srgbClr val="%s"/></a:solidFill>'
+           '<a:latin typeface="Space Grotesk"/><a:ea typeface="Space Grotesk"/>'
+           '<a:cs typeface="Space Grotesk"/><a:sym typeface="Space Grotesk"/></a:rPr>'
+           '<a:t>%%s</a:t></a:r>' % (sz, INK))
+    para = ('<a:p><a:pPr indent="0" lvl="0" marL="0" marR="0" rtl="0" algn="l">'
+            '<a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="0"/></a:spcAft>'
+            '<a:buNone/></a:pPr>%s</a:p>')
+    pic = ('<p:pic><p:nvPicPr><p:cNvPr descr="AAIF logo" id="%d" name="AAIF Lockup Mark"/>'
+           '<p:cNvPicPr preferRelativeResize="0"/><p:nvPr/></p:nvPicPr>'
+           '<p:blipFill rotWithShape="1"><a:blip r:embed="%s"><a:alphaModFix/></a:blip>'
+           '<a:srcRect b="0" l="0" r="0" t="0"/><a:stretch/></p:blipFill>'
+           '<p:spPr><a:xfrm><a:off x="%d" y="%d"/><a:ext cx="%d" cy="%d"/></a:xfrm>'
+           '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln>'
+           '</p:spPr></p:pic>'
+           % (first_id, embed, x, y + (cy - mark) // 2, mark, mark))
+    wordmark = ('<p:sp><p:nvSpPr><p:cNvPr id="%d" name="AAIF Lockup Wordmark"/><p:cNvSpPr/>'
+                '<p:nvPr/></p:nvSpPr><p:spPr><a:xfrm><a:off x="%d" y="%d"/>'
+                '<a:ext cx="%d" cy="%d"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/>'
+                '</a:prstGeom><a:noFill/><a:ln><a:noFill/></a:ln></p:spPr><p:txBody>'
+                '<a:bodyPr anchorCtr="0" anchor="ctr" bIns="0" lIns="0" spcFirstLastPara="1" '
+                'rIns="0" wrap="square" tIns="0"><a:noAutofit/></a:bodyPr><a:lstStyle/>%s%s'
+                '</p:txBody></p:sp>'
+                % (first_id + 1, x + mark + gap, y, word_cx, cy,
+                   para % (run % "Agentic AI"), para % (run % "Foundation")))
+    return pic + wordmark, mark + gap + word_cx
+
+
+def retext(body, text):
+    """Put `text` in the shape's first run and empty the rest, so the run's
+    formatting — and any mid-word run splitting — survives the swap. Callers
+    pass a "LOGO n" label with no leading or trailing space, which is why this
+    does not need create_chapter's xml:space="preserve" guard."""
+    seen = [False]
+
+    def one(_m):
+        if seen[0]:
+            return "<a:t></a:t>"
+        seen[0] = True
+        return "<a:t>%s</a:t>" % html.escape(text)
+    return TEXT_RE.sub(one, body)
+
+
+def unbox(body, label=None):
+    """Strip a chip's button styling: regular weight, left-aligned. `label` mutes
+    the chip and relabels it — pass it for a slot nobody has filled yet, and
+    leave it None for a chip holding a real name, which keeps text and ink."""
+    body = BOLD_RE.sub(r'\1b="0"', body)
+    body = CENTRE_RE.sub(r'\1algn="l"', body)
+    if label:
+        body = body.replace('<a:srgbClr val="%s"/>' % INK, '<a:srgbClr val="%s"/>' % MUTED)
+        body = retext(body, label)
+    return body
+
+
+def find_chips(shp):
+    """[(box index, text index)] for every logo chip — a filled roundRect with a
+    text shape at exactly the same geometry sitting on top of it. `boxes` only
+    holds empty shapes and the second pass only takes shapes with text, so the
+    two can never be the same index."""
+    boxes = {}
+    for i, s in enumerate(shp):
+        if s.kind == "sp" and s.geom == "roundRect" and s.box and not s.text:
+            boxes[s.box] = i
+    return [(boxes[s.box], i) for i, s in enumerate(shp)
+            if s.kind == "sp" and s.text and s.box in boxes]
+
+
+def find_host(shp, chips):
+    """The chip index that should become the AAIF lockup: the one the HOSTED BY
+    label introduces. Prefer the nearest chip to the label's right *in its own
+    band* — the hero layout, where label and chips share a row. Fall back to
+    document order for the deck and carousel layouts, where the label is stacked
+    ABOVE its chips and so shares a band with none of them."""
+    label = next((i for i, s in enumerate(shp) if s.text.upper() == "HOSTED BY"), None)
+    if label is None:
+        return None
+    lab = shp[label].box
+    if lab:
+        band = [t for _b, t in chips
+                if shp[t].box and shp[t].box.y == lab.y
+                and shp[t].box.cy == lab.cy and shp[t].box.x > lab.x]
+        if band:
+            return min(band, key=lambda i: shp[i].box.x)
+    return next((t for _b, t in chips if t > label), None)
+
+
+def rework_slide(xml):
+    """Return (new xml, chips found, whether the host slot became the lockup)."""
+    shp = shapes(xml)
+    chips = find_chips(shp)
+    if not chips:
+        return xml, 0, False
+
+    host = find_host(shp, chips)
+    # Reuse the header mark's image rather than embedding a second copy.
+    embed = next((EMBED_RE.search(s.body).group(1) for s in shp
+                  if s.kind == "pic" and EMBED_RE.search(s.body)), None)
+    if embed is None:
+        host = None
+    first_id = max(int(m) for m in ID_RE.findall(xml)) + 1
+
+    edits, slot = {}, 0
+    for box_i, text_i in chips:
+        edits[box_i] = ""                       # the button box goes away
+        chip_text = shp[text_i].text
+        if text_i == host:
+            continue                            # the reflow below builds the lockup
+        if BADGE_RE.match(chip_text):
+            edits[text_i] = ""
+        elif PLACEHOLDER_RE.match(chip_text):
+            slot += 1
+            edits[text_i] = unbox(shp[text_i].body, "LOGO %d" % slot)
+        else:
+            edits[text_i] = unbox(shp[text_i].body)
+
+    # Pack the host's row left on one even gap. Only that row: the founding-
+    # member grid elsewhere on the carousel keeps its columns.
+    if host is not None:
+        band = shp[host].box
+        row = sorted((i for i, s in enumerate(shp)
+                      if s.box and s.box.y == band.y and s.box.cy == band.cy
+                      and edits.get(i, s.body) != ""),
+                     key=lambda i: shp[i].box.x)
+        gap = int(band.cy * ROW_GAP)
+        x = min(shp[i].box.x for i in row)
+        for i in row:
+            if i == host:
+                body, w = lockup(x, band.y, band.cy, embed, first_id)
+            else:
+                # Width comes from the text as it will finally read, so a chip
+                # renamed to "LOGO n" is measured at its new length.
+                body = edits.get(i, shp[i].body)
+                w = text_width(shape_text(body), font_size(body))
+                body = _resize(_move(body, x), w)
+            edits[i] = body
+            x += w + gap
+
+    out, cursor = [], 0
+    for i in sorted(edits):
+        start, end = shp[i].span
+        out.append(xml[cursor:start])
+        out.append(edits[i])
+        cursor = end
+    out.append(xml[cursor:])
+    return "".join(out), len(chips), host is not None
+
+
+def rework_pptx(src, dst):
+    """Rework every slide of `src`, writing `dst` only when there is something to
+    upload. Returns {slide part: chip count} — empty when the file has no footer,
+    in which case `dst` is never created and no deflate is paid. A plan run and
+    a re-run over an already-reworked estate are therefore read-only and cheap."""
+    report, new_parts = {}, {}
+    with zipfile.ZipFile(src) as zin:
+        for name in zin.namelist():
+            if not SLIDE_RE.match(name):
+                continue
+            new, n, _host = rework_slide(zin.read(name).decode("utf-8"))
+            if n:
+                report[name] = n
+                new_parts[name] = new.encode("utf-8")
+    if report:
+        # create_chapter's repacker: it preserves each member's compression and
+        # attributes and validates the result with testzip() before replacing
+        # the file, so a corrupt repack can never reach gws_upload.
+        shutil.copyfile(src, dst)
+        cc._rewrite_zip(dst, lambda name, data: new_parts.get(name, data))
+    return report
+
+
+# ----------------------------------------------------------------------------
+# Drive
+# ----------------------------------------------------------------------------
+def walk_templates(root, jobs=8):
+    """([{id, name, path}] for every .pptx in a template folder, {chapter names
+    seen}). The chapter set is what lets main() tell "this chapter has no footer
+    left" from "this chapter's template folder was renamed and never scanned"."""
+    found, chapters, level, seen = [], set(), [(root, "Community Events")], set()
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        while level:
+            level = [(f, p) for f, p in level if f not in seen]
+            seen.update(f for f, _ in level)
+            nxt = []
+            for path, kids in pool.map(lambda t: (t[1], cc.list_children(t[0])), level):
+                leaf = path.rsplit("/", 1)[-1]
+                is_template = bool(TEMPLATE_FOLDER_RE.match(leaf))
+                for k in kids:
+                    if k["mimeType"] == cc.FOLDER:
+                        nxt.append((k["id"], path + "/" + k["name"]))
+                        if leaf == CHAPTERS_FOLDER:
+                            chapters.add(k["name"])
+                    elif k["mimeType"] == cc.PPTX and is_template:
+                        found.append({"id": k["id"], "name": k["name"],
+                                      "path": path + "/" + k["name"]})
+            level = nxt
+    return found, chapters
+
+
+def process(entry, tmpdir, write):
+    """Rework one template. Returns (entry, {slide: chips}, error or None)."""
+    # Named by Drive id, not by path: paths are truncated to stay inside the
+    # filename limit, and two truncated paths that collide would have concurrent
+    # workers overwriting each other's download.
+    src = os.path.join(tmpdir, "in-%s.pptx" % entry["id"])
+    dst = os.path.join(tmpdir, "out-%s.pptx" % entry["id"])
+    try:
+        cc.gws_download(entry["id"], src)
+        # gws_download discards stdout, so an error body written at exit 0 would
+        # otherwise surface as a BadZipFile blaming the OOXML engine.
+        if not os.path.exists(src) or os.path.getsize(src) == 0:
+            raise RuntimeError("download wrote no file")
+        if not zipfile.is_zipfile(src):
+            raise RuntimeError("download is not a .pptx (%d bytes) — an error body, "
+                               "not the template" % os.path.getsize(src))
+        report = rework_pptx(src, dst)
+        if report and write:
+            cc.gws_upload(entry["id"], dst, cc.PPTX)
+        return entry, report, None
+    except Exception as e:                       # one bad file must not stop the run
+        return entry, {}, str(e)[:200]
+    finally:
+        for p in (src, dst):
+            if os.path.exists(p):
+                os.remove(p)
+
+
+def rework_local(path):
+    """--rework-local: run the XML engine on one file, no Drive access at all."""
+    dst = re.sub(r"\.pptx$", "", path) + "-reworked.pptx"
+    report = rework_pptx(path, dst)
+    if not report:
+        print("%s: no logo footer found — nothing to rework" % path)
+        return 0
+    print("%s -> %s" % (path, dst))
+    for part in sorted(report):
+        print("   %s: %d chips" % (part, report[part]))
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--write", action="store_true",
+                    help="Actually upload the reworked templates (default: plan only)")
+    ap.add_argument("--chapter", help="Only templates whose Drive path contains this "
+                                      "(case-insensitive), e.g. 'New York City'")
+    ap.add_argument("--rework-local", metavar="PPTX",
+                    help="Rework a local .pptx to <name>-reworked.pptx; no Drive access")
+    ap.add_argument("--jobs", type=int, default=6,
+                    help="Concurrent Drive transfers, and folder listings during the "
+                         "scan (default: 6)")
+    args = ap.parse_args()
+
+    if args.rework_local:
+        return rework_local(args.rework_local)
+
+    print("Scanning the Community Events tree for event templates...")
+    entries, chapters = walk_templates(COMMUNITY_ROOT, max(args.jobs, 8))
+    scanned = entries
+    if args.chapter:
+        needle = args.chapter.lower()
+        entries = [e for e in entries if needle in e["path"].lower()]
+    if not entries:
+        print("No templates matched." if args.chapter else
+              "No templates found — has the Community Events tree moved?")
+        return 1
+    print("Found %d template file(s).%s\n"
+          % (len(entries), "" if args.write else "  PLAN ONLY — nothing will be written."))
+
+    changed = clean = failed = 0
+    with tempfile.TemporaryDirectory() as tmpdir, \
+            ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        for entry, report, err in pool.map(lambda e: process(e, tmpdir, args.write), entries):
+            if err:
+                failed += 1
+                print("  FAILED  %s\n            %s" % (entry["path"], err))
+            elif report:
+                changed += 1
+                print("  %s  %s  (%s)"
+                      % ("REWORKED" if args.write else "would rework", entry["path"],
+                         ", ".join("%s:%d" % (p.rsplit("/", 1)[-1], n)
+                                   for p, n in sorted(report.items()))))
+            else:
+                clean += 1
+
+    print("\n%d reworked, %d already clean or footerless, %d failed."
+          % (changed, clean, failed))
+
+    # A folder-name match that stops matching looks exactly like a clean estate,
+    # so name what the scan could not see instead of letting it read as done.
+    attention = []
+    if not args.chapter:
+        covered = set()
+        for e in scanned:
+            parts = e["path"].split("/")
+            if len(parts) > 2 and parts[1] == CHAPTERS_FOLDER:
+                covered.add(parts[2])
+        for missing in sorted(chapters - covered):
+            attention.append("chapter %r contributed no template — folder renamed?" % missing)
+        if not any("/%s/" % TEMPLATE_CITY in e["path"] for e in scanned):
+            attention.append("%s was never reached — new chapters would still be cloned "
+                             "from the OLD footer" % TEMPLATE_CITY)
+    if attention:
+        print("\nATTENTION — the sweep did not cover the whole estate:")
+        for line in attention:
+            print("  - %s" % line)
+    if changed and not args.write:
+        print("Re-run with --write to apply.")
+    return 1 if (failed or attention) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/aaif-create-chapter/scripts/create_chapter.py
+++ b/skills/aaif-create-chapter/scripts/create_chapter.py
@@ -448,11 +448,26 @@ def gws_upload(file_id, path, mime):
           "--upload", os.path.basename(path), "--upload-content-type", mime], cwd=d)
 
 def list_children(folder_id):
-    res = gws_json("drive", "files", "list", params={
-        "q": "'%s' in parents and trashed=false" % folder_id,
-        "fields": "files(id,name,mimeType)", "pageSize": 1000,
-        "supportsAllDrives": True, "includeItemsFromAllDrives": True})
-    return res.get("files", [])
+    """Every child of `folder_id`, following pagination to the end.
+
+    Drive may return fewer items than `pageSize` *and* a `nextPageToken` — that
+    is documented behaviour, not a >1000-children edge case. Reading only the
+    first page silently drops children, and a truncated listing is
+    indistinguishable from a complete one: a clone would miss files, and a
+    backfill would report a folder it never fully saw as clean."""
+    out, token = [], None
+    while True:
+        params = {
+            "q": "'%s' in parents and trashed=false" % folder_id,
+            "fields": "nextPageToken, files(id,name,mimeType)", "pageSize": 1000,
+            "supportsAllDrives": True, "includeItemsFromAllDrives": True}
+        if token:
+            params["pageToken"] = token
+        res = gws_json("drive", "files", "list", params=params)
+        out.extend(res.get("files", []))
+        token = res.get("nextPageToken")
+        if not token:
+            return out
 
 def create_folder(name, parent):
     return gws_json("drive", "files", "create",

--- a/skills/aaif-create-chapter/scripts/test_backfill_host_footer.py
+++ b/skills/aaif-create-chapter/scripts/test_backfill_host_footer.py
@@ -10,6 +10,15 @@ import os, re, sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import backfill_host_footer as bf
+import create_chapter as cc
+
+# No test in this file may touch Drive. The sibling backfill's suite carries the
+# same guard after a "unit" test once listed the live Chapters folder and
+# downloaded a production deck; main() here has no pre-Drive validation at all,
+# so one mocked argv line would be enough to start a sweep.
+for _name in ("gws_json", "gws_download", "gws_upload", "list_children", "_gws"):
+    setattr(cc, _name, (lambda n: lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("test touched the network via cc.%s" % n)))(_name))
 
 FAILURES = []
 
@@ -243,6 +252,142 @@ with tempfile.TemporaryDirectory() as td:
     rep = bf.rework_pptx(src, dst)
     check("a footerless deck reports nothing", rep == {})
     check("and no output file is written", not _os.path.exists(dst))
+
+print("find_host — band beats document order")
+# Without the band preference, the earlier-in-document-order member chip is
+# picked as the host: the lockup is drawn OVER a real member logo and the true
+# host slot is renumbered. Deleting that branch leaves every other assertion in
+# this file green, so this is the only thing locking it.
+crossed = ("<p:sld><p:cSld><p:spTree>%s%s%s%s%s%s</p:spTree></p:cSld></p:sld>"
+           % (header_pic(),
+              text_sp(20, 548640, Y, 914400, CY, "HOSTED BY", 0, bf.MUTED, 1100, "l"),
+              box_sp(21, *GRID_BOX), text_sp(22, *GRID_BOX, text="AWS"),
+              box_sp(23, 1536192, Y, 1883664, CY),
+              text_sp(24, 1536192, Y, 1883664, CY, "HOST VENUE CO.")))
+outc, _cc, hostc = bf.rework_slide(crossed)
+check("the in-band chip wins over the earlier document-order chip", hostc)
+check("the real member name is not overwritten by the lockup", "AWS" in outc)
+check("the host slot, not the member, became the lockup",
+      "HOST VENUE CO." not in outc and "LOGO" not in outc)
+
+print("run-split text — a label broken across runs still matches")
+# OOXML runs concatenate with NO separator; Slides splits them for a spell-check
+# or a language tag. Joining on " " made "HOSTED BY" read "HOSTED  BY", so the
+# host was not found and the host chip was RELABELLED "LOGO 1" — a destructive
+# half-migration reported as success.
+check("runs concatenate without a separator",
+      bf.shape_text("<a:t>HOSTED </a:t><a:t>BY</a:t>") == "HOSTED BY")
+check("internal whitespace is collapsed",
+      bf.shape_text("<a:t>HOST  VENUE</a:t><a:t>  CO.</a:t>") == "HOST VENUE CO.")
+split = hero_slide().replace("<a:t>HOSTED BY</a:t>", "<a:t>HOSTED </a:t><a:t>BY</a:t>")
+outs, chips_s, host_s = bf.rework_slide(split)
+check("the host is still found", host_s)
+check("the host slot is NOT relabelled as a placeholder", "LOGO 3" not in outs)
+check("the lockup is drawn", "Agentic AI" in outs)
+
+print("find_mark — the lockup uses the logo, not whatever picture is first")
+photo = ('<p:pic><p:nvPicPr><p:cNvPr id="99" name="Backdrop" descr="venue-photo.jpg"/>'
+         '<p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId77"/>'
+         '<a:stretch/></p:blipFill><p:spPr><a:xfrm><a:off x="0" y="0"/>'
+         '<a:ext cx="9144000" cy="5000000"/></a:xfrm>'
+         '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>')
+withphoto = hero_slide().replace(header_pic(), photo + header_pic())
+outp, _cp, hostp = bf.rework_slide(withphoto)
+check("a backdrop before the logo is not promoted to the mark",
+      'name="AAIF Lockup Mark"' in outp and 'r:embed="rId77"' not in
+      outp.split('name="AAIF Lockup Mark"')[1][:400])
+check("the lockup still embeds the header logo", hostp and outp.count('r:embed="rId3"') == 2)
+nomark = hero_slide().replace('descr="/tmp/x/logo.png" ', "").replace('name="Logo"', 'name="Blob"')
+check("find_mark falls back to a square picture", bf.find_mark(bf.shapes(nomark)) == "rId3")
+check("find_mark gives up rather than guessing",
+      bf.find_mark(bf.shapes("<p:sld>%s</p:sld>" % photo)) is None)
+
+print("unbox — muting survives a re-saved self-close")
+resaved2 = hero_slide().replace('"/>', '" />')
+outm, _cm, _hm = bf.rework_slide(resaved2)
+check("a relabelled slot is muted, not left in ink",
+      outm.count('val="%s"' % bf.MUTED) >= 4)
+for s_ in bf.shapes(outm):
+    if re.match(r"^LOGO \d+$", s_.text):
+        check("LOGO %s is not in ink" % s_.text.split()[-1],
+              bf.INK.lower() not in s_.body.lower())
+
+print("orphan and duplicate button plates")
+# A plate with no text partner used to survive, then get reflowed to cx=0 — a
+# zero-width bordered rect that renders as a stray hairline. 115 production
+# files carried one.
+orphan = hero_slide().replace(box_sp(26, 1536192, Y, 1883664, CY),
+                              box_sp(26, 1536192, Y, 1883664, CY)
+                              + box_sp(40, 3000000, Y, 900000, CY))
+outo, _co, _ho = bf.rework_slide(orphan)
+check("an unpaired plate in the host band is removed", "roundRect" not in outo)
+check("no shape is left at zero width",
+      all(s_.box.cx > 0 for s_ in bf.shapes(outo) if s_.box))
+dup = hero_slide().replace(box_sp(26, 1536192, Y, 1883664, CY),
+                           box_sp(26, 1536192, Y, 1883664, CY)
+                           + box_sp(41, 1536192, Y, 1883664, CY))
+outd, _cd, _hd = bf.rework_slide(dup)
+check("stacked plates at identical geometry both go", "roundRect" not in outd)
+
+print("rework_slide — a slide with no numeric cNvPr id")
+noids = re.sub(r'\sid="\d+"', "", hero_slide())
+try:
+    _o, n_noid, _h = bf.rework_slide(noids)
+    check("no ValueError from id allocation", True)
+except ValueError as e:
+    check("no ValueError from id allocation", False, str(e))
+
+print("rework_pptx — the write path and what it must not touch")
+with tempfile.TemporaryDirectory() as td:
+    src = _os.path.join(td, "mixed.pptx")
+    dst = _os.path.join(td, "mixed-out.pptx")
+    media = b"\x89PNG" + b"0" * 4096
+    with _zip.ZipFile(src, "w") as z:
+        z.writestr("[Content_Types].xml", "<Types/>")
+        z.writestr("ppt/slides/slide1.xml", plain)
+        z.writestr("ppt/slides/slide2.xml", hero_slide())
+        z.writestr("ppt/slideLayouts/slideLayout1.xml", hero_slide())
+        z.writestr("ppt/media/image1.png", media)
+    rep = bf.rework_pptx(src, dst)
+    check("only the slide with chips is reported", list(rep) == ["ppt/slides/slide2.xml"])
+    check("the report carries the lockup flag", rep["ppt/slides/slide2.xml"] == (3, True))
+    with _zip.ZipFile(dst) as z:
+        check("the repack is a valid zip", z.testzip() is None)
+        check("every part survives the repack", len(z.namelist()) == 5)
+        check("the chip slide is reworked", "Agentic AI" in z.read("ppt/slides/slide2.xml").decode())
+        check("the chipless slide is byte-identical", z.read("ppt/slides/slide1.xml").decode() == plain)
+        check("slideLayouts are out of scope",
+              z.read("ppt/slideLayouts/slideLayout1.xml").decode() == hero_slide())
+        check("media survives untouched", z.read("ppt/media/image1.png") == media)
+
+print("repair pass — an already-migrated file with a zero-width plate")
+# The state 115 production files were left in: no chips (already migrated), a
+# lockup already drawn, and one plate reflowed to cx=0. A re-run must clean it,
+# and must NOT report the file as having lost its host slot.
+migrated, _cm2, _hm2 = bf.rework_slide(hero_slide())
+stray_plate = box_sp(50, 2164109, Y, 0, CY)
+damaged = migrated.replace("</p:spTree>", stray_plate + "</p:spTree>")
+check("the damaged fixture really has a zero-width plate",
+      any(s_.geom == "roundRect" and s_.box and s_.box.cx == 0
+          for s_ in bf.shapes(damaged)))
+outr, nr, hostr = bf.rework_slide(damaged)
+check("the repair pass reports work to do", nr == 1, "got %d" % nr)
+check("the zero-width plate is removed", "roundRect" not in outr)
+check("an already-drawn lockup counts as present", hostr)
+check("the lockup itself is untouched", outr.count("Agentic AI") == 1)
+check("a repaired file is then stable", bf.rework_slide(outr)[1] == 0)
+
+print("repair pass — a clean migrated file is still a no-op")
+again2, n2, _h2 = bf.rework_slide(migrated)
+check("no work reported", n2 == 0)
+check("byte-identical", again2 == migrated)
+
+print("main() — populations that must each contribute a template")
+check("SERIES_FOLDER names the online tree", bf.SERIES_FOLDER == "Online")
+check("dated per-event folders are not template folders",
+      not bf.TEMPLATE_FOLDER_RE.match("2026-07-28 · MCP Release Party")
+      and not bf.TEMPLATE_FOLDER_RE.match("Archive")
+      and not bf.TEMPLATE_FOLDER_RE.match("Agentic-Architecture"))
 
 print()
 if FAILURES:

--- a/skills/aaif-create-chapter/scripts/test_backfill_host_footer.py
+++ b/skills/aaif-create-chapter/scripts/test_backfill_host_footer.py
@@ -1,0 +1,251 @@
+"""Tests for backfill_host_footer's slide-XML engine.
+
+Plain script, no pytest: run it, it exits 1 on the first failure. The fixtures
+are synthetic PresentationML built here, not a real chapter deck — see the PII
+rule in AGENTS.md.
+
+  python skills/aaif-create-chapter/scripts/test_backfill_host_footer.py
+"""
+import os, re, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import backfill_host_footer as bf
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print("  ok   %s" % name)
+    else:
+        print("  FAIL %s %s" % (name, detail))
+        FAILURES.append(name)
+
+
+# ----------------------------------------------------------------------------
+# Fixture builders — a minimal slide in the shape the real templates use
+# ----------------------------------------------------------------------------
+def text_sp(sid, x, y, cx, cy, text, bold=1, colour=bf.INK, sz=1200, algn="ctr"):
+    return ('<p:sp><p:nvSpPr><p:cNvPr id="%d" name="Shape %d"/><p:cNvSpPr/><p:nvPr/>'
+            '</p:nvSpPr><p:spPr><a:xfrm><a:off x="%d" y="%d"/><a:ext cx="%d" cy="%d"/>'
+            '</a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr><p:txBody>'
+            '<a:bodyPr/><a:lstStyle/><a:p><a:pPr indent="0" rtl="0" algn="%s"><a:buNone/>'
+            '</a:pPr><a:r><a:rPr b="%d" sz="%d"><a:solidFill><a:srgbClr val="%s"/>'
+            '</a:solidFill><a:latin typeface="JetBrains Mono"/></a:rPr><a:t>%s</a:t></a:r>'
+            '</a:p></p:txBody></p:sp>'
+            % (sid, sid, x, y, cx, cy, algn, bold, sz, colour, text))
+
+
+def box_sp(sid, x, y, cx, cy):
+    return ('<p:sp><p:nvSpPr><p:cNvPr id="%d" name="Shape %d"/><p:cNvSpPr/><p:nvPr/>'
+            '</p:nvSpPr><p:spPr><a:xfrm><a:off x="%d" y="%d"/><a:ext cx="%d" cy="%d"/>'
+            '</a:xfrm><a:prstGeom prst="roundRect"><a:avLst><a:gd fmla="val 17857" '
+            'name="adj"/></a:avLst></a:prstGeom><a:solidFill><a:srgbClr val="F6F5F1"/>'
+            '</a:solidFill><a:ln w="12700"><a:solidFill><a:srgbClr val="C9C6BF"/>'
+            '</a:solidFill></a:ln></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p>'
+            '<a:pPr><a:buNone/></a:pPr><a:r><a:t> </a:t></a:r></a:p></p:txBody></p:sp>'
+            % (sid, sid, x, y, cx, cy))
+
+
+def header_pic(sid=16, embed="rId3"):
+    return ('<p:pic><p:nvPicPr><p:cNvPr id="%d" name="Logo"/><p:cNvPicPr/><p:nvPr/>'
+            '</p:nvPicPr><p:blipFill><a:blip r:embed="%s"/><a:stretch/></p:blipFill>'
+            '<p:spPr><a:xfrm><a:off x="548640" y="512064"/><a:ext cx="475488" cy="475488"/>'
+            '</a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>'
+            % (sid, embed))
+
+
+Y, CY = 7516368, 512064
+# A chip in its own band, well below the host row — the carousel's member grid.
+GRID_BOX = (548640, 8000000, 1901952, 475488)
+
+
+def hero_slide(with_badge=False):
+    """HOSTED BY [HOST VENUE CO.] WITH [MEMBER LOGO] [MEMBER LOGO], all in one band."""
+    parts = [header_pic(),
+             text_sp(25, 548640, Y, 914400, CY, "HOSTED BY", 0, bf.MUTED, 1100, "l"),
+             box_sp(26, 1536192, Y, 1883664, CY),
+             text_sp(27, 1536192, Y, 1883664, CY, "HOST VENUE CO.")]
+    nxt = 28
+    if with_badge:
+        parts += [box_sp(nxt, 3600000, Y, 1200000, CY),
+                  text_sp(nxt + 1, 3600000, Y, 1200000, CY, "AAIF · SF")]
+        nxt += 2
+    parts += [text_sp(nxt, 4900000, Y, 566928, CY, "WITH", 0, bf.MUTED, 1100, "l"),
+              box_sp(nxt + 1, 5600000, Y, 1792224, CY),
+              text_sp(nxt + 2, 5600000, Y, 1792224, CY, "MEMBER LOGO"),
+              box_sp(nxt + 3, 7500000, Y, 1792224, CY),
+              text_sp(nxt + 4, 7500000, Y, 1792224, CY, "MEMBER LOGO")]
+    return "<p:sld><p:cSld><p:spTree>%s</p:spTree></p:cSld></p:sld>" % "".join(parts)
+
+
+def texts(xml):
+    return [t for t in re.findall(r"<a:t>(.*?)</a:t>", xml) if t.strip()]
+
+
+def offsets(xml):
+    """(x, cx) for every element in the footer band, left to right. The lockup
+    is two shapes — the mark is vertically centred in the band, so it does not
+    share the band's y — and is merged back into the single element it reads as,
+    otherwise the gap in front of the wordmark measures the mark as empty space."""
+    spans, lock = [], []
+    for s in bf.shapes(xml):
+        if not s.box:
+            continue
+        name = re.search(r'<p:cNvPr[^>]*name="([^"]*)"', s.body)
+        if name and name.group(1).startswith("AAIF Lockup"):
+            lock.append((s.box.x, s.box.x + s.box.cx))
+        elif s.box.y == Y and s.box.cy == CY:
+            spans.append((s.box.x, s.box.x + s.box.cx))
+    if lock:
+        spans.append((min(a for a, _ in lock), max(b for _, b in lock)))
+    return [(a, b - a) for a, b in sorted(spans)]
+
+
+# ----------------------------------------------------------------------------
+print("rework_slide — the hero footer")
+src = hero_slide()
+out, chips, host = bf.rework_slide(src)
+
+check("finds all three chips", chips == 3, "got %d" % chips)
+check("replaces the host slot", host)
+check("no roundRect survives", "roundRect" not in out)
+check("the old host name is gone", "HOST VENUE CO." not in out)
+check("the lockup wordmark is drawn", texts(out).count("Agentic AI") == 1
+      and texts(out).count("Foundation") == 1)
+check("the lockup reuses the header's image", out.count('r:embed="rId3"') == 2)
+check("placeholders are renumbered", "LOGO 1" in out and "LOGO 2" in out
+      and "MEMBER LOGO" not in out)
+check("labels survive untouched", "HOSTED BY" in out and "WITH" in out)
+check("placeholders are muted", out.count('<a:srgbClr val="%s"/>' % bf.MUTED) >= 4)
+check("nothing is bold any more in the row", 'b="1" sz="1200"' not in out)
+check("nothing stays centre-aligned", 'algn="ctr"' not in out)
+
+print("rework_slide — left-packing")
+xs = offsets(out)
+check("row starts at the original left margin", xs[0][0] == 548640, "got %d" % xs[0][0])
+gaps = [xs[i + 1][0] - (xs[i][0] + xs[i][1]) for i in range(len(xs) - 1)]
+check("every gap is the same", len(set(gaps)) == 1, "gaps=%s" % gaps)
+check("the gap is the configured fraction of the band",
+      gaps and gaps[0] == int(CY * bf.ROW_GAP), "got %s" % gaps[:1])
+check("shapes never overlap", all(g > 0 for g in gaps), "gaps=%s" % gaps)
+
+print("rework_slide — the redundant chapter badge")
+out2, chips2, _ = bf.rework_slide(hero_slide(with_badge=True))
+check("the badge chip is counted", chips2 == 4, "got %d" % chips2)
+check("the badge is dropped, not restyled", "AAIF · SF" not in out2)
+check("badge removal does not renumber past LOGO 2",
+      "LOGO 1" in out2 and "LOGO 2" in out2 and "LOGO 3" not in out2)
+
+print("rework_slide — real names keep their ink")
+grid = ("<p:sld><p:cSld><p:spTree>%s%s%s%s%s</p:spTree></p:cSld></p:sld>"
+        % (header_pic(),
+           text_sp(20, 548640, Y, 914400, CY, "HOSTED BY", 0, bf.MUTED, 1100, "l"),
+           box_sp(21, 1536192, Y, 1883664, CY),
+           text_sp(22, 1536192, Y, 1883664, CY, "HOST VENUE CO."),
+           box_sp(23, *GRID_BOX) + text_sp(24, *GRID_BOX, text="AWS")))
+out3, chips3, _ = bf.rework_slide(grid)
+check("a named chip is kept verbatim", "AWS" in out3)
+check("a named chip is not renumbered", "LOGO" not in out3)
+check("a named chip loses its box", "roundRect" not in out3)
+check("a chip outside the host row is not moved",
+      any(s.box == GRID_BOX for s in bf.shapes(out3)))
+
+print("rework_slide — idempotence and no-ops")
+again, chips_again, _ = bf.rework_slide(out)
+check("a second pass finds nothing", chips_again == 0, "got %d" % chips_again)
+check("a second pass is byte-identical", again == out)
+plain = "<p:sld><p:cSld><p:spTree>%s</p:spTree></p:cSld></p:sld>" % header_pic()
+same, n, host_none = bf.rework_slide(plain)
+check("a footerless slide is untouched", same == plain and n == 0 and not host_none)
+
+print("rework_slide — a slide with no image to borrow")
+no_pic = hero_slide().replace(header_pic(), "")
+out4, chips4, host4 = bf.rework_slide(no_pic)
+check("chips are still unboxed without a mark", chips4 == 3 and "roundRect" not in out4)
+check("the host slot is left alone rather than half-drawn", not host4)
+check("no lockup is invented", "Agentic AI" not in out4)
+
+print("retext — run formatting survives")
+split = ('<a:r><a:rPr b="1" sz="1200"><a:solidFill><a:srgbClr val="0A0A0A"/></a:solidFill>'
+         '</a:rPr><a:t>MEMBER </a:t></a:r><a:r><a:rPr b="1"/><a:t>LOGO</a:t></a:r>')
+res = bf.retext(split, "LOGO 7")
+check("the first run carries the new text", "<a:t>LOGO 7</a:t>" in res)
+check("the trailing run is emptied", res.count("<a:t></a:t>") == 1)
+check("the run properties are untouched", 'sz="1200"' in res)
+check("XML-special text is escaped", "&amp;" in bf.retext(split, "A & B"))
+
+print("text_width and font_size")
+check("mono width is exact", bf.text_width("LOGO 1", 1200)
+      == int(6 * bf.MONO_EM * 12 * bf.EMU_PER_PT))
+check("font_size reads the first run", bf.font_size('<a:rPr b="0" sz="1100"/>') == 1100)
+check("font_size falls back when absent", bf.font_size("<a:rPr/>") == 1100)
+
+print("TEMPLATE_FOLDER_RE")
+for good in ("Event Templates (Copy for Each Event)", "Event Template", "Event Name",
+             "event templates"):
+    check("matches %r" % good, bool(bf.TEMPLATE_FOLDER_RE.match(good)))
+for bad in ("Banners (Chapter Specific, Changed Rarely)", "Chapters", "Archive",
+            "2026-07-28 · MCP Release Party", "Event Names of Note"):
+    check("skips %r" % bad, not bf.TEMPLATE_FOLDER_RE.match(bad))
+
+print("find_host — the label stacked ABOVE its chip row")
+# The deck cover and the carousel put HOSTED BY on its own line above the chips,
+# so the label shares a band with none of them. A band-only lookup finds no host
+# here and would silently leave the slot un-lockup'd — the regression this locks.
+LY, LCY = 3877056, 219456
+CHIP_Y, CHIP_CY = 4151376, 347472
+stacked = ("<p:sld><p:cSld><p:spTree>%s%s%s%s%s%s%s</p:spTree></p:cSld></p:sld>"
+           % (header_pic(),
+              text_sp(20, 457200, LY, 1828800, LCY, "HOSTED BY", 0, bf.MUTED, 1100, "l"),
+              box_sp(21, 457200, CHIP_Y, 1737360, CHIP_CY),
+              text_sp(22, 457200, CHIP_Y, 1737360, CHIP_CY, "HOST VENUE CO."),
+              text_sp(23, 2331720, CHIP_Y, 1417320, CHIP_CY, "AAIF · SF"),
+              box_sp(24, 3886200, CHIP_Y, 1554480, CHIP_CY),
+              text_sp(25, 3886200, CHIP_Y, 1554480, CHIP_CY, "MEMBER LOGO")))
+# Shape 23 has no box of its own, so make it a real chip by giving it one.
+stacked = stacked.replace(text_sp(23, 2331720, CHIP_Y, 1417320, CHIP_CY, "AAIF · SF"),
+                          box_sp(26, 2331720, CHIP_Y, 1417320, CHIP_CY)
+                          + text_sp(23, 2331720, CHIP_Y, 1417320, CHIP_CY, "AAIF · SF"))
+out5, chips5, host5 = bf.rework_slide(stacked)
+check("the host is found across bands", host5)
+check("the lockup is drawn", "Agentic AI" in out5 and "Foundation" in out5)
+check("the stale host name is gone", "HOST VENUE CO." not in out5)
+check("the badge is still dropped", "AAIF · SF" not in out5)
+check("the remaining slot is renumbered", "LOGO 1" in out5 and "MEMBER LOGO" not in out5)
+check("the label itself is not moved into the chip row",
+      any(s.box and s.box.y == LY and "HOSTED BY" in s.text for s in bf.shapes(out5)))
+
+print("re-saved XML — attributes on tags and a spaced self-close")
+# Google Slides re-serializes a deck the moment anyone opens it: shape tags come
+# back carrying attributes and xfrm children self-close as " />". Both forms must
+# still parse, or a re-run silently reports a modified deck as clean.
+resaved = (hero_slide().replace("<p:sp>", '<p:sp xmlns:foo="urn:x">')
+                       .replace("<p:pic>", '<p:pic xmlns:foo="urn:x">')
+                       .replace('"/>', '" />'))
+check("shapes are still found", len(bf.shapes(resaved)) == len(bf.shapes(hero_slide())))
+check("every shape still has geometry",
+      all(s.box for s in bf.shapes(resaved) if s.kind in ("sp", "pic")))
+out6, chips6, host6 = bf.rework_slide(resaved)
+check("chips are still found in a re-saved slide", chips6 == 3, "got %d" % chips6)
+check("the host slot is still replaced", host6)
+check("boxes are still removed", "roundRect" not in out6)
+check("placeholders are still renumbered", "LOGO 1" in out6 and "LOGO 2" in out6)
+
+print("rework_pptx — no output file when there is nothing to upload")
+import tempfile, zipfile as _zip, os as _os
+with tempfile.TemporaryDirectory() as td:
+    src = _os.path.join(td, "plain.pptx")
+    dst = _os.path.join(td, "out.pptx")
+    with _zip.ZipFile(src, "w") as z:
+        z.writestr("ppt/slides/slide1.xml", plain)
+        z.writestr("ppt/media/image1.png", b"\x89PNG" + b"0" * 4096)
+    rep = bf.rework_pptx(src, dst)
+    check("a footerless deck reports nothing", rep == {})
+    check("and no output file is written", not _os.path.exists(dst))
+
+print()
+if FAILURES:
+    print("%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+    sys.exit(1)
+print("all passed")

--- a/skills/aaif-dayof-slides/SKILL.md
+++ b/skills/aaif-dayof-slides/SKILL.md
@@ -26,6 +26,15 @@ deck (`Event Template/Slides.pptx`). Fill the per-event slides from the tracker 
 **leave the fixed brand slides** (`[FIXED]`: About AAIF, the global-network stats)
 **exactly as written** — they are brand-standard.
 
+**The logo footer is not yours to write.** On the cover and the welcome slide,
+`HOSTED BY` carries the fixed AAIF lockup — AAIF hosts these events — and the
+slots beside it read `LOGO 1`, `LOGO 2`. Those are placeholders an organizer
+replaces with a **logo image**; the words are just what an empty slot looks
+like, so do not treat them as copy to fill in. Never emit a host-venue name or
+a member name for those slots, and never replace the lockup. The venue and the
+members get their credit in prose on **slide 12 (Thank you)**, which is where
+the `Host`/`Members` inputs belong.
+
 Keep it **terse and label-driven** (the deck voice). Output as `Slide N — <name>:`
 then the fields, slide for slide, then paste into the template.
 Never include emails, phone numbers, door codes, or attendee names that are not already public in any post, slide, or message.
@@ -33,7 +42,8 @@ Never include emails, phone numbers, door codes, or attendee names that are not 
 ## Input (from the event tracker)
 - Event : `[EVENT TITLE]`   Series: `[SERIES]`   Theme: `[THEME + ONE-LINER]`
 - When : `[DATE & TIME]`   Venue/City: `[VENUE], [CITY]`
-- Host : `[HOST VENUE]`   Members: `[MEMBER LOGOS]`
+- Host : `[HOST VENUE]`   Members: `[MEMBER LOGOS]`   *(→ slide 12's credits, not
+  the cover: see the logo-footer note below)*
 - Speakers : `[FOR EACH: NAME | ROLE | TALK or DEMO | "QUOTE"]`
 - Agenda : `[RUN-OF-SHOW: TIME | BLOCK | NOTE]`
 - Next : `[NEXT EVENT + DATE]`   Links: `[LUMA / SLACK / NEWSLETTER]`
@@ -52,8 +62,8 @@ Agentic AI Night:
 
 > **Slide 1 — Cover:**
 >   Kicker: THE AAIF COMMUNITY · Title: Agentic AI Night. · Sub: Launch Series —
->   San Francisco · Date: WED — JUNE 24, 2026 — 17:30 — LATE · Hosted by: Host
->   Venue Co. · With: [member logos]
+>   San Francisco · Date: WED — JUNE 24, 2026 — 17:30 — LATE
+>   (the HOSTED BY / LOGO 1 / LOGO 2 footer is left alone — see above)
 >
 > **Slide 6 — Tonight's theme:**
 >   Label: TONIGHT'S THEME 01 · Title: Agents in production. · Body: What's working

--- a/skills/aaif-dayof-slides/SKILL.md
+++ b/skills/aaif-dayof-slides/SKILL.md
@@ -28,9 +28,9 @@ deck (`Event Template/Slides.pptx`). Fill the per-event slides from the tracker 
 
 **The logo footer is not yours to write.** On the cover and the welcome slide,
 `HOSTED BY` carries the fixed AAIF lockup — AAIF hosts these events — and the
-slots beside it read `LOGO 1`, `LOGO 2`. Those are placeholders an organizer
-replaces with a **logo image**; the words are just what an empty slot looks
-like, so do not treat them as copy to fill in. Never emit a host-venue name or
+slots beside it read `LOGO 1`, `LOGO 2`, …. Those are placeholders an organizer
+deletes and replaces with a **logo image**; the words are just what an empty
+slot looks like, so do not treat them as copy to fill in. Never emit a host-venue name or
 a member name for those slots, and never replace the lockup. The venue and the
 members get their credit in prose on **slide 12 (Thank you)**, which is where
 the `Host`/`Members` inputs belong.


### PR DESCRIPTION
## Summary

The event templates' `HOSTED BY / WITH` logo footer drew each logo as a bordered, filled rounded-rect **button** holding centred bold text. A chip like that reads as a control you can press, and a row of them fought the flat rule-and-type language the rest of the deck is drawn in. This removes the boxes, puts the **AAIF lockup** in the host slot (AAIF hosts these events — the slot previously said `HOST VENUE CO.`), turns the remaining slots into muted `LOGO 1` / `LOGO 2` placeholders, and re-packs the row left on one even gap.

The lockup is built from the mark image each slide **already embeds for its own header** — identified by name, not by being the first picture on the slide — so no media and no relationship is added and the footer lockup cannot drift from the header's.

**Applied to production in two passes:** 356 templates across all 83 chapters, the online series and the shared Templates folder; then a further **98 repaired** after self-review found a defect the first pass introduced (below). A plan run now reports `0 reworked, 359 already clean, 0 failed` with an empty `ATTENTION` block.

## Changesets

### 1. `chore(lint): let codespell read the OOXML lIns attribute`
`pyproject.toml` (+2 -1) — `lIns` is a text body's left inset; codespell reads it as "lines". Lands first because the script below needs it.

### 2. `feat(templates): put the AAIF lockup in the event logo footer`
`backfill_host_footer.py`, `test_backfill_host_footer.py` (+733)

Three cases are kept apart: an **unfilled slot** is renumbered `LOGO n` and muted; a **real name** (the carousel's founding-member grid) keeps its text and ink, and its position too unless it sits in the host's own row; the old **`AAIF · SF` badge** is dropped, because the lockup now says the same thing.

Scope is **templates**, not per-event copies — and that set includes **TemplateCity**, the folder `create_chapter.py` clones for every new chapter, so the sweep is what stops new chapters being minted on the old footer.

### 3. `docs(skills): document the host-footer rework and its authoring rule`
`aaif-create-chapter/SKILL.md`, `aaif-dayof-slides/SKILL.md`, `CHANGELOG.md` (+83 -4)

`aaif-dayof-slides` needed a **correction**: its Slide 1 example told the agent to write `Hosted by: Host Venue Co.` into the cover, which under the new footer would have someone typing a venue name over the AAIF lockup.

### 4. `fix(drive): follow pagination in list_children`
`create_chapter.py` (+16 -4) — Drive may return fewer items than `pageSize` *and* a `nextPageToken`. A truncated listing was indistinguishable from a complete one, so a clone would miss files and a backfill would report a folder it never fully saw as clean. Shared with `create_chapter` and the sibling backfill, hence its own commit.

### 5. `fix: address self-review findings`
`backfill_host_footer.py`, `test_backfill_host_footer.py` (+342 -57)

The critical one **had already shipped**: an unpaired button plate was never deleted, then reflowed to the width of its own empty text — a zero-width bordered rect that renders as a **visible hairline** on 98 templates. Confirmed by diffing a Drive revision pre/post and by rendering the slide. Plus seven silent-failure classes (run-split labels, first-picture-as-mark, ink tolerance, falsy error strings, a discarded host flag, `max()` on an empty list, duplicate file ids). Tests 60 → 96 assertions.

### 6. `docs: correct claims the review found overstated`
Six documentation claims that were wrong, including one that was load-bearing for the script's own safety argument.

## Test Plan
- [x] `pre-commit run --all-files` — 18 hooks pass
- [x] `PYTHONPATH=lib pytest lib/aaif_events/tests` — 210 passed
- [x] All 27 `skills/*/scripts/test_*.py` pass (96 assertions in the new suite)
- [x] The band-preference branch is **provably locked** — deleting it fails two assertions
- [x] Live plan run: `0 reworked, 359 clean, 0 failed`, exit 0, empty `ATTENTION`
- [x] Repair sweep: 98 reworked, 0 failed, 0 half-migrations; the hairline is gone in a re-render
- [x] Estate audited file-by-file for half-applied states; the two remaining flags are false positives (slide 12's prose credit, and organizer-supplied logo images the script correctly skipped — verified byte-identical pre/post)
- [ ] Reviewer: confirm the three judgement calls in Changeset 2 match intent

## Notes for the reviewer

- **Per-event copies** organizers made *outside* template folders still carry the old boxed footer — out of scope by agreement.
- **Five oddly-named files** that live *inside* template folders were swept along with them (`Vijay_Copy_of_Event-Hero-Square.pptx`, `2026-08-27 Denver AAIF Event.pptx`, `Lean Coffee After Dark…`, `#27 linkedin.pptx`, `CCCCCCCC.pptx`). Revertable only via Drive revision history.
- **One finding deliberately not fixed:** grouped shapes (`<p:grpSp>`) are treated as top-level with child-space offsets. These templates contain none, and the flat-`spTree` assumption is inherited from `create_chapter`'s `SP_RE`; it is now *stated* rather than assumed. A proper fix means scoping to direct children of `spTree` — a change to shared parsing, better on its own.
- **Security review: NO FINDINGS** (injection, path traversal and zip-slip each traced to why they're unreachable).

_Generated using hero-skills._