### PR TITLE
fix: the three follow-ups deferred out of PR #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ plugin version is the `version` field in `.claude-plugin/plugin.json`.
   side never had a seam, so the brand lived in those files as literal font names
   and hex values and had drifted a long way from it — Space Grotesk and Manrope
   as display faces, Arial in every theme, Office's stock colour scheme
-  underneath, a warm-grey ramp half a shade off `--line-2`, a navy `1E2761` in
-  the trackers, and 205 runs of body prose set in JetBrains Mono when the system
-  reserves mono for metadata.
+  underneath, a warm-grey ramp half a shade off `--line-2`, and a navy `1E2761`
+  in the trackers. JetBrains Mono is deliberately *not* on that list: the
+  trackers' 205 mono runs are field labels, table headers, dates, statuses and
+  phase eyebrows — metadata, which is exactly what the system reserves mono
+  for — so they are left alone, and the orphaned Manrope/Space Grotesk embeds
+  are pruned around them. (An earlier revision of this sweep read those 205
+  runs as body prose and rewrote them to the sans; that was wrong and was
+  reverted before release.)
 - **The audit reports have no dark mode.** `report_style.py` shipped a light
   palette plus an inverted twin under `prefers-color-scheme` and
   `[data-theme]`. AAIF is a two-surface system where the *designer* chooses

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -81,9 +81,19 @@ Three things about it are worth knowing before editing:
   for a font it does not embed, still declaring the ones it no longer uses, and
   carrying their bytes — which is where the trackers ended up. `prune_embedded_
   fonts` reconciles the table against what the document actually references and
-  drops the orphans: a tracker goes from ~382KB to ~19KB, because once mono body
-  prose becomes the sans, JetBrains Mono is referenced nowhere and its four
-  embedded faces (~443KB) go too.
+  drops the orphans: a tracker sheds Arial, Georgia, Manrope and Space Grotesk
+  from its table and the four Manrope/Space Grotesk faces (~180KB) from
+  `word/fonts/`.
+  **JetBrains Mono is not among them, and that is the point of reconciling
+  against usage rather than against a drop-list.** A tracker's 205 mono runs are
+  its field labels, table headers, dates, statuses and phase eyebrows — mono
+  doing exactly what the rule two sections up reserves it for — so the face is
+  still referenced, stays declared, and keeps its embed. A tracker therefore
+  lands at ~430KB, slightly *above* where it started, because the metric
+  fallback goes in on top. An earlier pass reported ~19KB instead; it got there
+  by rewriting every mono run in `word/document.xml` to the sans, which read
+  205 metadata runs as body prose and flattened the distinction this system is
+  built on. Size is not the thing being optimised here.
   The embedded bytes cannot simply be renamed along with the entry: they *are*
   Manrope, and calling them Instrument Sans makes Word render the old face
   under the new name, which is worse than substituting. **Instrument Sans is

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,18 +82,25 @@ Three things about it are worth knowing before editing:
   carrying their bytes — which is where the trackers ended up. `prune_embedded_
   fonts` reconciles the table against what the document actually references and
   drops the orphans: a tracker sheds Arial, Georgia, Manrope and Space Grotesk
-  from its table and the four Manrope/Space Grotesk faces (~180KB) from
-  `word/fonts/`.
+  from its table, and the four Manrope/Space Grotesk faces from `word/fonts/` —
+  measured, 153,600 bytes in the zip (~321KB unpacked), taking the file
+  394,482 → 240,252.
   **JetBrains Mono is not among them, and that is the point of reconciling
   against usage rather than against a drop-list.** A tracker's 205 mono runs are
   its field labels, table headers, dates, statuses and phase eyebrows — mono
-  doing exactly what the rule two sections up reserves it for — so the face is
-  still referenced, stays declared, and keeps its embed. A tracker therefore
-  lands at ~430KB, slightly *above* where it started, because the metric
-  fallback goes in on top. An earlier pass reported ~19KB instead; it got there
-  by rewriting every mono run in `word/document.xml` to the sans, which read
-  205 metadata runs as body prose and flattened the distinction this system is
-  built on. Size is not the thing being optimised here.
+  doing exactly what the "metadata and eyebrows" rule under *What the system
+  actually says* reserves it for — so the face is still referenced, stays
+  declared, and keeps its embed.
+
+  A tracker therefore lands at **~430KB, slightly *above* where it started**,
+  because `ensure_fallback_font` adds the metric fallback on top: that pass
+  alone is ~186KB of the total, so most of the gap is Manrope rather than mono.
+  Treat ~430KB as soft — the fallback's two TTFs are written STORED, and
+  deflating them would drop ~106KB and stale every copy of this number at once.
+  An earlier pass reported ~19KB instead; it got there by rewriting every mono
+  run in `word/document.xml` to the sans, which read 205 metadata runs as body
+  prose and flattened the distinction this system is built on. Size is not the
+  thing being optimised here.
   The embedded bytes cannot simply be renamed along with the entry: they *are*
   Manrope, and calling them Instrument Sans makes Word render the old face
   under the new name, which is worse than substituting. **Instrument Sans is

--- a/lib/aaif_events/ooxml_style.py
+++ b/lib/aaif_events/ooxml_style.py
@@ -33,6 +33,7 @@ import hashlib
 import os
 import re
 import zipfile
+from typing import NamedTuple, Sequence
 
 #: `design/aaif-tokens.css`, which is itself generated from the design system
 #: bundle by `scripts/extract_design_tokens.py`. Parsing it — rather than
@@ -79,8 +80,19 @@ def token(name):
 #: One family, per the design system: "There is no second display face."
 SANS = "Instrument Sans"
 #: A PPTX cannot express a font *stack*, so the system names JetBrains Mono for
-#: the metadata runs that resolve to `--font-mono` on the web. It stays — but
-#: only for metadata. See `_MONO_IS_PROSE` below.
+#: the metadata runs that resolve to `--font-mono` on the web. It stays, in
+#: every part and both formats: DESIGN.md reserves mono for "metadata and
+#: eyebrows", and a run already set in it is that reservation being honoured,
+#: not drift. It is absent from `FONT_MAP` for the same reason `+mj-lt` is.
+#:
+#: An earlier pass demoted mono to the sans throughout `word/document.xml`, on
+#: the reading that the trackers' 205 mono runs were body prose. They were not:
+#: every one is a field label (EVENT TITLE, DATE & TIME), a table header
+#: (TASK/OWNER/DUE/STATUS), a date, a status, or a phase eyebrow ("4 WEEKS OUT
+#: May 27 · lock the basics"). The trackers' actual prose was already in the
+#: sans. The rule flattened the one thing mono is for, so it is gone — but see
+#: the note in `prune_embedded_fonts`, which the removal puts back on its
+#: other branch.
 MONO = "JetBrains Mono"
 
 #: Every face found across the estate that is not one of the two above. Calibri
@@ -108,12 +120,6 @@ FONT_MAP = {
 # font, not a face. It is absent from FONT_MAP on purpose — such a run is
 # already correct once the theme is, and rewriting it to a literal would break
 # the indirection the theme exists to provide.
-
-#: Parts where JetBrains Mono is carrying body prose rather than metadata, and
-#: so must become Instrument Sans. The design system is explicit: "Mono carries
-#: metadata, not prose." The trackers set 205 body runs in mono; a deck's mono
-#: runs are eyebrows, dates and cities, which are exactly what it is for.
-_MONO_IS_PROSE = ("word/document.xml",)
 
 
 # ------------------------------------------------------------------- colour --
@@ -327,21 +333,14 @@ def _restyle_pptx(xml, part_name):
 _DOCX_BORDER_CTX = ("w:tcBorders", "w:pBdr", "w:tblBorders")
 
 
-def _restyle_docx(xml, part_name):
-    mono_to_sans = part_name in _MONO_IS_PROSE
-
-    def face(f):
-        if f == MONO:
-            return SANS if mono_to_sans else None
-        return FONT_MAP.get(f)
-
+def _restyle_docx(xml):
     def handler(tag, attrs, stack):
         if tag == "w:rFonts":
             new = attrs
             for a in ("w:ascii", "w:hAnsi", "w:cs", "w:eastAsia"):
                 cur = _attr(new, a)
                 if cur:
-                    repl = face(cur)
+                    repl = FONT_MAP.get(cur)
                     if repl:
                         new = _rewrite_attr(new, a, repl)
             return new
@@ -471,11 +470,9 @@ def restyle_part(part_name, data):
     if (_PPTX_PARTS.match(part_name) or part_name in _PPTX_SINGLETONS
             or re.match(r"ppt/theme/theme\d+\.xml$", part_name)):
         out = _restyle_pptx(xml, part_name)
-    elif part_name in ("word/document.xml", "word/styles.xml",
-                       "word/header1.xml", "word/footer1.xml"):
-        out = _restyle_docx(xml, part_name)
-    elif re.match(r"word/(header|footer)\d+\.xml$", part_name):
-        out = _restyle_docx(xml, part_name)
+    elif (part_name in ("word/document.xml", "word/styles.xml")
+            or re.match(r"word/(header|footer)\d+\.xml$", part_name)):
+        out = _restyle_docx(xml)
     elif re.match(r"word/theme/theme\d+\.xml$", part_name):
         out = _restyle_word_theme(xml)
     elif part_name == "xl/styles.xml":
@@ -844,9 +841,9 @@ def improve_contrast(path):
     failure COUNT need not drop: a rescue from 1.19 to 4.48 against a 4.50
     threshold is real and leaves that count unchanged.
 
-    Returns `(rescued, before, after)`, where `before`/`after` count runs
-    failing AA and `rescued` counts runs **materially improved** — an AA
-    crossing, or an escape from the invisible band to at least `AA_LARGE`.
+    Returns a `Rescued`, whose `before`/`after` count runs failing AA and
+    whose `runs` counts those **materially improved** — an AA crossing, or an
+    escape from the invisible band to at least `AA_LARGE`.
 
     Those are two different numbers on purpose. A slide can be genuinely
     repaired without any AA crossing: lifting footer text from 1.19 to 4.48
@@ -860,7 +857,7 @@ def improve_contrast(path):
     before = [f for f in ct.check_pptx(path)
               if f.ratio is not None and f.ratio < f.threshold]
     if not before:
-        return 0, 0, 0
+        return Rescued()
 
     failing_parts = {f.part for f in before}
 
@@ -935,7 +932,7 @@ def improve_contrast(path):
                 os.remove(trial)
 
     if not keep:
-        return 0, len(before), len(before)
+        return Rescued(0, len(before), len(before))
 
     _rewrite_zip_to(path, path + ".new",
                     lambda n, d: (to_on_dark(d.decode("utf-8")).encode("utf-8")
@@ -957,7 +954,7 @@ def improve_contrast(path):
 
     after_all = [f for f in ct.check_pptx(path)
                  if f.ratio is not None and f.ratio < f.threshold]
-    return rescued, len(before), len(after_all)
+    return Rescued(rescued, len(before), len(after_all))
 
 
 def _rewrite_zip_to(src, dst, transform, drop=(), add=None):
@@ -1018,13 +1015,44 @@ _EMBED = re.compile(r"<w:embed(?:Regular|Bold|Italic|BoldItalic)\b[^>]*/>")
 _EMBED_ID = re.compile(r'r:id="([^"]+)"')
 
 
+class Pruned(NamedTuple):
+    """What `prune_embedded_fonts` took out of `word/fontTable.xml`.
+
+    A plain 2-tuple here was read positionally at three call sites and printed
+    through `report["pruned"][0]`, which is a truth test on a *list of face
+    names* — legible only if you already know the order. Named, `pruned.faces`
+    says what the index meant.
+    """
+    #: Face names dropped from the table.
+    faces: Sequence = ()
+    #: `word/fonts/*.ttf` parts dropped with them.
+    parts: Sequence = ()
+
+
+class Rescued(NamedTuple):
+    """What `improve_contrast` did to one file's legibility.
+
+    `runs` is deliberately not derivable from `before - after`: a run lifted
+    from 1.19 to 4.48 against a 4.50 threshold is materially rescued and leaves
+    the AA count unchanged. `report.get("rescued", (0,))[0]` was the reporting
+    gate for exactly that number, and nothing about the expression said so.
+    """
+    #: Runs materially improved — an AA crossing, or an escape from the
+    #: invisible band to at least `AA_LARGE`.
+    runs: int = 0
+    #: Runs failing AA before the repair.
+    before: int = 0
+    #: Runs failing AA after it.
+    after: int = 0
+
+
 def prune_embedded_fonts(path):
     """Make `word/fontTable.xml` agree with the faces the document actually uses.
 
     Reconciled against USAGE, not just against the rename map: an entry is
     dropped when its face was renamed away *or* when no content part references
-    it any more. Both happen here — `_MONO_IS_PROSE` rewrites mono body prose
-    to the sans, so JetBrains Mono stops being used at all.
+    it any more. The second case is the one the rename map cannot see — a face
+    the estate declares and embeds but no run asks for.
 
     Renaming every face to Instrument Sans leaves a tracker in a worse state
     than it started: the document references a font the file does not embed,
@@ -1038,26 +1066,30 @@ def prune_embedded_fonts(path):
     the table is deduplicated to the faces actually in use.
 
     That does mean the trackers no longer carry an embedded copy of their
-    typeface. Instrument Sans is not embeddable from here — `assets/fonts` has
+    display typeface. Instrument Sans is not embeddable from here — `assets/fonts` has
     woff2, which OOXML cannot use — so this is honest rather than complete:
     correct metadata and a smaller file, and the face resolves from the system
     (Google Docs, where these live, has it). See DESIGN.md.
 
-    Returns (faces removed, parts dropped).
+    Returns a `Pruned`.
     """
     with zipfile.ZipFile(path) as z:
         names = set(z.namelist())
         if "word/fontTable.xml" not in names:
-            return [], []
+            return Pruned()
         table = z.read("word/fontTable.xml").decode("utf-8", "replace")
         rels_name = "word/_rels/fontTable.xml.rels"
         rels = z.read(rels_name).decode("utf-8", "replace") if rels_name in names else ""
         # What the document ACTUALLY asks for. Deduping by mapped name alone
-        # leaves a face declared and embedded that nothing references: mono
-        # body prose is rewritten to the sans by `_MONO_IS_PROSE`, so a tracker
-        # kept JetBrains Mono in its table and shipped 443KB of it while using
-        # it zero times. The table has to be reconciled against usage, which is
-        # what this function's name has always claimed.
+        # leaves a face declared and embedded that nothing references — every
+        # tracker declared Space Grotesk and Manrope after the rename folded
+        # both into Instrument Sans, and shipped their bytes with it. The table
+        # has to be reconciled against usage, which is what this function's
+        # name has always claimed.
+        #
+        # JetBrains Mono is the case that goes the OTHER way and is why this is
+        # usage-driven rather than a drop-list: the trackers' metadata runs
+        # genuinely are set in it, so it stays declared and stays embedded.
         in_use = set()
         for n in names:
             if not n.startswith("word/") or n.endswith("fontTable.xml"):
@@ -1126,7 +1158,7 @@ def prune_embedded_fonts(path):
             new_rels = new_rels.replace(rm.group(0), "")
 
     if not removed and not parts:
-        return [], []
+        return Pruned()
 
     def tx(name, data):
         if name == "word/fontTable.xml":
@@ -1143,7 +1175,7 @@ def prune_embedded_fonts(path):
 
     _rewrite_zip_to(path, path + ".new", tx, drop=set(parts))
     os.replace(path + ".new", path)
-    return sorted(set(removed)), sorted(parts)
+    return Pruned(tuple(sorted(set(removed))), tuple(sorted(parts)))
 
 
 # ------------------------------------------------- retiring a legacy plate ----

--- a/lib/aaif_events/ooxml_style.py
+++ b/lib/aaif_events/ooxml_style.py
@@ -33,7 +33,7 @@ import hashlib
 import os
 import re
 import zipfile
-from typing import NamedTuple, Sequence
+from typing import NamedTuple
 
 #: `design/aaif-tokens.css`, which is itself generated from the design system
 #: bundle by `scripts/extract_design_tokens.py`. Parsing it — rather than
@@ -83,7 +83,10 @@ SANS = "Instrument Sans"
 #: the metadata runs that resolve to `--font-mono` on the web. It stays, in
 #: every part and both formats: DESIGN.md reserves mono for "metadata and
 #: eyebrows", and a run already set in it is that reservation being honoured,
-#: not drift. It is absent from `FONT_MAP` for the same reason `+mj-lt` is.
+#: not drift. It is absent from `FONT_MAP` for the same reason `+mj-lt` is —
+#: neither is drift — though not by the same mechanism: `+mj-lt` is a theme
+#: reference that resolves correctly once the theme does, while mono is a
+#: literal face the system deliberately keeps.
 #:
 #: An earlier pass demoted mono to the sans throughout `word/document.xml`, on
 #: the reading that the trackers' 205 mono runs were body prose. They were not:
@@ -120,6 +123,38 @@ FONT_MAP = {
 # font, not a face. It is absent from FONT_MAP on purpose — such a run is
 # already correct once the theme is, and rewriting it to a literal would break
 # the indirection the theme exists to provide.
+
+
+# ---------------------------------------------------------------- records --
+class Pruned(NamedTuple):
+    """What `prune_embedded_fonts` took out of `word/fontTable.xml`.
+
+    A plain 2-tuple here was read positionally at three call sites and printed
+    through `report["pruned"][0]`, which is a truth test on a *list of face
+    names* — legible only if you already know the order. Named, `pruned.faces`
+    says what the index meant.
+    """
+    #: Face names dropped from the table.
+    faces: tuple = ()
+    #: `word/fonts/*.ttf` parts dropped with them.
+    parts: tuple = ()
+
+
+class Rescued(NamedTuple):
+    """What `improve_contrast` did to one file's legibility.
+
+    `runs` is deliberately not derivable from `before - after`: a run lifted
+    from 1.19 to 4.48 against a 4.50 threshold is materially rescued and leaves
+    the AA count unchanged. `report.get("rescued", (0,))[0]` was the reporting
+    gate for exactly that number, and nothing about the expression said so.
+    """
+    #: Runs materially improved — an AA crossing, or an escape from the
+    #: invisible band to at least `AA_LARGE`.
+    runs: int = 0
+    #: Runs failing AA before the repair.
+    before: int = 0
+    #: Runs failing AA after it.
+    after: int = 0
 
 
 # ------------------------------------------------------------------- colour --
@@ -1015,37 +1050,6 @@ _EMBED = re.compile(r"<w:embed(?:Regular|Bold|Italic|BoldItalic)\b[^>]*/>")
 _EMBED_ID = re.compile(r'r:id="([^"]+)"')
 
 
-class Pruned(NamedTuple):
-    """What `prune_embedded_fonts` took out of `word/fontTable.xml`.
-
-    A plain 2-tuple here was read positionally at three call sites and printed
-    through `report["pruned"][0]`, which is a truth test on a *list of face
-    names* — legible only if you already know the order. Named, `pruned.faces`
-    says what the index meant.
-    """
-    #: Face names dropped from the table.
-    faces: Sequence = ()
-    #: `word/fonts/*.ttf` parts dropped with them.
-    parts: Sequence = ()
-
-
-class Rescued(NamedTuple):
-    """What `improve_contrast` did to one file's legibility.
-
-    `runs` is deliberately not derivable from `before - after`: a run lifted
-    from 1.19 to 4.48 against a 4.50 threshold is materially rescued and leaves
-    the AA count unchanged. `report.get("rescued", (0,))[0]` was the reporting
-    gate for exactly that number, and nothing about the expression said so.
-    """
-    #: Runs materially improved — an AA crossing, or an escape from the
-    #: invisible band to at least `AA_LARGE`.
-    runs: int = 0
-    #: Runs failing AA before the repair.
-    before: int = 0
-    #: Runs failing AA after it.
-    after: int = 0
-
-
 def prune_embedded_fonts(path):
     """Make `word/fontTable.xml` agree with the faces the document actually uses.
 
@@ -1056,8 +1060,11 @@ def prune_embedded_fonts(path):
 
     Renaming every face to Instrument Sans leaves a tracker in a worse state
     than it started: the document references a font the file does not embed,
-    the font table still declares the faces nobody uses any more, and ~760KB of
-    embedded TTFs for those faces ride along in every copy.
+    the font table still declares the faces nobody uses any more, and their
+    embedded TTFs ride along in every copy — ~321KB unpacked (~154KB in the
+    zip) across Manrope and Space Grotesk. (~760KB is the total of ALL the
+    embedded faces in a tracker; most of that is JetBrains Mono, which is in
+    use and stays.)
 
     The embeds cannot simply be renamed with the entries — their BYTES are
     Manrope and Space Grotesk, so calling them "Instrument Sans" would make
@@ -1066,10 +1073,15 @@ def prune_embedded_fonts(path):
     the table is deduplicated to the faces actually in use.
 
     That does mean the trackers no longer carry an embedded copy of their
-    display typeface. Instrument Sans is not embeddable from here — `assets/fonts` has
-    woff2, which OOXML cannot use — so this is honest rather than complete:
-    correct metadata and a smaller file, and the face resolves from the system
-    (Google Docs, where these live, has it). See DESIGN.md.
+    display typeface. Instrument Sans is not embeddable from here —
+    `assets/fonts` has woff2, which OOXML cannot use — so this is honest rather
+    than complete: correct metadata, and the face resolves from the system
+    (Google Docs, where these live, has it).
+
+    This pass alone makes the file smaller, but the sweep as a whole does not:
+    `ensure_fallback_font` adds the metric fallback afterwards, and a tracker
+    lands ABOVE where it started. See DESIGN.md — size is not what is being
+    optimised here.
 
     Returns a `Pruned`.
     """

--- a/lib/aaif_events/tests/test_ooxml_style.py
+++ b/lib/aaif_events/tests/test_ooxml_style.py
@@ -15,6 +15,7 @@ is no way to see that except by opening the file.
 relationship ids; the engine's whole premise is that it edits attributes in
 place and copies everything else through untouched.
 """
+import collections
 import os
 import re
 import zipfile
@@ -263,13 +264,24 @@ def test_the_shipped_fixtures_are_conformant(name):
     """The repo's only OOXML assets, and therefore the CI gate: if these drift
     off the design system, this fails in review rather than months later.
 
-    Note what they CANNOT catch: both were captured after a sweep that demoted
-    every mono run to the sans, so neither holds a single JetBrains Mono run
-    any more. They are ~19KB each because of it. A fixture that did would be
-    ~430KB — the four mono faces stay embedded once the face is in use — which
-    is not worth carrying twice in a public repo, so mono preservation is
-    pinned by `test_mono_survives_the_sweep_in_every_word_part` on synthetic
-    XML instead."""
+    Note what they CANNOT catch. Both were captured after a sweep that demoted
+    every mono run to the sans, so neither holds a single JetBrains Mono run —
+    and neither holds any `word/fonts/` part at all. They are ~19KB each
+    because of both absences, and a realistic tracker is ~430KB, which is not
+    worth carrying twice in a public repo. So:
+
+    * **mono preservation** is pinned by
+      `test_mono_survives_the_sweep_in_every_word_part` on synthetic XML, and
+      the embed that follows from it by
+      `test_a_face_in_use_keeps_its_declaration_and_its_embed`;
+    * **`ensure_fallback_font` is not covered here either** — this test calls
+      only `audit()`. Running the fallback pass on a shipped fixture takes it
+      19,769 -> 210,090 bytes on its own, so ~186KB of that ~430KB is Manrope,
+      not mono. Do not read the size gap as a mono figure.
+
+    The ~430KB is also softer than it looks: `ensure_fallback_font` writes its
+    two TTFs STORED, so deflating them would drop ~106KB and stale every
+    "~430KB" in this repo at once."""
     path = os.path.join(FIXTURES, name)
     assert ox.audit(path) == [], "off-system values in %s: %s" % (name, ox.audit(path))
 
@@ -282,6 +294,68 @@ def test_restyling_a_conformant_fixture_changes_nothing(name, tmp_path):
         for part in z.namelist():
             data = z.read(part)
             assert ox.restyle_part(part, data) == data, "%s/%s changed" % (name, part)
+
+
+def _parts(path):
+    with zipfile.ZipFile(path) as z:
+        for n in z.namelist():
+            yield n, z.read(n)
+
+
+def _replace_part(path, name, data):
+    """Rewrite one part in place, preserving every other byte."""
+    with zipfile.ZipFile(path) as z:
+        items = [(i, z.read(i.filename)) for i in z.infolist()]
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        for info, blob in items:
+            z.writestr(info, data if info.filename == name else blob)
+
+
+def test_a_real_tracker_keeps_its_mono_through_the_whole_pipeline(tmp_path):
+    """End to end over the actual pre-sweep tracker, not synthetic XML.
+
+    The unit tests pin restyle and prune separately; this pins the INTERACTION,
+    which is where removing `_MONO_IS_PROSE` actually has to hold up: restyle
+    must leave the 205 metadata runs alone, prune must then see the face as
+    in-use and keep its four embeds, and the fallback pass must not undo
+    either. The shipped fixtures cannot serve here — they are post-flattening
+    and hold no mono — so this reads the pre-sweep copy out of git.
+    """
+    import subprocess
+    blob = subprocess.run(
+        ["git", "show", "78a6599:lib/aaif_events/tests/fixtures/event_tracker_irl.docx"],
+        cwd=os.path.dirname(FIXTURES), capture_output=True)
+    if blob.returncode != 0 or not blob.stdout:
+        pytest.skip("pre-sweep tracker not reachable from this checkout")
+    path = str(tmp_path / "tracker.docx")
+    with open(path, "wb") as fh:
+        fh.write(blob.stdout)
+
+    def _faces(p_):
+        with zipfile.ZipFile(p_) as z:
+            xml = z.read("word/document.xml").decode("utf-8", "replace")
+        return collections.Counter(re.findall(r'w:ascii="([^"]+)"', xml))
+
+    assert _faces(path)[ox.MONO] == 205, "the pre-sweep tracker changed shape"
+
+    for name, data in list(_parts(path)):
+        out = ox.restyle_part(name, data)
+        if out is not data:
+            _replace_part(path, name, out)
+    pruned = ox.prune_embedded_fonts(path)
+    ox.ensure_fallback_font(path)
+
+    after = _faces(path)
+    assert after[ox.MONO] == 205, "restyle flattened the metadata runs"
+    assert ox.SANS in after, "the display drift was not folded into the sans"
+    assert "Space Grotesk" not in after and "Manrope" not in after
+    # In use, so neither the table entry nor the embeds may be pruned.
+    assert ox.MONO not in pruned.faces, "the in-use face was pruned"
+    with zipfile.ZipFile(path) as z:
+        names = z.namelist()
+    assert [n for n in names if "JetBrainsMono" in n], "the in-use embeds went"
+    assert not [n for n in names if "SpaceGrotesk" in n]
+    assert ox.audit(path) == [], "the swept tracker is still off-system"
 
 
 # ------------------------------------------------------- plate slides --------
@@ -651,9 +725,64 @@ def test_the_renamed_faces_embedded_bytes_are_dropped_not_relabelled(tmp_path):
     assert parts == ("word/fonts/Manrope.ttf", "word/fonts/SpaceGrotesk.ttf")
     with zipfile.ZipFile(deck) as z:
         names = z.namelist()
-        assert "word/fonts/JetBrainsMono.ttf" in names     # still used, kept
+        # Kept — but NOT because it is in use: this fixture's document.xml
+        # names no faces at all, so `in_use` is empty and the no-evidence
+        # escape hatch keeps everything. The usage-driven retention that the
+        # real trackers rely on is pinned by
+        # `test_a_face_in_use_keeps_its_declaration_and_its_embed` below.
+        assert "word/fonts/JetBrainsMono.ttf" in names
         assert "word/fonts/Manrope.ttf" not in names
         assert "Manrope.ttf" not in z.read("[Content_Types].xml").decode()
+
+
+def test_a_face_in_use_keeps_its_declaration_and_its_embed(tmp_path):
+    """The direction the real trackers take, and the one nothing tested.
+
+    Removing `_MONO_IS_PROSE` means a tracker's 205 metadata runs stay in
+    JetBrains Mono, so the face is genuinely referenced and its four embedded
+    TTFs (~444KB unpacked) must survive the prune. The other mono test above
+    cannot show this — its document names no faces, so mono survives there for
+    the opposite reason. This one references mono AND embeds it, which is the
+    combination a real tracker has.
+    """
+    path = str(tmp_path / "in-use.docx")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml",
+                   '<Types xmlns="ct"><Override ContentType="font" '
+                   'PartName="/word/fonts/JetBrainsMono.ttf"/><Override '
+                   'ContentType="font" PartName="/word/fonts/Manrope.ttf"/></Types>')
+        # Both faces named by real runs; only Manrope is unreferenced.
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="Instrument Sans"/></w:rPr></w:r>'
+                   '<w:r><w:rPr><w:rFonts w:ascii="JetBrains Mono" '
+                   'w:hAnsi="JetBrains Mono"/></w:rPr></w:r></w:document>')
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="Instrument Sans"/>'
+                   '<w:font w:name="JetBrains Mono">'
+                   '<w:embedRegular r:id="rId1"/></w:font>'
+                   '<w:font w:name="Manrope"><w:embedRegular r:id="rId2"/>'
+                   '</w:font></w:fonts>')
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">'
+                   '<Relationship Id="rId1" Type="font" '
+                   'Target="fonts/JetBrainsMono.ttf"/>'
+                   '<Relationship Id="rId2" Type="font" '
+                   'Target="fonts/Manrope.ttf"/></Relationships>')
+        z.writestr("word/fonts/JetBrainsMono.ttf", b"JBM" * 200)
+        z.writestr("word/fonts/Manrope.ttf", b"MNR" * 200)
+
+    pruned = ox.prune_embedded_fonts(path)
+    # The unused face goes; the one in use does not.
+    assert pruned.faces == ("Manrope",)
+    assert pruned.parts == ("word/fonts/Manrope.ttf",)
+    with zipfile.ZipFile(path) as z:
+        names, table = z.namelist(), z.read("word/fontTable.xml").decode()
+        assert "word/fonts/JetBrainsMono.ttf" in names, "the in-use embed was pruned"
+        assert ox.MONO in table, "the in-use face lost its declaration"
+        assert "word/fonts/Manrope.ttf" not in names
 
 
 def test_no_embed_reference_is_left_dangling(tmp_path):
@@ -743,9 +872,9 @@ def test_a_face_nothing_references_is_dropped_even_if_it_was_not_renamed(tmp_pat
     can go unreferenced without the rename map ever naming it. The document
     below asks only for Instrument Sans, so the mono entry and its embed go.
 
-    See `test_the_renamed_faces_embedded_bytes_are_dropped_not_relabelled` for
-    the other direction — the real trackers DO reference mono, and there its
-    embed must survive."""
+    See `test_a_face_in_use_keeps_its_declaration_and_its_embed` for the other
+    direction — the real trackers DO reference mono, and there its embed must
+    survive."""
     path = str(tmp_path / "u.docx")
     with zipfile.ZipFile(path, "w") as z:
         z.writestr("[Content_Types].xml",

--- a/lib/aaif_events/tests/test_ooxml_style.py
+++ b/lib/aaif_events/tests/test_ooxml_style.py
@@ -198,18 +198,35 @@ def test_word_keeps_the_files_own_lowercase_hex():
     assert ox.token("ink-3") not in out       # not the uppercase form
 
 
-def test_mono_body_prose_becomes_the_sans():
-    """"Mono carries metadata, not prose" — and the trackers set 205 body runs
-    in JetBrains Mono."""
+@pytest.mark.parametrize("part", ["word/document.xml", "word/styles.xml",
+                                  "word/header1.xml", "word/footer2.xml"])
+def test_mono_survives_the_sweep_in_every_word_part(part):
+    """DESIGN.md reserves mono for "metadata and eyebrows", so a run already
+    set in it is the rule being honoured, not drift — in the body like anywhere.
+
+    An earlier pass demoted mono to the sans in `word/document.xml` alone, on
+    the reading that the trackers' 205 mono runs were body prose. Every one of
+    them is a field label, a table header, a date, a status or a phase eyebrow;
+    the prose was already in the sans. `word/document.xml` is parametrized
+    FIRST here because it is the part that regressed.
+    """
     xml = _docx('<w:rPr><w:rFonts w:ascii="JetBrains Mono" w:hAnsi="JetBrains Mono"/></w:rPr>')
+    data = xml.encode()
+    out = ox.restyle_part(part, data)
+    # Byte-identical, not merely mono-preserving: the sweep uses "did the bytes
+    # change" as its upload test, so a tracker whose only non-sans face is mono
+    # must not be re-uploaded at all.
+    assert out is data
+    assert ox.MONO in out.decode() and ox.SANS not in out.decode()
+
+
+def test_the_faces_around_mono_still_move():
+    """The parametrized test above passes trivially if the docx pass stopped
+    rewriting fonts altogether. Pin that it did not."""
+    xml = _docx('<w:rPr><w:rFonts w:ascii="Space Grotesk" w:hAnsi="Consolas"/></w:rPr>')
     out = ox.restyle_part("word/document.xml", xml.encode()).decode()
-    assert ox.MONO not in out and out.count(ox.SANS) == 2
-
-
-def test_mono_is_kept_outside_the_body():
-    xml = _docx('<w:rPr><w:rFonts w:ascii="JetBrains Mono"/></w:rPr>')
-    out = ox.restyle_part("word/styles.xml", xml.encode()).decode()
-    assert ox.MONO in out
+    assert 'w:ascii="%s"' % ox.SANS in out      # display drift -> the sans
+    assert 'w:hAnsi="%s"' % ox.MONO in out      # a metadata face -> the mono
 
 
 # --------------------------------------------------------------- invariants --
@@ -244,7 +261,15 @@ def test_the_scanner_preserves_every_other_byte():
 @pytest.mark.parametrize("name", ["event_tracker_irl.docx", "event_tracker_online.docx"])
 def test_the_shipped_fixtures_are_conformant(name):
     """The repo's only OOXML assets, and therefore the CI gate: if these drift
-    off the design system, this fails in review rather than months later."""
+    off the design system, this fails in review rather than months later.
+
+    Note what they CANNOT catch: both were captured after a sweep that demoted
+    every mono run to the sans, so neither holds a single JetBrains Mono run
+    any more. They are ~19KB each because of it. A fixture that did would be
+    ~430KB — the four mono faces stay embedded once the face is in use — which
+    is not worth carrying twice in a public repo, so mono preservation is
+    pinned by `test_mono_survives_the_sweep_in_every_word_part` on synthetic
+    XML instead."""
     path = os.path.join(FIXTURES, name)
     assert ox.audit(path) == [], "off-system values in %s: %s" % (name, ox.audit(path))
 
@@ -418,7 +443,7 @@ def test_the_repair_leaves_a_light_slide_alone(tmp_path):
     deck = _ct_deck(tmp_path, [(tc.SOLID_WHITE, [tc._run("BODY", "0A0A0A")])])
     with zipfile.ZipFile(deck) as z:
         before = z.read("ppt/slides/slide1.xml")
-    assert ox.improve_contrast(deck) == (0, 0, 0)
+    assert ox.improve_contrast(deck) == ox.Rescued()
     with zipfile.ZipFile(deck) as z:
         assert z.read("ppt/slides/slide1.xml") == before
 
@@ -452,7 +477,7 @@ def test_a_small_drop_inside_the_passing_band_does_not_block_the_repair(tmp_path
 def test_a_clean_deck_is_not_rewritten(tmp_path):
     from aaif_events.tests import test_contrast as tc
     deck = _ct_deck(tmp_path, [(tc.SOLID_WHITE, [tc._run("BODY", "0A0A0A", size=2400)])])
-    assert ox.improve_contrast(deck) == (0, 0, 0)
+    assert ox.improve_contrast(deck) == ox.Rescued()
 
 
 def test_escaping_the_invisible_band_counts_even_without_an_aa_crossing(tmp_path):
@@ -602,7 +627,7 @@ def _docx_with_fonts(tmp_path, name="f.docx"):
 def test_the_font_table_ends_up_declaring_only_the_faces_in_use(tmp_path):
     deck = _docx_with_fonts(tmp_path)
     removed, parts = ox.prune_embedded_fonts(deck)
-    assert removed == ["Arial", "Georgia", "Manrope", "Space Grotesk"]
+    assert removed == ("Arial", "Georgia", "Manrope", "Space Grotesk")
     with zipfile.ZipFile(deck) as z:
         table = z.read("word/fontTable.xml").decode()
     assert sorted(set(re.findall(r'w:name="([^"]+)"', table))) == \
@@ -623,7 +648,7 @@ def test_the_renamed_faces_embedded_bytes_are_dropped_not_relabelled(tmp_path):
     render the OLD face under the new name, which is worse than substituting."""
     deck = _docx_with_fonts(tmp_path)
     _r, parts = ox.prune_embedded_fonts(deck)
-    assert sorted(parts) == ["word/fonts/Manrope.ttf", "word/fonts/SpaceGrotesk.ttf"]
+    assert parts == ("word/fonts/Manrope.ttf", "word/fonts/SpaceGrotesk.ttf")
     with zipfile.ZipFile(deck) as z:
         names = z.namelist()
         assert "word/fonts/JetBrainsMono.ttf" in names     # still used, kept
@@ -649,7 +674,7 @@ def test_no_embed_reference_is_left_dangling(tmp_path):
 def test_pruning_is_idempotent(tmp_path):
     deck = _docx_with_fonts(tmp_path)
     ox.prune_embedded_fonts(deck)
-    assert ox.prune_embedded_fonts(deck) == ([], [])
+    assert ox.prune_embedded_fonts(deck) == ox.Pruned()
 
 
 def test_a_bad_repack_never_replaces_the_original(tmp_path):
@@ -714,10 +739,13 @@ def test_the_repair_will_not_push_readable_text_into_the_invisible_band(tmp_path
 
 
 def test_a_face_nothing_references_is_dropped_even_if_it_was_not_renamed(tmp_path):
-    """The table must agree with USAGE, not just with the rename map. Mono body
-    prose is rewritten to the sans, so JetBrains Mono stops being referenced at
-    all — and deduping by mapped name alone left it declared and shipping 443KB
-    of embedded faces in every tracker."""
+    """The table must agree with USAGE, not just with the rename map: a face
+    can go unreferenced without the rename map ever naming it. The document
+    below asks only for Instrument Sans, so the mono entry and its embed go.
+
+    See `test_the_renamed_faces_embedded_bytes_are_dropped_not_relabelled` for
+    the other direction — the real trackers DO reference mono, and there its
+    embed must survive."""
     path = str(tmp_path / "u.docx")
     with zipfile.ZipFile(path, "w") as z:
         z.writestr("[Content_Types].xml",
@@ -738,8 +766,8 @@ def test_a_face_nothing_references_is_dropped_even_if_it_was_not_renamed(tmp_pat
                    'Target="fonts/JetBrainsMono.ttf"/></Relationships>')
         z.writestr("word/fonts/JetBrainsMono.ttf", b"TTF" * 200)
     removed, parts = ox.prune_embedded_fonts(path)
-    assert removed == ["JetBrains Mono"]
-    assert parts == ["word/fonts/JetBrainsMono.ttf"]
+    assert removed == ("JetBrains Mono",)
+    assert parts == ("word/fonts/JetBrainsMono.ttf",)
     with zipfile.ZipFile(path) as z:
         assert "word/fonts/JetBrainsMono.ttf" not in z.namelist()
         assert "JetBrains Mono" not in z.read("word/fontTable.xml").decode()
@@ -756,7 +784,7 @@ def test_a_face_that_is_still_referenced_is_kept(tmp_path):
         z.writestr("word/fontTable.xml",
                    '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
                    '<w:font w:name="JetBrains Mono"/></w:fonts>')
-    assert ox.prune_embedded_fonts(path) == ([], [])
+    assert ox.prune_embedded_fonts(path) == ox.Pruned()
     with zipfile.ZipFile(path) as z:
         assert "JetBrains Mono" in z.read("word/fontTable.xml").decode()
 
@@ -954,7 +982,7 @@ def test_pruning_keeps_a_face_that_only_an_altname_references(tmp_path):
     the other re-adds it, and every sweep re-uploads every tracker forever."""
     deck = _docx_asking_for_the_sans(tmp_path, name="alt.docx")
     ox.ensure_fallback_font(deck)
-    assert ox.prune_embedded_fonts(deck) == ([], []), "the fallback was pruned"
+    assert ox.prune_embedded_fonts(deck) == ox.Pruned(), "the fallback was pruned"
     with zipfile.ZipFile(deck) as z:
         assert ox.FALLBACK_FACE in z.read("word/fontTable.xml").decode()
 

--- a/skills/aaif-create-chapter/scripts/restyle_design_system.py
+++ b/skills/aaif-create-chapter/scripts/restyle_design_system.py
@@ -61,7 +61,7 @@ import sys
 import tempfile
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
-from typing import NamedTuple, Sequence
+from typing import NamedTuple
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import create_chapter as cc      # Drive plumbing + the shared zip rewriter
@@ -141,10 +141,12 @@ class Estate(NamedTuple):
     chapters: set
     #: Likewise for online series.
     series: set
-    #: Chapters/series that hold Office files at all — the denominator for the
-    #: "contributed none" coverage check.
+    #: Owners that hold Office files at all — the denominator for the
+    #: "contributed none" coverage check. Chapters and series, plus the shared
+    #: Templates folder, which `walk_estate` also treats as an owner.
     with_files: set
-    #: Organizers' event copies, deliberately left alone.
+    #: COUNT of organizers' event copies passed over — not the files
+    #: themselves. They are deliberately left alone and never collected.
     skipped: int
     #: Files sitting in a template folder that are not templates.
     strays: list
@@ -158,44 +160,86 @@ class Changes(NamedTuple):
     * **`{}` meant "already conformant"**, so `if not report` was the whole
       clean/changed decision. Every optional key then had to be fetched with a
       `.get` and a default that re-stated the empty case — `report.get(
-      "rescued", (0,))[0]` — and one such default being subtly wrong is how a
-      file that HAD changed printed nothing. `reportable` names that decision
-      once, and every field has a real default, so no call site invents one.
+      "rescued", (0,))[0]` — and a wrong default there would make a file that
+      HAD changed print nothing. (No such bug shipped; the enumeration was
+      kept correct by hand every time it changed. The point is that keeping it
+      correct was the author's job and nothing checked it.) `conformant` names
+      that decision once, and every field has a real default, so no call site
+      invents one.
     * **positional sub-tuples**: `report["pruned"][0]` and
       `report.get("rescued", (0,))[0]` are truth tests on an unnamed slot.
       Those are `ox.Pruned` and `ox.Rescued` now, so they read
       `changes.pruned.faces` and `changes.rescued.runs`.
+
+    The two questions this record answers are deliberately different, and both
+    are properties so the difference stays visible side by side: `wrote` gates
+    the upload, `conformant` gates the reporting. A file can be written without
+    being off-system (a plate, a contrast repair), and can be worth reporting
+    without being written (`--check`, `--contrast`, an unrepairable deck).
     """
-    #: Off-system values found before the pass, and after it. Anything left in
-    #: `after` is drift `ooxml_style` has no rule for, and is reported.
-    before: Sequence = ()
-    after: Sequence = ()
+    #: Off-system values `ox.audit` found before the pass, and after it. On the
+    #: write path anything left in `after` is drift `ooxml_style` has no rule
+    #: for. Under `--check` nothing is rewritten, so `after` IS `before` and
+    #: carries drift the rules would have handled.
+    before: tuple = ()
+    after: tuple = ()
     #: Zip parts rewritten.
     parts: int = 0
-    #: Plate slides added or refreshed, by label.
-    plates: Sequence = ()
-    #: Legacy background images replaced.
-    retired: Sequence = ()
+    #: Plate slide labels added or refreshed. `str`, and ", ".join-ed by the
+    #: caller — hence `tuple` and not `Sequence`, which a bare string satisfies
+    #: and would silently join per character.
+    plates: tuple = ()
+    #: Paths of legacy background images replaced. Joined the same way.
+    retired: tuple = ()
     pruned: ox.Pruned = ox.Pruned()
     #: Whether the metric fallback font was embedded.
     fallback: bool = False
     rescued: ox.Rescued = ox.Rescued()
-    #: `--contrast` only: runs failing AA, and runs that could not be scored.
-    contrast: Sequence = ()
-    unchecked: Sequence = ()
+    #: `--contrast` only: checker findings failing AA, and findings that could
+    #: not be scored. Never added together — see `Legibility`.
+    contrast: tuple = ()
+    unchecked: tuple = ()
 
     @property
-    def reportable(self):
-        """Whether this file earns a line in the run's output.
+    def wrote(self):
+        """Whether the file's bytes actually changed — the upload/archive gate.
 
-        False means "already conformant, and nothing to say" — the old `{}`.
-        A file can be reportable without having been WRITTEN: `--check` and
-        `--contrast` both report without touching Drive.
+        Narrower than "worth reporting": an off-system file that no rule
+        matched is worth a line but was not written, and a deck whose
+        legibility could not be repaired was measured but not touched.
+
+        This predicate used to be spelled out inline in `process()`, ~300 lines
+        from the reporting one, sharing seven of its terms with nothing saying
+        why they differed — so adding a field meant remembering an
+        unrelated-looking `if`. That is the hazard this whole record exists to
+        remove, so the two now sit adjacent where the difference is reviewable.
         """
-        return bool(self.before or self.after or self.parts or self.plates
+        return bool(self.parts or self.plates or self.retired or self.fallback
+                    or self.pruned.faces or self.pruned.parts
+                    or self.rescued.runs)
+
+    @property
+    def conformant(self):
+        """Nothing was found and nothing was done — the old `{}`.
+
+        Named for the state rather than for the output, because it is not
+        quite "earns a line": a `--contrast` file with only UNCHECKED findings
+        is non-conformant here and the caller still folds it back into the
+        clean count. Naming it `reportable` made that look like a bug in the
+        caller rather than the deliberate narrowing it is.
+
+        `rescued.before` is in here and NOT in `wrote`, which is the whole
+        point of separating them: a deck with runs failing AA that
+        `improve_contrast` could not repair is untouched on disk and must
+        still be reported. Gating that on `rescued.runs` meant `--fix-contrast`
+        answered "already conformant" over a deck it had just measured as
+        unreadable.
+        """
+        return not (self.before or self.after or self.parts or self.plates
                     or self.retired or self.fallback or self.contrast
                     or self.unchecked or self.pruned.faces
-                    or self.pruned.parts or self.rescued.runs)
+                    or self.pruned.parts or self.rescued.runs
+                    or self.rescued.before)
 
 
 def walk_estate(root, jobs=8):
@@ -249,6 +293,26 @@ def walk_estate(root, jobs=8):
             seen_ids.add(f["id"])
             unique.append(f)
     return Estate(unique, chapters, series, with_files, skipped, sorted(strays))
+
+
+class Outcome(NamedTuple):
+    """One file's whole result: which file, what happened, what went wrong.
+
+    Named for the same reason its leaves were. It is also the return that
+    actually carries the ordering hazard the leaves only describe: `changes` is
+    empty on failure and indistinguishable from a clean file, so a caller that
+    tests `changes.conformant` before `error` counts every failure as clean and
+    prints nothing at all.
+
+    Python gives no way to make that order impossible without a sum type and an
+    `isinstance` at each call site, which buys little in a repo with no type
+    checker. What it does buy: `for r in pool.map(...)` reading `r.error` /
+    `r.changes` matches the `Synced` loop in `upload_agents.py`, so the two
+    near-identical worker loops in this codebase stop using two idioms.
+    """
+    entry: dict
+    changes: Changes = Changes()
+    error: str = None
 
 
 #: Characters kept when a Drive name becomes part of a local path. Everything
@@ -357,11 +421,11 @@ def _plates_for(entry, plate_dir):
 
 class Legibility(NamedTuple):
     """`contrast_report`'s two lists, which must never be added together."""
-    #: Runs measured as failing WCAG AA against what is behind them.
-    bad: Sequence = ()
-    #: Runs that could not be scored — an inherited colour, a translucent run,
-    #: a background the checker could not read. NOT failures.
-    unchecked: Sequence = ()
+    #: Findings measured as failing WCAG AA against what is behind them.
+    bad: tuple = ()
+    #: Findings that could not be scored — an inherited colour, a translucent
+    #: run, a background the checker could not read. NOT failures.
+    unchecked: tuple = ()
 
 
 def contrast_report(entry, src):
@@ -378,15 +442,20 @@ def contrast_report(entry, src):
     # distinction the checker is built around: inherited-colour runs are common,
     # so counting them as failures means --contrast can never exit 0 and its
     # exit status stops meaning anything.
-    return Legibility([f for f in found if f.ratio is not None and f.ratio < f.threshold],
-                      [f for f in found if f.ratio is None])
+    # Tuples, so a no-findings result actually equals `Legibility()`. Building
+    # these as lists made `contrast_report(clean_deck, src) == Legibility()`
+    # False against a `()` default, which fails as `[] != ()` and reads like a
+    # logic bug.
+    return Legibility(
+        tuple(f for f in found if f.ratio is not None and f.ratio < f.threshold),
+        tuple(f for f in found if f.ratio is None))
 
 
 def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
             contrast_only=False, fix_contrast=False, retire=False):
-    """Restyle one file. Returns `(entry, Changes, error or None)`.
+    """Restyle one file. Returns an `Outcome`.
 
-    The `Changes` is empty — `.reportable` False — when the file is already
+    The `Changes` is empty — `.conformant` True — when the file is already
     conformant and there is nothing to say about it. On error it is empty too,
     but the caller must test the error first: an empty record is indistinguish-
     able from a clean file, which is the point of returning the error beside it
@@ -408,13 +477,13 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
                                "not the template" % os.path.getsize(src))
         if contrast_only:
             legible = contrast_report(entry, src)
-            return entry, Changes(contrast=legible.bad,
-                                  unchecked=legible.unchecked), None
+            return Outcome(entry, Changes(contrast=legible.bad,
+                                          unchecked=legible.unchecked))
         before = ox.audit(src)
         if check_only:
             # `after` is `before`: nothing was rewritten, so what the file holds
             # afterwards is what it held.
-            return entry, Changes(before=before, after=before), None
+            return Outcome(entry, Changes(before=tuple(before), after=tuple(before)))
 
         # Archive BEFORE any rewrite: the archive must hold what Drive holds.
         # Gated on `write` ALONE, not on `before` — a file can be perfectly
@@ -434,9 +503,9 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
 
         parts = cc._rewrite_zip(src, ox.restyle_part)
         # Renaming the faces leaves a Word file referencing a font it does not
-        # embed, still declaring the faces nobody uses, and carrying ~760KB of
-        # their embedded bytes. Reconcile the font table with what the document
-        # now actually asks for.
+        # embed, still declaring the faces nobody uses, and carrying their
+        # embedded bytes (~321KB of Manrope and Space Grotesk). Reconcile the
+        # font table with what the document now actually asks for.
         pruned = (ox.prune_embedded_fonts(src)
                   if entry["mime"] == cc.DOCX else ox.Pruned())
         # Pruning leaves the document asking for a face it does not carry.
@@ -449,7 +518,7 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
         # from is already conformant — otherwise every new slide would carry a
         # copy of the drift this run just removed.
         wanted = _plates_for(entry, plate_dir)
-        plated = ox.add_plate_slides(src, wanted) if wanted else []
+        plated = list(ox.add_plate_slides(src, wanted)) if wanted else []
         # Adding is idempotent by label, so a deck that already has its plates
         # needs its ARTWORK refreshed separately when the art itself changes.
         plated += ox.update_plates(src, wanted) if wanted else []
@@ -472,25 +541,35 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
         rescued = (ox.improve_contrast(src)
                    if fix_contrast and entry["mime"] == cc.PPTX else ox.Rescued())
         after = ox.audit(src)
-        if not (parts or plated or rescued.runs or retired
-                or pruned.faces or pruned.parts or fallback):
-            # Nothing changed. If we archived a file we are not going to upload,
-            # take the copy back out so the archive means "these were replaced".
+        # Build the record FIRST and let it answer both questions. The
+        # "did anything change" test used to be spelled out here, ~300 lines
+        # from the near-identical reporting test on the record; see `wrote`.
+        changes = Changes(before=tuple(before), after=tuple(after), parts=parts,
+                          plates=tuple(plated), retired=tuple(retired),
+                          pruned=pruned, fallback=fallback, rescued=rescued)
+        if not changes.wrote:
+            # Nothing was written. If we archived a file we are not going to
+            # upload, take the copy back out so the archive keeps meaning
+            # "these were replaced".
             if fresh and archived and os.path.exists(archived):
                 os.remove(archived)
-            return entry, Changes(before=before, after=after), None
+            # `rescued` is carried even here, and this is the point of
+            # separating `wrote` from `conformant`: a deck whose failing runs
+            # `improve_contrast` declined to repair is untouched on disk but
+            # was MEASURED as unreadable, and dropping the record made
+            # --fix-contrast report it as already conformant.
+            return Outcome(entry, Changes(before=tuple(before), after=tuple(after),
+                                          rescued=rescued))
         if write:
             cc.gws_upload(entry["id"], src, entry["mime"])
-        return entry, Changes(before=before, after=after, parts=parts,
-                              plates=plated, retired=retired, pruned=pruned,
-                              fallback=fallback, rescued=rescued), None
+        return Outcome(entry, changes)
     except Exception as e:                # one bad file must not stop the run
         # Prefix the class: this catch spans the XML engine, the archive, and
         # both transfers, and a bare message makes a ValueError in the rewrite
         # read as a network blip. Never return a bare str() — an exception whose
         # str() is empty would be falsy and the caller would count the file as
         # clean, printing nothing at all.
-        return entry, Changes(), "%s: %s" % (type(e).__name__, str(e)[:200])
+        return Outcome(entry, error="%s: %s" % (type(e).__name__, str(e)[:200]))
     finally:
         if os.path.exists(src):
             os.remove(src)
@@ -618,19 +697,20 @@ def main():
     residue, unchecked_only = [], []
     with tempfile.TemporaryDirectory() as tmpdir, \
             ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        for entry, changes, err in pool.map(
+        for r in pool.map(
                 lambda e: process(e, tmpdir, args.write, backup_dir, args.check,
                                   args.plates, args.contrast, args.fix_contrast,
                                   args.retire),
                 entries):
+            entry, changes, err = r.entry, r.changes, r.error
             # The error first: a failed file also comes back with an empty
-            # record, so testing `reportable` before `err` would count every
+            # record, so testing `conformant` before `err` would count every
             # failure as clean and print nothing.
             if err is not None:
                 failed += 1
                 print("  FAILED  %s\n            %s" % (entry["path"], err))
                 continue
-            if not changes.reportable:
+            if changes.conformant:
                 clean += 1
                 continue
             changed += 1
@@ -678,6 +758,15 @@ def main():
                       "(%d below AA -> %d)"
                       % (changes.rescued.runs, changes.rescued.before,
                          changes.rescued.after))
+            elif changes.rescued.before:
+                # Measured unreadable, and the repair declined it — every
+                # candidate remap would have pushed some other run below AA or
+                # into the invisible band. Without this arm the deck falls out
+                # of the run silently, and --fix-contrast answers "already
+                # conformant" over text nobody can read.
+                print("                 ! legibility: %d run(s) below AA and "
+                      "NOT repairable without breaking others — needs a design "
+                      "fix, not a remap" % changes.rescued.before)
             if changes.after:
                 print("                 REMAINS: %s" % _summarise(changes.after))
 

--- a/skills/aaif-create-chapter/scripts/restyle_design_system.py
+++ b/skills/aaif-create-chapter/scripts/restyle_design_system.py
@@ -61,6 +61,7 @@ import sys
 import tempfile
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
+from typing import NamedTuple, Sequence
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import create_chapter as cc      # Drive plumbing + the shared zip rewriter
@@ -131,8 +132,74 @@ def is_template(name):
 PLATED = {"Event-Hero.pptx": "wide", "Event-Hero-Square.pptx": "square"}
 
 
+class Estate(NamedTuple):
+    """What one scan of Drive found. Six values; the docstring here used to
+    promise five, which is the failure mode a positional return invites."""
+    #: The OOXML files in scope, deduped by Drive id.
+    entries: list
+    #: Every chapter folder name seen, in scope or not.
+    chapters: set
+    #: Likewise for online series.
+    series: set
+    #: Chapters/series that hold Office files at all — the denominator for the
+    #: "contributed none" coverage check.
+    with_files: set
+    #: Organizers' event copies, deliberately left alone.
+    skipped: int
+    #: Files sitting in a template folder that are not templates.
+    strays: list
+
+
+class Changes(NamedTuple):
+    """What one file's pass actually did.
+
+    This was a bare dict, and the two habits it grew are why it is a record:
+
+    * **`{}` meant "already conformant"**, so `if not report` was the whole
+      clean/changed decision. Every optional key then had to be fetched with a
+      `.get` and a default that re-stated the empty case — `report.get(
+      "rescued", (0,))[0]` — and one such default being subtly wrong is how a
+      file that HAD changed printed nothing. `reportable` names that decision
+      once, and every field has a real default, so no call site invents one.
+    * **positional sub-tuples**: `report["pruned"][0]` and
+      `report.get("rescued", (0,))[0]` are truth tests on an unnamed slot.
+      Those are `ox.Pruned` and `ox.Rescued` now, so they read
+      `changes.pruned.faces` and `changes.rescued.runs`.
+    """
+    #: Off-system values found before the pass, and after it. Anything left in
+    #: `after` is drift `ooxml_style` has no rule for, and is reported.
+    before: Sequence = ()
+    after: Sequence = ()
+    #: Zip parts rewritten.
+    parts: int = 0
+    #: Plate slides added or refreshed, by label.
+    plates: Sequence = ()
+    #: Legacy background images replaced.
+    retired: Sequence = ()
+    pruned: ox.Pruned = ox.Pruned()
+    #: Whether the metric fallback font was embedded.
+    fallback: bool = False
+    rescued: ox.Rescued = ox.Rescued()
+    #: `--contrast` only: runs failing AA, and runs that could not be scored.
+    contrast: Sequence = ()
+    unchecked: Sequence = ()
+
+    @property
+    def reportable(self):
+        """Whether this file earns a line in the run's output.
+
+        False means "already conformant, and nothing to say" — the old `{}`.
+        A file can be reportable without having been WRITTEN: `--check` and
+        `--contrast` both report without touching Drive.
+        """
+        return bool(self.before or self.after or self.parts or self.plates
+                    or self.retired or self.fallback or self.contrast
+                    or self.unchecked or self.pruned.faces
+                    or self.pruned.parts or self.rescued.runs)
+
+
 def walk_estate(root, jobs=8):
-    """(entries, chapters, series, owners-with-files, out-of-scope count).
+    """Scan Drive for the template estate. Returns an `Estate`.
 
     `entries` are the OOXML files in scope, deduped by Drive id — a file
     reachable under two parents would otherwise be handed to two workers that
@@ -181,7 +248,7 @@ def walk_estate(root, jobs=8):
         if f["id"] not in seen_ids:
             seen_ids.add(f["id"])
             unique.append(f)
-    return unique, chapters, series, with_files, skipped, sorted(strays)
+    return Estate(unique, chapters, series, with_files, skipped, sorted(strays))
 
 
 #: Characters kept when a Drive name becomes part of a local path. Everything
@@ -288,6 +355,15 @@ def _plates_for(entry, plate_dir):
     return out
 
 
+class Legibility(NamedTuple):
+    """`contrast_report`'s two lists, which must never be added together."""
+    #: Runs measured as failing WCAG AA against what is behind them.
+    bad: Sequence = ()
+    #: Runs that could not be scored — an inherited colour, a translucent run,
+    #: a background the checker could not read. NOT failures.
+    unchecked: Sequence = ()
+
+
 def contrast_report(entry, src):
     """Text in this file that fails WCAG AA against what is behind it.
 
@@ -296,22 +372,25 @@ def contrast_report(entry, src):
     background and its text sits on the page.
     """
     if entry["mime"] != cc.PPTX:
-        return [], []
+        return Legibility()
     found = ctr.check_pptx(src)
     # Unreadable and unchecked are DIFFERENT, and conflating them destroys the
     # distinction the checker is built around: inherited-colour runs are common,
     # so counting them as failures means --contrast can never exit 0 and its
     # exit status stops meaning anything.
-    return ([f for f in found if f.ratio is not None and f.ratio < f.threshold],
-            [f for f in found if f.ratio is None])
+    return Legibility([f for f in found if f.ratio is not None and f.ratio < f.threshold],
+                      [f for f in found if f.ratio is None])
 
 
 def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
             contrast_only=False, fix_contrast=False, retire=False):
-    """Restyle one file. Returns (entry, report, error or None).
+    """Restyle one file. Returns `(entry, Changes, error or None)`.
 
-    `report` is `{"parts": n, "before": [...], "after": [...]}` when the file
-    changed or is off-system, and `{}` when it is already conformant.
+    The `Changes` is empty — `.reportable` False — when the file is already
+    conformant and there is nothing to say about it. On error it is empty too,
+    but the caller must test the error first: an empty record is indistinguish-
+    able from a clean file, which is the point of returning the error beside it
+    rather than encoding it in the record.
     """
     ext = OOXML[entry["mime"]]
     # Named by Drive id, not by path: two truncated paths that collide would
@@ -328,13 +407,14 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
             raise RuntimeError("download is not OOXML (%d bytes) — an error body, "
                                "not the template" % os.path.getsize(src))
         if contrast_only:
-            bad, unchecked = contrast_report(entry, src)
-            return entry, ({"contrast": bad, "unchecked": unchecked}
-                           if bad or unchecked else {}), None
+            legible = contrast_report(entry, src)
+            return entry, Changes(contrast=legible.bad,
+                                  unchecked=legible.unchecked), None
         before = ox.audit(src)
         if check_only:
-            return entry, ({"before": before, "parts": 0, "after": before,
-                            "plates": []} if before else {}), None
+            # `after` is `before`: nothing was rewritten, so what the file holds
+            # afterwards is what it held.
+            return entry, Changes(before=before, after=before), None
 
         # Archive BEFORE any rewrite: the archive must hold what Drive holds.
         # Gated on `write` ALONE, not on `before` — a file can be perfectly
@@ -358,7 +438,7 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
         # their embedded bytes. Reconcile the font table with what the document
         # now actually asks for.
         pruned = (ox.prune_embedded_fonts(src)
-                  if entry["mime"] == cc.DOCX else ([], []))
+                  if entry["mime"] == cc.DOCX else ox.Pruned())
         # Pruning leaves the document asking for a face it does not carry.
         # Give it an embedded metric fallback to reach for, so a .docx opened
         # on a machine without Instrument Sans still sets in something close
@@ -390,30 +470,27 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
                 replacement = fh.read()
             retired = ox.retire_plates(src, replacement, _plate_digests(plate_dir))
         rescued = (ox.improve_contrast(src)
-                   if fix_contrast and entry["mime"] == cc.PPTX else (0, 0, 0))
+                   if fix_contrast and entry["mime"] == cc.PPTX else ox.Rescued())
         after = ox.audit(src)
-        if not parts and not plated and not rescued[0] and not retired \
-                and not pruned[0] and not pruned[1] and not fallback:
+        if not (parts or plated or rescued.runs or retired
+                or pruned.faces or pruned.parts or fallback):
             # Nothing changed. If we archived a file we are not going to upload,
             # take the copy back out so the archive means "these were replaced".
             if fresh and archived and os.path.exists(archived):
                 os.remove(archived)
-            return entry, ({"before": before, "parts": 0, "after": after,
-                            "plates": [], "rescued": (0, 0, 0)}
-                           if before else {}), None
+            return entry, Changes(before=before, after=after), None
         if write:
             cc.gws_upload(entry["id"], src, entry["mime"])
-        return entry, {"before": before, "parts": parts, "after": after,
-                       "plates": plated, "rescued": rescued,
-                       "retired": retired, "pruned": pruned,
-                       "fallback": fallback}, None
+        return entry, Changes(before=before, after=after, parts=parts,
+                              plates=plated, retired=retired, pruned=pruned,
+                              fallback=fallback, rescued=rescued), None
     except Exception as e:                # one bad file must not stop the run
         # Prefix the class: this catch spans the XML engine, the archive, and
         # both transfers, and a bare message makes a ValueError in the rewrite
         # read as a network blip. Never return a bare str() — an exception whose
         # str() is empty would be falsy and the caller would count the file as
         # clean, printing nothing at all.
-        return entry, {}, "%s: %s" % (type(e).__name__, str(e)[:200])
+        return entry, Changes(), "%s: %s" % (type(e).__name__, str(e)[:200])
     finally:
         if os.path.exists(src):
             os.remove(src)
@@ -508,9 +585,10 @@ def main():
         print("Archiving pre-change files to %s" % backup_dir)
 
     print("Scanning the Community Events tree for templates...")
-    entries, chapters, series, with_files, skipped, strays = walk_estate(
-        COMMUNITY_ROOT, max(args.jobs, 8))
-    scanned = entries
+    estate = walk_estate(COMMUNITY_ROOT, max(args.jobs, 8))
+    chapters, series, with_files = estate.chapters, estate.series, estate.with_files
+    skipped, strays = estate.skipped, estate.strays
+    entries = scanned = estate.entries
     if args.chapter:
         # Matched against whole path SEGMENTS, not as a substring. A substring
         # match on "Templates" would also select every chapter's "Event
@@ -540,22 +618,24 @@ def main():
     residue, unchecked_only = [], []
     with tempfile.TemporaryDirectory() as tmpdir, \
             ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        for entry, report, err in pool.map(
+        for entry, changes, err in pool.map(
                 lambda e: process(e, tmpdir, args.write, backup_dir, args.check,
                                   args.plates, args.contrast, args.fix_contrast,
                                   args.retire),
                 entries):
+            # The error first: a failed file also comes back with an empty
+            # record, so testing `reportable` before `err` would count every
+            # failure as clean and print nothing.
             if err is not None:
                 failed += 1
                 print("  FAILED  %s\n            %s" % (entry["path"], err))
                 continue
-            if not report:
+            if not changes.reportable:
                 clean += 1
                 continue
             changed += 1
             if args.contrast:
-                bad = report["contrast"]
-                unchecked = report.get("unchecked", [])
+                bad, unchecked = changes.contrast, changes.unchecked
                 if not bad:
                     unchecked_only.append((entry["path"], len(unchecked)))
                     changed -= 1
@@ -572,33 +652,34 @@ def main():
                 if len(bad) > 6:
                     print("        ... and %d more" % (len(bad) - 6))
                 continue
-            if report["after"]:
-                residue.append((entry["path"], report["after"]))
+            if changes.after:
+                residue.append((entry["path"], changes.after))
             verb = ("off-system" if args.check else
                     "RESTYLED" if args.write else "would restyle")
             print("  %-12s %s\n                 %s"
                   % (verb, entry["path"],
-                     _summarise(report["before"]) or "(already conformant)"))
-            if report.get("plates"):
-                print("                 + plates: %s" % ", ".join(report["plates"]))
-            if report.get("pruned") and report["pruned"][0]:
-                faces, dropped = report["pruned"]
+                     _summarise(changes.before) or "(already conformant)"))
+            if changes.plates:
+                print("                 + plates: %s" % ", ".join(changes.plates))
+            if changes.pruned.faces:
                 print("                 + fonts: dropped %s from the font table"
-                      "%s" % (", ".join(faces),
-                              "; removed %d embedded face part(s)" % len(dropped)
-                              if dropped else ""))
-            if report.get("fallback"):
+                      "%s" % (", ".join(changes.pruned.faces),
+                              "; removed %d embedded face part(s)"
+                              % len(changes.pruned.parts)
+                              if changes.pruned.parts else ""))
+            if changes.fallback:
                 print("                 + fonts: embedded the %s metric "
                       "fallback for %s" % (ox.FALLBACK_FACE, ox.SANS))
-            if report.get("retired"):
+            if changes.retired:
                 print("                 + retired legacy plate: %s"
-                      % ", ".join(os.path.basename(x) for x in report["retired"]))
-            if report.get("rescued", (0,))[0]:
-                n, b, a = report["rescued"]
+                      % ", ".join(os.path.basename(x) for x in changes.retired))
+            if changes.rescued.runs:
                 print("                 + legibility: %d run(s) rescued "
-                      "(%d below AA -> %d)" % (n, b, a))
-            if report["after"]:
-                print("                 REMAINS: %s" % _summarise(report["after"]))
+                      "(%d below AA -> %d)"
+                      % (changes.rescued.runs, changes.rescued.before,
+                         changes.rescued.after))
+            if changes.after:
+                print("                 REMAINS: %s" % _summarise(changes.after))
 
     if args.contrast:
         print("\n%d file(s) hold unreadable text, %d clean, %d failed."

--- a/skills/aaif-create-chapter/scripts/test_restyle_design_system.py
+++ b/skills/aaif-create-chapter/scripts/test_restyle_design_system.py
@@ -254,9 +254,15 @@ class TestNothingIsWrittenWithoutAnArchive(unittest.TestCase):
             return rd.process(self.entry, work, write, self.backup, False)
 
     def test_a_write_run_archives_the_bytes_that_were_in_drive(self):
-        _e, report, err = self._run(write=True)
+        _e, changes, err = self._run(write=True)
         self.assertIsNone(err)
-        self.assertTrue(report, "a file that changed must report what changed")
+        # `.reportable`, not `assertTrue(changes)`: a Changes is a namedtuple
+        # and is therefore ALWAYS truthy. When this was a dict, `{}` carried
+        # the clean/changed decision implicitly and this line tested it;
+        # against a record the same line passes unconditionally.
+        self.assertTrue(changes.reportable,
+                        "a file that changed must report what changed")
+        self.assertEqual(changes.pruned.faces, ("Space Grotesk",))
         archived = rd._archive_path(self.entry, self.backup)
         self.assertTrue(os.path.exists(archived), "nothing was archived")
         with open(archived, "rb") as fh:
@@ -275,8 +281,10 @@ class TestNothingIsWrittenWithoutAnArchive(unittest.TestCase):
         """The archive means "these were replaced". A file that turned out to
         need nothing must not leave a copy behind implying it was."""
         self.payload = _already_conformant_docx()
-        _e, report, err = self._run(write=True)
+        _e, changes, err = self._run(write=True)
         self.assertIsNone(err)
+        self.assertFalse(changes.reportable,
+                         "a file that needed nothing must report nothing")
         self.assertEqual(self.uploaded, [])
         self.assertFalse(os.path.exists(rd._archive_path(self.entry, self.backup)))
 
@@ -335,7 +343,7 @@ class TestWalkEstate(unittest.TestCase):
         return rd.walk_estate("root", jobs=2)
 
     def test_it_finds_exactly_the_templates_and_no_more(self):
-        entries, _c, _s, _w, _skipped, _strays = self.walk()
+        entries = self.walk().entries
         got = {e["path"].replace("Community Events/", "", 1) for e in entries}
         self.assertEqual(got, {
             "Chapters/Boston/About.docx",
@@ -347,20 +355,20 @@ class TestWalkEstate(unittest.TestCase):
         })
 
     def test_an_organizers_dated_copy_is_counted_not_swept(self):
-        entries, _c, _s, _w, skipped, _strays = self.walk()
-        paths = {e["path"] for e in entries}
+        estate = self.walk()
+        paths = {e["path"] for e in estate.entries}
         self.assertFalse(any("2026-09-01" in p for p in paths))
-        self.assertEqual(skipped, 1)
+        self.assertEqual(estate.skipped, 1)
 
     def test_a_non_template_in_a_template_folder_is_named_as_a_stray(self):
-        _e, _c, _s, _w, _skipped, strays = self.walk()
+        strays = self.walk().strays
         self.assertEqual(
             [p.replace("Community Events/", "", 1) for p in strays],
             ["Chapters/Boston/Event Templates (Copy for Each Event)/"
              "#27 linkedin.pptx"])
 
     def test_the_mint_folders_are_reached(self):
-        entries, _c, _s, _w, _skipped, _strays = self.walk()
+        entries = self.walk().entries
         paths = " ".join(e["path"] for e in entries)
         for mint in rd.MINTS:
             self.assertIn(mint, paths)
@@ -369,14 +377,13 @@ class TestWalkEstate(unittest.TestCase):
         """The dedupe exists so two workers never share a scratch filename."""
         self.TREE["shared"] = self.TREE["shared"] + [
             ("f9", "Event Tracker (IRL).docx", False)]
-        entries, *_rest = self.walk()
-        ids = [e["id"] for e in entries]
+        ids = [e["id"] for e in self.walk().entries]
         self.assertEqual(len(ids), len(set(ids)))
 
     def test_chapter_and_series_names_are_reported(self):
-        _e, chapters, series, _w, _skipped, _strays = self.walk()
-        self.assertEqual(chapters, {"Boston", "TemplateCity"})
-        self.assertEqual(series, {"TemplateSeries"})
+        estate = self.walk()
+        self.assertEqual(estate.chapters, {"Boston", "TemplateCity"})
+        self.assertEqual(estate.series, {"TemplateSeries"})
 
 
 class TestRetirementScope(unittest.TestCase):

--- a/skills/aaif-create-chapter/scripts/test_restyle_design_system.py
+++ b/skills/aaif-create-chapter/scripts/test_restyle_design_system.py
@@ -246,22 +246,30 @@ class TestNothingIsWrittenWithoutAnArchive(unittest.TestCase):
                 self.uploaded.append((fid, fh.read()))
 
         for name, fn in (("gws_download", fake_download), ("gws_upload", fake_upload)):
+            # Capture the ORIGINAL before patching. Reading it back out after
+            # the setattr — as this did — hands addCleanup the fake, so cleanup
+            # "restores" the fake and rd.cc stays patched for the rest of the
+            # process. Harmless while no later class called these; a live trap
+            # for the --check/--contrast tests below, which do.
+            real = getattr(rd.cc, name)
             setattr(rd.cc, name, fn)
-            self.addCleanup(setattr, rd.cc, name, getattr(rd.cc, name))
+            self.addCleanup(setattr, rd.cc, name, real)
 
-    def _run(self, write):
+    def _run(self, write, **kw):
         with tempfile.TemporaryDirectory() as work:
-            return rd.process(self.entry, work, write, self.backup, False)
+            return rd.process(self.entry, work, write, self.backup,
+                              kw.pop("check_only", False), **kw)
 
     def test_a_write_run_archives_the_bytes_that_were_in_drive(self):
         _e, changes, err = self._run(write=True)
         self.assertIsNone(err)
-        # `.reportable`, not `assertTrue(changes)`: a Changes is a namedtuple
+        # `.conformant`, not `assertFalse(changes)`: a Changes is a namedtuple
         # and is therefore ALWAYS truthy. When this was a dict, `{}` carried
-        # the clean/changed decision implicitly and this line tested it;
-        # against a record the same line passes unconditionally.
-        self.assertTrue(changes.reportable,
-                        "a file that changed must report what changed")
+        # the clean/changed decision implicitly and a bare truth test caught
+        # it; against a record the same line passes unconditionally.
+        self.assertFalse(changes.conformant,
+                         "a file that changed must report what changed")
+        self.assertTrue(changes.wrote, "and must be recorded as written")
         self.assertEqual(changes.pruned.faces, ("Space Grotesk",))
         archived = rd._archive_path(self.entry, self.backup)
         self.assertTrue(os.path.exists(archived), "nothing was archived")
@@ -283,8 +291,9 @@ class TestNothingIsWrittenWithoutAnArchive(unittest.TestCase):
         self.payload = _already_conformant_docx()
         _e, changes, err = self._run(write=True)
         self.assertIsNone(err)
-        self.assertFalse(changes.reportable,
-                         "a file that needed nothing must report nothing")
+        self.assertTrue(changes.conformant,
+                        "a file that needed nothing must report nothing")
+        self.assertFalse(changes.wrote, "and must not be recorded as written")
         self.assertEqual(self.uploaded, [])
         self.assertFalse(os.path.exists(rd._archive_path(self.entry, self.backup)))
 
@@ -384,6 +393,161 @@ class TestWalkEstate(unittest.TestCase):
         estate = self.walk()
         self.assertEqual(estate.chapters, {"Boston", "TemplateCity"})
         self.assertEqual(estate.series, {"TemplateSeries"})
+
+    def test_owners_holding_office_files_are_reported(self):
+        """`with_files` is the DENOMINATOR of the "contributed none" coverage
+        check — the thing that catches a renamed template folder. It was the
+        ignored `_w` of the old 6-tuple and no test ever named it; a scan that
+        stopped populating it would silently disable that check.
+
+        The shared Templates folder counts as an owner too, which is why the
+        field is documented as owners rather than chapters."""
+        estate = self.walk()
+        self.assertIn("Boston", estate.with_files)
+        self.assertIn("TemplateSeries", estate.with_files)
+        self.assertTrue(estate.with_files <= (estate.chapters | estate.series
+                                              | {rd.SHARED_TEMPLATES}),
+                        "an owner appeared that is neither chapter, series, "
+                        "nor the shared Templates folder: %s" % estate.with_files)
+
+
+class TestTheTwoPredicates(unittest.TestCase):
+    """`conformant` and `wrote` carry the whole clean/changed and
+    upload/skip decision, and every term of them was individually unpinned:
+    replacing any single disjunct with False left the suite green, because the
+    two tests that touched the predicate had four terms true at once.
+
+    Dropping `before` alone, for instance, makes a `--check` run — which
+    returns `Changes(before=..., after=...)` with `parts=0` — report nothing
+    and exit 0 forever. That is the exact failure the record exists to stop.
+    """
+
+    #: (label, a Changes that must be NON-conformant on the strength of one field)
+    ONE_TERM = [
+        ("before", rd.Changes(before=("drift",))),
+        ("after", rd.Changes(after=("residue",))),
+        ("parts", rd.Changes(parts=1)),
+        ("plates", rd.Changes(plates=("plate-a",))),
+        ("retired", rd.Changes(retired=("bg1.png",))),
+        ("fallback", rd.Changes(fallback=True)),
+        ("contrast", rd.Changes(contrast=("finding",))),
+        ("unchecked", rd.Changes(unchecked=("finding",))),
+        ("pruned.faces", rd.Changes(pruned=rd.ox.Pruned(faces=("Arial",)))),
+        ("pruned.parts", rd.Changes(pruned=rd.ox.Pruned(parts=("f.ttf",)))),
+        ("rescued.runs", rd.Changes(rescued=rd.ox.Rescued(runs=1, before=1))),
+        ("rescued.before", rd.Changes(rescued=rd.ox.Rescued(runs=0, before=3, after=3))),
+    ]
+
+    def test_an_empty_record_is_conformant_and_unwritten(self):
+        self.assertTrue(rd.Changes().conformant)
+        self.assertFalse(rd.Changes().wrote)
+
+    def test_each_field_on_its_own_makes_the_record_non_conformant(self):
+        for label, ch in self.ONE_TERM:
+            with self.subTest(field=label):
+                self.assertFalse(ch.conformant,
+                                 "%s alone must earn a line" % label)
+
+    #: The fields that mean "bytes changed on disk" — a strict subset.
+    WROTE_FIELDS = {"parts", "plates", "retired", "fallback",
+                    "pruned.faces", "pruned.parts", "rescued.runs"}
+
+    def test_wrote_is_exactly_the_fields_that_change_bytes(self):
+        """`wrote` gates the upload and the archive, so a field that does NOT
+        change the file must not set it — otherwise a --check run would upload."""
+        for label, ch in self.ONE_TERM:
+            with self.subTest(field=label):
+                self.assertEqual(ch.wrote, label in self.WROTE_FIELDS, label)
+
+    def test_wrote_implies_non_conformant(self):
+        """Anything written must also be reported. The reverse does not hold."""
+        for label, ch in self.ONE_TERM:
+            if ch.wrote:
+                self.assertFalse(ch.conformant, label)
+
+    def test_a_deck_measured_unreadable_but_not_repaired_is_still_reported(self):
+        """The named regression. `improve_contrast` declines a remap that would
+        break other runs and returns Rescued(0, 12, 12) — nothing written, but
+        twelve runs measured below AA. Gating on `.runs` alone made
+        --fix-contrast answer "already conformant" over unreadable text."""
+        ch = rd.Changes(rescued=rd.ox.Rescued(runs=0, before=12, after=12))
+        self.assertFalse(ch.wrote, "nothing was written, so nothing to upload")
+        self.assertFalse(ch.conformant, "but it must NOT be counted clean")
+
+
+class TestCheckAndContrastModes(unittest.TestCase):
+    """Both branches of `process()` were rewritten and neither had a test.
+    `_run` hard-coded both flags False."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.entry = {"id": "fid1", "name": "About.docx", "mime": rd.cc.DOCX,
+                      "path": "Community Events/Chapters/Boston/About.docx"}
+        # doc_font, not just the font TABLE: `ox.audit` reports off-system
+        # values in the document, so a drifted table alone leaves `before`
+        # empty and the --check assertions below would pass vacuously.
+        self.payload = _docx(["Space Grotesk"], doc_font="Space Grotesk")
+        self.uploaded = []
+
+        def fake_download(fid, out):
+            with open(out, "wb") as fh:
+                fh.write(self.payload)
+
+        def fake_upload(fid, path, mime):
+            self.uploaded.append(fid)
+
+        for name, fn in (("gws_download", fake_download), ("gws_upload", fake_upload)):
+            real = getattr(rd.cc, name)
+            setattr(rd.cc, name, fn)
+            self.addCleanup(setattr, rd.cc, name, real)
+
+    def _process(self, check_only=False, **kw):
+        with tempfile.TemporaryDirectory() as work:
+            return rd.process(self.entry, work, False, self.tmp.name,
+                              check_only, **kw)
+
+    def test_check_reports_the_drift_and_writes_nothing(self):
+        r = self._process(check_only=True)
+        self.assertIsNone(r.error)
+        self.assertFalse(r.changes.conformant, "--check found nothing to say")
+        self.assertFalse(r.changes.wrote, "--check must never write")
+        self.assertEqual(self.uploaded, [])
+
+    def test_check_leaves_after_equal_to_before(self):
+        """Nothing is rewritten, so what the file holds afterwards is what it
+        held — the field doc says so and `main()` prints REMAINS from it."""
+        r = self._process(check_only=True)
+        self.assertEqual(r.changes.after, r.changes.before)
+        self.assertTrue(r.changes.before, "the fixture is off-system on purpose")
+
+    def test_a_conformant_file_under_check_says_nothing(self):
+        self.payload = _docx(["Instrument Sans"], doc_font="Instrument Sans")
+        r = self._process(check_only=True)
+        self.assertTrue(r.changes.conformant)
+
+    def test_contrast_on_a_docx_measures_nothing_and_is_conformant(self):
+        """Only .pptx has a slide background; a Word tracker's text sits on the
+        page, so `contrast_report` returns an empty Legibility."""
+        r = self._process(contrast_only=True)
+        self.assertIsNone(r.error)
+        self.assertEqual(r.changes.contrast, ())
+        self.assertEqual(r.changes.unchecked, ())
+        self.assertTrue(r.changes.conformant)
+
+    def test_contrast_report_on_a_non_pptx_equals_the_empty_record(self):
+        """Tuples, not lists: built as lists this is `[] != ()` and reads like
+        a logic bug in the caller."""
+        self.assertEqual(rd.contrast_report(self.entry, "ignored"),
+                         rd.Legibility())
+
+    def test_the_two_legibility_lists_are_not_interchangeable(self):
+        """A positional swap is silent and would make --contrast report
+        inherited-colour runs as AA failures and never exit 0."""
+        leg = rd.Legibility(bad=("f1",), unchecked=("f2", "f3"))
+        self.assertEqual(leg.bad, ("f1",))
+        self.assertEqual(leg.unchecked, ("f2", "f3"))
+        self.assertEqual(leg[0], leg.bad)
 
 
 class TestRetirementScope(unittest.TestCase):

--- a/skills/aaif-create-chapter/scripts/test_upload_agents.py
+++ b/skills/aaif-create-chapter/scripts/test_upload_agents.py
@@ -2,14 +2,14 @@
 """Unit tests for the per-chapter icon upload.
 
 This script was the last one in `aaif-create-chapter/scripts/` with no test
-beside it, and it is the one that writes the most files: eighty chapters times
-an agent, ten generics and six logo files. Two of its properties are the ones
-worth pinning, because both fail QUIETLY:
+beside it, and it is the one that writes the most files: every chapter in the
+estate times an agent, ten generics and six logo files. Two of its properties
+are the ones worth pinning, because both fail QUIETLY:
 
   (a) **it must be idempotent.** The whole reason it can be re-run after adding
       one chapter is that a file whose bytes already match is left alone. If
-      the digest comparison stops working, a full run silently re-uploads ~1400
-      files and every organizer sees their whole Icons folder change date.
+      the digest comparison stops working, a full run silently re-uploads the
+      whole estate and every organizer sees their Icons folder change date.
 
   (b) **a chapter with no generated art must FAIL, not upload a partial set.**
       `art_for` returns the generics and the logos for any chapter name, so a
@@ -188,7 +188,7 @@ class TestSyncingOneChapter(unittest.TestCase):
         drive = self._full_icons_folder()
         r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
         self.assertIsNone(r.error)
-        self.assertEqual(r.uploaded, [])
+        self.assertEqual(r.uploaded, ())
         self.assertEqual(len(r.skipped), 17)      # own agent + 10 + 6
         self.assertEqual(drive.uploaded, [])
         self.assertEqual(drive.created, [])
@@ -200,7 +200,7 @@ class TestSyncingOneChapter(unittest.TestCase):
         drive = self._full_icons_folder()
         drive.files["d-Agent 03.gif"] = ("Agent 03.gif", b"stale bytes")
         r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
-        self.assertEqual(r.uploaded, ["Agent 03.gif"])
+        self.assertEqual(r.uploaded, ("Agent 03.gif",))
         self.assertEqual([fid for fid, _d in drive.uploaded], ["d-Agent 03.gif"])
         self.assertEqual(drive.created, [], "no duplicate file was created")
 
@@ -209,7 +209,7 @@ class TestSyncingOneChapter(unittest.TestCase):
         drive.children["icons"] = [c for c in drive.children["icons"]
                                    if c != "d-AAIF Mark.svg"]
         r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
-        self.assertEqual(r.uploaded, ["AAIF Mark.svg"])
+        self.assertEqual(r.uploaded, ("AAIF Mark.svg",))
         self.assertEqual(drive.created, ["AAIF Mark.svg"])
         self.assertEqual(len(drive.uploaded), 1, "created, then its bytes sent")
 
@@ -300,11 +300,200 @@ class TestSyncingOneChapter(unittest.TestCase):
         self.assertEqual(os.listdir(self.work), [], "a scratch file was left behind")
 
 
+class TestTheWriteGate(unittest.TestCase):
+    """`--write` is the only thing between a plan and 80 chapters of uploads.
+
+    CLAUDE.md: "a script that writes on its default invocation is a bug." The
+    first version of this file did not actually pin that — mutating
+    `if write:` to `if True:` left all fifteen tests green, because the only
+    plan-run test used an EMPTY Drive and returned at the `folder is None`
+    early exit without ever reaching the upload loop. These drive the loop.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.art = os.path.join(self.tmp.name, "art")
+        self.work = os.path.join(self.tmp.name, "work")
+        os.makedirs(self.art)
+        os.makedirs(self.work)
+        _art_dir(self.art)
+
+    def _drifted_folder(self):
+        """An Icons folder that is current except for one stale file."""
+        children, files = {"chap": ["icons"]}, {"icons": ("Icons", None)}
+        kids = []
+        for fname, path in ua.art_for(self.art, "Boston"):
+            fid = "d-" + fname
+            with open(path, "rb") as fh:
+                files[fid] = (fname, fh.read())
+            kids.append(fid)
+        children["icons"] = kids
+        files["d-Agent 03.gif"] = ("Agent 03.gif", b"stale bytes")
+        return _FakeDrive(children, files).install(self)
+
+    def test_a_plan_run_over_an_existing_folder_names_the_drift_but_writes_none(self):
+        """The mutation-catching case: the upload loop IS entered, one file is
+        found to differ, and still nothing reaches Drive."""
+        drive = self._drifted_folder()
+        r = ua.sync_chapter("chap", "Boston", self.art, False, self.work)
+        self.assertIsNone(r.error)
+        self.assertEqual(r.uploaded, ("Agent 03.gif",), "the drift must be named")
+        self.assertEqual(drive.uploaded, [], "a plan run uploaded a file")
+        self.assertEqual(drive.created, [], "a plan run created a file")
+        self.assertEqual(drive.made_folders, [], "a plan run created a folder")
+
+    def test_the_same_run_with_write_does_reach_drive(self):
+        """The other half — without this, the test above passes if uploading
+        broke entirely."""
+        drive = self._drifted_folder()
+        ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertEqual([fid for fid, _d in drive.uploaded], ["d-Agent 03.gif"])
+
+    def test_a_plan_run_never_creates_the_icons_folder(self):
+        drive = _FakeDrive({"chap": []}, {}).install(self)
+        ua.sync_chapter("chap", "Boston", self.art, False, self.work)
+        self.assertEqual(drive.made_folders, [])
+
+    def test_the_icons_folder_is_created_by_name_under_the_chapter(self):
+        """`made_folders` was only ever asserted EMPTY, so the create path ran
+        untested: mutating the name to "Ikons", or the parent to the tree root,
+        left every test green and would scatter 80 stray folders."""
+        drive = _FakeDrive({"chap": []}, {}).install(self)
+        ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertEqual(drive.made_folders, [(ua.ICONS_FOLDER, "chap")])
+
+    def test_a_stray_file_named_icons_is_not_mistaken_for_the_folder(self):
+        """An organizer parking a file called "Icons" in their chapter folder
+        would otherwise have `list_children` called on a file id."""
+        drive = _FakeDrive({"chap": ["stray"]},
+                           {"stray": ("Icons", b"not a folder")}).install(self)
+        ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertEqual(drive.made_folders, [(ua.ICONS_FOLDER, "chap")],
+                         "the real folder must still be created alongside it")
+
+
+class TestMainSummary(unittest.TestCase):
+    """`main()` is where the misreport the `Synced` record exists to prevent
+    would actually surface, and it had no test at all."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.art = os.path.join(self.tmp.name, "art")
+        os.makedirs(self.art)
+        _art_dir(self.art)
+
+    def _run(self, results, argv_extra=()):
+        """Drive main() over canned Synced records; return (exit code, stdout)."""
+        import io
+        import contextlib
+        real_chapters, real_sync, real_argv = ua.chapters, ua.sync_chapter, sys.argv
+        ua.chapters = lambda: [("id-%s" % r.name, r.name) for r in results]
+        ua.sync_chapter = lambda cid, name, *a, **k: next(
+            r for r in results if r.name == name)
+        sys.argv = ["upload_agents.py", "--art", self.art] + list(argv_extra)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                code = ua.main()
+            return code, buf.getvalue()
+        finally:
+            ua.chapters, ua.sync_chapter, sys.argv = real_chapters, real_sync, real_argv
+
+    def test_the_three_outcomes_are_counted_and_the_exit_code_follows(self):
+        code, out = self._run([
+            ua.Synced("Alpha", uploaded=("Agent 01.gif",)),
+            ua.Synced("Bravo"),                       # nothing to do
+            ua.Synced("Delta", error="RuntimeError: 403"),
+        ])
+        self.assertEqual(code, 1, "a failure must not exit 0")
+        self.assertIn("1 chapter(s) would be updated, 1 already current, 1 failed", out)
+
+    def test_a_failed_chapter_is_named_in_the_summary_not_only_inline(self):
+        """The docstring promises a run "reports which chapters are missing
+        their agent". `missing` was collected and never printed."""
+        _code, out = self._run([
+            ua.Synced("Delta", error="no agent art generated for this chapter"),
+        ])
+        self.assertIn("CHAPTERS NEEDING ATTENTION", out)
+        self.assertIn("Delta", out.split("CHAPTERS NEEDING ATTENTION")[1])
+        self.assertIn("Rebuild the art", out)
+
+    def test_an_all_clean_run_exits_zero_and_says_nothing_alarming(self):
+        code, out = self._run([ua.Synced("Alpha"), ua.Synced("Bravo")])
+        self.assertEqual(code, 0)
+        self.assertNotIn("CHAPTERS NEEDING ATTENTION", out)
+        self.assertIn("2 already current", out)
+
+    def test_a_chapter_filter_that_matches_nothing_is_an_error(self):
+        code, _out = self._run([ua.Synced("Alpha")], ("--chapter", "Nowhere"))
+        self.assertEqual(code, 1)
+
+    def test_the_chapter_filter_is_case_insensitive(self):
+        code, out = self._run([ua.Synced("Alpha", uploaded=("x.gif",))],
+                              ("--chapter", "alpha"))
+        self.assertEqual(code, 0)
+        self.assertIn("1 chapter(s)", out)
+
+    def test_an_incomplete_art_directory_is_refused_before_any_chapter(self):
+        os.remove(os.path.join(self.art, "Agent 01.gif"))
+        code, out = self._run([ua.Synced("Alpha")])
+        self.assertEqual(code, 2, "a short art set must not half-populate Drive")
+        self.assertIn("expected 10 generic agents", out)
+
+    def test_an_art_directory_with_no_logos_is_refused(self):
+        for f in LOGOS:
+            os.remove(os.path.join(self.art, f))
+        code, out = self._run([ua.Synced("Alpha")])
+        self.assertEqual(code, 2)
+        self.assertIn("no AAIF logos", out)
+
+
 class TestTheRecord(unittest.TestCase):
     def test_a_synced_defaults_to_no_work_and_no_error(self):
         r = ua.Synced("Boston")
         self.assertEqual((r.name, r.uploaded, r.skipped, r.error),
                          ("Boston", (), (), None))
+
+    def test_every_error_path_returns_empty_uploaded_and_skipped(self):
+        """`main()` relies on this: it reads `uploaded` only after finding no
+        error, so a record carrying both would be miscounted. The docstring
+        claims the invariant; nothing checked it."""
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        art, work = os.path.join(tmp.name, "a"), os.path.join(tmp.name, "w")
+        os.makedirs(art)
+        os.makedirs(work)
+        _art_dir(art)
+        _FakeDrive({"chap": []}, {}).install(self)
+
+        def boom(_folder_id):
+            raise RuntimeError("403")
+
+        cases = [("no art", lambda: ua.sync_chapter("chap", "Nowhere", art, True, work))]
+        cc.list_children = boom
+        cases.append(("drive down",
+                      lambda: ua.sync_chapter("chap", "Boston", art, True, work)))
+        for label, call in cases:
+            r = call()
+            self.assertIsNotNone(r.error, label)
+            self.assertEqual(r.uploaded, (), label)
+            self.assertEqual(r.skipped, (), label)
+
+    def test_an_unreadable_art_directory_is_returned_not_raised(self):
+        """`art_for` does an os.listdir and used to sit OUTSIDE the try, so a
+        vanished art dir raised through pool.map and abandoned every chapter
+        not yet reached."""
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        work = os.path.join(tmp.name, "w")
+        os.makedirs(work)
+        _FakeDrive({"chap": []}, {}).install(self)
+        r = ua.sync_chapter("chap", "Boston",
+                            os.path.join(tmp.name, "gone"), True, work)
+        self.assertIsNotNone(r.error, "it raised instead of reporting")
+        self.assertIn("FileNotFoundError", r.error)
 
 
 if __name__ == "__main__":

--- a/skills/aaif-create-chapter/scripts/test_upload_agents.py
+++ b/skills/aaif-create-chapter/scripts/test_upload_agents.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Unit tests for the per-chapter icon upload.
+
+This script was the last one in `aaif-create-chapter/scripts/` with no test
+beside it, and it is the one that writes the most files: eighty chapters times
+an agent, ten generics and six logo files. Two of its properties are the ones
+worth pinning, because both fail QUIETLY:
+
+  (a) **it must be idempotent.** The whole reason it can be re-run after adding
+      one chapter is that a file whose bytes already match is left alone. If
+      the digest comparison stops working, a full run silently re-uploads ~1400
+      files and every organizer sees their whole Icons folder change date.
+
+  (b) **a chapter with no generated art must FAIL, not upload a partial set.**
+      `art_for` returns the generics and the logos for any chapter name, so a
+      chapter whose own agent was never generated still produces sixteen files
+      to upload. Without the guard it would get a complete-looking Icons folder
+      holding everyone else's art and none of its own — and the run would
+      report it as updated.
+
+Nothing here touches Drive: `create_chapter`'s five Drive calls are replaced
+with a fake folder tree.
+
+Run: python3 skills/aaif-create-chapter/scripts/test_upload_agents.py
+"""
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import upload_agents as ua        # noqa: E402
+import create_chapter as cc       # noqa: E402
+
+#: The shared files every chapter's folder holds, exactly as the real art
+#: directory names them.
+GENERICS = ["Agent %02d.gif" % i for i in range(1, 11)]
+LOGOS = ["AAIF Logo.svg", "AAIF Logo.png", "AAIF Logo Reverse.svg",
+         "AAIF Logo Reverse.png", "AAIF Mark.svg", "AAIF Mark.png"]
+
+
+def _art_dir(tmp, chapters=("Boston",)):
+    """A directory shaped like `agent_art.build_agents` + `build_logos` output."""
+    for name in list(GENERICS) + list(LOGOS):
+        with open(os.path.join(tmp, name), "wb") as fh:
+            fh.write(b"shared-" + name.encode())
+    for c in chapters:
+        with open(os.path.join(tmp, "%s Agent.gif" % c), "wb") as fh:
+            fh.write(b"agent-for-" + c.encode())
+    return tmp
+
+
+class TestWhatAChapterShouldHold(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.art = _art_dir(self.tmp.name)
+
+    def test_a_chapter_gets_its_own_agent_plus_the_shared_set(self):
+        got = [f for f, _p in ua.art_for(self.art, "Boston")]
+        self.assertEqual(got[0], "Boston Agent.gif",
+                         "the chapter's own agent comes first")
+        self.assertEqual(sorted(got[1:]), sorted(GENERICS + LOGOS))
+
+    def test_a_chapter_with_no_agent_still_lists_the_shared_set(self):
+        """Which is exactly why `sync_chapter` needs its own guard: this
+        function cannot tell the difference, so the caller must."""
+        got = [f for f, _p in ua.art_for(self.art, "Nowhere")]
+        self.assertEqual(sorted(got), sorted(GENERICS + LOGOS))
+
+    def test_the_filename_is_derived_the_same_way_the_art_builder_derives_it(self):
+        """A chapter whose name has a slash or a colon in it must still find
+        its file — and must not reach outside the art directory to do it."""
+        for name, safe in (("Washington, D.C.", "Washington, D.C."),
+                           ("Montréal", "Montréal"),
+                           ("Tel Aviv-Yafo", "Tel Aviv-Yafo"),
+                           ("A/B", "A_B"),
+                           ("../etc", ".._etc")):
+            with open(os.path.join(self.art, "%s Agent.gif" % safe), "wb") as fh:
+                fh.write(b"x")
+            got = [f for f, _p in ua.art_for(self.art, name)]
+            self.assertEqual(got[0], "%s Agent.gif" % safe, name)
+
+    def test_a_chapters_own_agent_is_never_mistaken_for_a_shared_one(self):
+        """The two regexes are what keep the per-chapter file per-chapter. If
+        `GENERIC_RE` widened, every chapter would be handed every other
+        chapter's agent."""
+        self.assertFalse(ua.GENERIC_RE.match("Boston Agent.gif"))
+        self.assertFalse(ua.LOGO_RE.match("Boston Agent.gif"))
+        for f in GENERICS:
+            self.assertTrue(ua.GENERIC_RE.match(f), f)
+        for f in LOGOS:
+            self.assertTrue(ua.LOGO_RE.match(f), f)
+        # "Agent 1.gif" is not one of ours — the builder writes two digits, and
+        # a loose pattern here would pick up a hand-added file.
+        self.assertFalse(ua.GENERIC_RE.match("Agent 1.gif"))
+        self.assertFalse(ua.LOGO_RE.match("AAIF Logo.pptx"))
+
+
+class _FakeDrive:
+    """The five `create_chapter` calls `sync_chapter` makes, over a dict tree.
+
+    Files are `{id: (name, bytes)}`; `children` maps a folder id to the ids
+    under it. Every upload and create is recorded so a test can assert that a
+    run wrote NOTHING, which is the assertion idempotence needs.
+    """
+
+    def __init__(self, children=None, files=None):
+        self.children = children or {}
+        self.files = files or {}
+        self.uploaded, self.created, self.made_folders = [], [], []
+        #: {filename: the mimeType the file was CREATED with in Drive}
+        self.declared = {}
+        self._next = 0
+
+    def _id(self, prefix):
+        self._next += 1
+        return "%s%d" % (prefix, self._next)
+
+    def list_children(self, folder_id):
+        out = []
+        for cid in self.children.get(folder_id, []):
+            name, data = self.files[cid]
+            out.append({"id": cid, "name": name,
+                        "mimeType": cc.FOLDER if data is None else "image/gif"})
+        return out
+
+    def gws_download(self, file_id, out):
+        with open(out, "wb") as fh:
+            fh.write(self.files[file_id][1])
+
+    def gws_upload(self, file_id, path, mime):
+        with open(path, "rb") as fh:
+            data = fh.read()
+        self.uploaded.append((file_id, data))
+        self.files[file_id] = (self.files[file_id][0], data)
+
+    def create_folder(self, name, parent):
+        fid = self._id("folder")
+        self.made_folders.append((name, parent))
+        self.files[fid] = (name, None)
+        self.children.setdefault(parent, []).append(fid)
+        return fid
+
+    def gws_json(self, *args, params=None, body=None):
+        fid = self._id("file")
+        self.created.append(body["name"])
+        self.declared[body["name"]] = body["mimeType"]
+        self.files[fid] = (body["name"], b"")
+        self.children.setdefault(body["parents"][0], []).append(fid)
+        return {"id": fid}
+
+    def install(self, case):
+        for name in ("list_children", "gws_download", "gws_upload",
+                     "create_folder", "gws_json"):
+            real = getattr(cc, name)
+            setattr(cc, name, getattr(self, name))
+            case.addCleanup(setattr, cc, name, real)
+        return self
+
+
+class TestSyncingOneChapter(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.art = os.path.join(self.tmp.name, "art")
+        self.work = os.path.join(self.tmp.name, "work")
+        os.makedirs(self.art)
+        os.makedirs(self.work)
+        _art_dir(self.art)
+
+    def _full_icons_folder(self, chapter="Boston"):
+        """A Drive tree whose Icons folder already holds byte-identical art."""
+        children, files = {"chap": ["icons"]}, {"icons": ("Icons", None)}
+        kids = []
+        for fname, path in ua.art_for(self.art, chapter):
+            fid = "d-" + fname
+            with open(path, "rb") as fh:
+                files[fid] = (fname, fh.read())
+            kids.append(fid)
+        children["icons"] = kids
+        return _FakeDrive(children, files).install(self)
+
+    def test_a_folder_that_already_matches_is_left_completely_alone(self):
+        """Idempotence, asserted on the WRITE path — a plan run uploads nothing
+        whatever the digests say, so testing it with write=False would pass
+        even if the comparison were deleted."""
+        drive = self._full_icons_folder()
+        r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertIsNone(r.error)
+        self.assertEqual(r.uploaded, [])
+        self.assertEqual(len(r.skipped), 17)      # own agent + 10 + 6
+        self.assertEqual(drive.uploaded, [])
+        self.assertEqual(drive.created, [])
+        self.assertEqual(drive.made_folders, [])
+
+    def test_a_file_whose_bytes_drifted_is_re_uploaded_over_the_same_id(self):
+        """Over the EXISTING id, not as a second file: creating a new one would
+        leave the organizer's folder holding two 'Agent 03.gif'."""
+        drive = self._full_icons_folder()
+        drive.files["d-Agent 03.gif"] = ("Agent 03.gif", b"stale bytes")
+        r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertEqual(r.uploaded, ["Agent 03.gif"])
+        self.assertEqual([fid for fid, _d in drive.uploaded], ["d-Agent 03.gif"])
+        self.assertEqual(drive.created, [], "no duplicate file was created")
+
+    def test_a_missing_file_is_created_then_filled(self):
+        drive = self._full_icons_folder()
+        drive.children["icons"] = [c for c in drive.children["icons"]
+                                   if c != "d-AAIF Mark.svg"]
+        r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertEqual(r.uploaded, ["AAIF Mark.svg"])
+        self.assertEqual(drive.created, ["AAIF Mark.svg"])
+        self.assertEqual(len(drive.uploaded), 1, "created, then its bytes sent")
+
+    def test_each_file_is_created_with_its_own_mime_type(self):
+        """An .svg stored as image/gif is not previewable in Drive and
+        downloads with the wrong type — and the module holds a GIF constant
+        left over from when the folder was agents only."""
+        drive = _FakeDrive({"chap": []}, {}).install(self)
+        ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertEqual(drive.declared["AAIF Mark.svg"], "image/svg+xml")
+        self.assertEqual(drive.declared["AAIF Mark.png"], "image/png")
+        self.assertEqual(drive.declared["Agent 01.gif"], "image/gif")
+        self.assertEqual(drive.declared["Boston Agent.gif"], "image/gif")
+
+    def test_mime_by_ext_covers_everything_the_matchers_can_admit(self):
+        """`MIME_BY_EXT[...]` is a bare subscript, so it must be TOTAL over
+        what `art_for` can return — and it is, because the two matchers admit
+        only .gif, .svg and .png. Widening either regex without adding the
+        extension here turns into a KeyError mid-run, after some chapters have
+        already been written. An unrecognised extension in the art directory is
+        simply not collected:"""
+        with open(os.path.join(self.art, "AAIF Logo.webp"), "wb") as fh:
+            fh.write(b"x")
+        names = [f for f, _p in ua.art_for(self.art, "Boston")]
+        self.assertNotIn("AAIF Logo.webp", names)
+        self.assertEqual(
+            {os.path.splitext(f)[1].lower() for f in names} - set(ua.MIME_BY_EXT),
+            set(), "art_for returned an extension MIME_BY_EXT cannot map")
+
+    def test_a_chapter_with_no_agent_art_is_an_error_not_a_partial_upload(self):
+        drive = _FakeDrive({"chap": []}, {}).install(self)
+        r = ua.sync_chapter("chap", "Nowhere", self.art, True, self.work)
+        self.assertIsNotNone(r.error)
+        self.assertIn("no agent art", r.error)
+        self.assertFalse(r.uploaded)
+        self.assertEqual(drive.uploaded, [], "not one shared file was sent")
+        self.assertEqual(drive.made_folders, [], "no empty Icons folder left behind")
+
+    def test_a_plan_run_writes_nothing_and_names_everything_missing(self):
+        drive = _FakeDrive({"chap": []}, {}).install(self)
+        r = ua.sync_chapter("chap", "Boston", self.art, False, self.work)
+        self.assertIsNone(r.error)
+        self.assertEqual(len(r.uploaded), 17)
+        self.assertEqual(drive.made_folders, [])
+        self.assertEqual(drive.uploaded, [])
+        self.assertEqual(drive.created, [])
+
+    def test_a_drive_failure_is_returned_not_raised(self):
+        """`sync_chapter` runs under a pool map over eighty chapters; one
+        raising would abandon the rest mid-run."""
+        drive = _FakeDrive({"chap": []}, {}).install(self)
+
+        def boom(folder_id):
+            raise RuntimeError("403 insufficient permissions")
+        cc.list_children = boom
+        r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertIn("RuntimeError", r.error)
+        self.assertIn("403", r.error)
+        self.assertFalse(r.uploaded)
+        self.assertEqual(drive.uploaded, [])
+
+    def test_an_exception_with_an_empty_message_still_reports_as_a_failure(self):
+        """A bare str(e) would be "" — falsy — and main() counts a chapter with
+        no error and no uploads as ALREADY CURRENT. The class name is what
+        keeps the message truthy."""
+        _drive = _FakeDrive({"chap": []}, {}).install(self)
+
+        def boom(folder_id):
+            raise RuntimeError()
+        cc.list_children = boom
+        r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertTrue(r.error, "an empty message must not read as success")
+        self.assertIn("RuntimeError", r.error)
+
+    def test_the_comparison_download_is_cleaned_up_even_when_it_fails(self):
+        """The scratch copies land in one shared tmpdir for the whole run; a
+        leaked one per file is 1400 files of art on the runner's disk."""
+        drive = self._full_icons_folder()
+        real = drive.gws_download
+
+        def flaky(file_id, out):
+            real(file_id, out)
+            if file_id == "d-Agent 05.gif":
+                raise OSError("connection reset")
+        cc.gws_download = flaky
+        r = ua.sync_chapter("chap", "Boston", self.art, True, self.work)
+        self.assertIn("OSError", r.error)
+        self.assertEqual(os.listdir(self.work), [], "a scratch file was left behind")
+
+
+class TestTheRecord(unittest.TestCase):
+    def test_a_synced_defaults_to_no_work_and_no_error(self):
+        r = ua.Synced("Boston")
+        self.assertEqual((r.name, r.uploaded, r.skipped, r.error),
+                         ("Boston", (), (), None))
+
+
+if __name__ == "__main__":
+    # Every TestCase in this module must actually be collected. Appending a
+    # class BELOW this guard defines it after unittest.main() has already run,
+    # so it is silently never executed.
+    import inspect
+    defined = [n for n, o in list(globals().items())
+               if inspect.isclass(o) and issubclass(o, unittest.TestCase)]
+    loaded = unittest.defaultTestLoader.loadTestsFromModule(sys.modules[__name__])
+    collected = {type(t).__name__ for s_ in loaded for t in s_}
+    missing = sorted(set(defined) - collected)
+    if missing:
+        raise SystemExit("test classes defined but never collected: %s"
+                         % ", ".join(missing))
+    unittest.main()

--- a/skills/aaif-create-chapter/scripts/upload_agents.py
+++ b/skills/aaif-create-chapter/scripts/upload_agents.py
@@ -51,6 +51,7 @@ import os
 import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from typing import NamedTuple, Optional, Sequence
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import create_chapter as cc      # noqa: E402
@@ -94,19 +95,39 @@ def art_for(art_dir, name):
     return want
 
 
+class Synced(NamedTuple):
+    """What one chapter's `Icons/` folder needed.
+
+    `uploaded` and `skipped` are both lists of filenames and were returned
+    positionally next to each other, which is a swap waiting to happen — and
+    the summary counts a chapter as clean on `not uploaded` alone, so a swap
+    would report a whole estate as current while uploading nothing.
+
+    `error` is beside them rather than raised: `sync_chapter` runs under a
+    `ThreadPoolExecutor.map`, and one chapter's Drive failure must not take the
+    other eighty down with it.
+    """
+    name: str
+    uploaded: Sequence = ()
+    skipped: Sequence = ()
+    error: Optional[str] = None
+
+
 def sync_chapter(chapter_id, name, art_dir, write, tmpdir):
-    """(name, uploaded, skipped, error). Idempotent: a file whose bytes already
-    match is left alone, so a re-run after adding one chapter touches only it."""
+    """Bring one chapter's `Icons/` folder up to date. Returns a `Synced`.
+
+    Idempotent: a file whose bytes already match is left alone, so a re-run
+    after adding one chapter touches only it."""
     want = art_for(art_dir, name)
     if not any(f.endswith(" Agent.gif") for f, _p in want):
-        return name, [], [], "no agent art generated for this chapter"
+        return Synced(name, error="no agent art generated for this chapter")
     try:
         kids = cc.list_children(chapter_id)
         folder = next((k for k in kids if k["name"] == ICONS_FOLDER
                        and k["mimeType"] == cc.FOLDER), None)
         if folder is None:
             if not write:
-                return name, [f for f, _p in want], [], None
+                return Synced(name, uploaded=[f for f, _p in want])
             folder_id = cc.create_folder(ICONS_FOLDER, chapter_id)
             existing = {}
         else:
@@ -138,9 +159,11 @@ def sync_chapter(chapter_id, name, art_dir, write, tmpdir):
                 else:
                     cc.gws_upload(hit["id"], path, mime)
             uploaded.append(fname)
-        return name, uploaded, skipped, None
+        return Synced(name, uploaded, skipped)
     except Exception as e:
-        return name, [], [], "%s: %s" % (type(e).__name__, str(e)[:200])
+        # Never a bare str(): an exception whose str() is empty would be falsy
+        # and main() would count the chapter as clean, printing nothing at all.
+        return Synced(name, error="%s: %s" % (type(e).__name__, str(e)[:200]))
 
 
 def main():
@@ -183,16 +206,17 @@ def main():
     missing = []
     with tempfile.TemporaryDirectory() as tmpdir, \
             ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        for name, up, skip, err in pool.map(
+        for r in pool.map(
                 lambda t: sync_chapter(t[0], t[1], args.art, args.write, tmpdir), todo):
-            if err:
+            if r.error:
                 failed += 1
-                missing.append((name, err))
-                print("  FAILED  %s\n            %s" % (name, err))
-            elif up:
+                missing.append((r.name, r.error))
+                print("  FAILED  %s\n            %s" % (r.name, r.error))
+            elif r.uploaded:
                 uploaded += 1
                 print("  %s  %-26s %d file(s)"
-                      % ("UPLOADED" if args.write else "would add", name, len(up)))
+                      % ("UPLOADED" if args.write else "would add", r.name,
+                         len(r.uploaded)))
             else:
                 clean += 1
     print("\n%d chapter(s) %s, %d already current, %d failed."

--- a/skills/aaif-create-chapter/scripts/upload_agents.py
+++ b/skills/aaif-create-chapter/scripts/upload_agents.py
@@ -51,7 +51,7 @@ import os
 import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import NamedTuple, Optional, Sequence
+from typing import NamedTuple, Optional
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import create_chapter as cc      # noqa: E402
@@ -108,8 +108,10 @@ class Synced(NamedTuple):
     other eighty down with it.
     """
     name: str
-    uploaded: Sequence = ()
-    skipped: Sequence = ()
+    #: Filenames sent (or, in a plan run, that WOULD be sent).
+    uploaded: tuple = ()
+    #: Filenames already byte-identical in Drive and left alone.
+    skipped: tuple = ()
     error: Optional[str] = None
 
 
@@ -118,16 +120,21 @@ def sync_chapter(chapter_id, name, art_dir, write, tmpdir):
 
     Idempotent: a file whose bytes already match is left alone, so a re-run
     after adding one chapter touches only it."""
-    want = art_for(art_dir, name)
-    if not any(f.endswith(" Agent.gif") for f, _p in want):
-        return Synced(name, error="no agent art generated for this chapter")
     try:
+        # Inside the try: `art_for` does an `os.listdir`, and an art directory
+        # that vanishes or turns unreadable mid-run would otherwise raise
+        # straight out through `pool.map` and abandon every chapter that had
+        # not been reached yet — the exact failure this function returns its
+        # error rather than raising in order to avoid.
+        want = art_for(art_dir, name)
+        if not any(f.endswith(" Agent.gif") for f, _p in want):
+            return Synced(name, error="no agent art generated for this chapter")
         kids = cc.list_children(chapter_id)
         folder = next((k for k in kids if k["name"] == ICONS_FOLDER
                        and k["mimeType"] == cc.FOLDER), None)
         if folder is None:
             if not write:
-                return Synced(name, uploaded=[f for f, _p in want])
+                return Synced(name, uploaded=tuple(f for f, _p in want))
             folder_id = cc.create_folder(ICONS_FOLDER, chapter_id)
             existing = {}
         else:
@@ -159,7 +166,7 @@ def sync_chapter(chapter_id, name, art_dir, write, tmpdir):
                 else:
                     cc.gws_upload(hit["id"], path, mime)
             uploaded.append(fname)
-        return Synced(name, uploaded, skipped)
+        return Synced(name, tuple(uploaded), tuple(skipped))
     except Exception as e:
         # Never a bare str(): an exception whose str() is empty would be falsy
         # and main() would count the chapter as clean, printing nothing at all.
@@ -208,7 +215,10 @@ def main():
             ThreadPoolExecutor(max_workers=args.jobs) as pool:
         for r in pool.map(
                 lambda t: sync_chapter(t[0], t[1], args.art, args.write, tmpdir), todo):
-            if r.error:
+            # `is not None`, not truthiness: `error` is a defaulted field now,
+            # and an empty string would fall through to `else: clean += 1` —
+            # the chapter counted "already current", nothing printed, exit 0.
+            if r.error is not None:
                 failed += 1
                 missing.append((r.name, r.error))
                 print("  FAILED  %s\n            %s" % (r.name, r.error))
@@ -221,6 +231,20 @@ def main():
                 clean += 1
     print("\n%d chapter(s) %s, %d already current, %d failed."
           % (uploaded, "updated" if args.write else "would be updated", clean, failed))
+    # The module docstring promises "a full run reports which chapters are
+    # missing their agent, so a forgotten one shows up rather than staying
+    # invisible". `missing` was collected and never read, so that summary did
+    # not exist — the inline FAILED lines scroll past in an eighty-chapter run,
+    # which is exactly when the promise matters.
+    if missing:
+        print("\nCHAPTERS NEEDING ATTENTION (%d):" % len(missing))
+        for name, why in sorted(missing):
+            print("  - %-26s %s" % (name, why))
+        no_art = [n for n, why in missing if why.startswith("no agent art")]
+        if no_art:
+            print("\n%d of these have no generated agent. Rebuild the art for "
+                  "them before re-running:\n  %s"
+                  % (len(no_art), ", ".join(sorted(no_art))))
     if uploaded and not args.write:
         print("Re-run with --write to apply.")
     return 1 if failed else 0


### PR DESCRIPTION
## Summary

Closes the three items deferred out of #32: a design-system rule that was
flattening the thing it was meant to protect, the report dict that made a
skipped upload silent, and the last untested script in
`aaif-create-chapter/scripts/`.

The first changed shape once the evidence was in — it is a removal, not the
narrowing originally proposed. A six-agent self-review then found 24 further
issues, all applied in `bcd55ac`.

## Changesets

### 1. `bc7a586` — the three deferred follow-ups

**`_MONO_IS_PROSE` removed — mono in the trackers is metadata.**
The rule rewrote every JetBrains Mono run in `word/document.xml` to Instrument
Sans, on the reading that the trackers' 205 mono runs were body prose. Reading
all 205 out of the pre-sweep tracker (`78a6599`) says otherwise — they are field
labels (`EVENT TITLE`, `DATE & TIME`, `VENUE`), table headers
(`TASK`/`OWNER`/`DUE`/`STATUS`), dates, owners, statuses, and phase eyebrows
(`4 WEEKS OUT   May 27 · lock the basics`). The prose — task lines, the chapter
blurb, the how-to-use copy — was already in the sans. `DESIGN.md` reserves mono
for "metadata and eyebrows", so the rule deleted the one thing mono is for.

**Records replace the report dict and the positional returns.** `Changes`
(with `wrote` / `conformant`), `Outcome`, `Estate`, `Legibility`, `ox.Pruned`,
`ox.Rescued`, `Synced`. The dict's `{}`-means-conformant sentinel and
`report.get("rescued", (0,))[0]` are both gone.

**`test_upload_agents.py`** for the last untested script in that folder.

### 2. `bcd55ac` — the self-review, 24 findings from six agents

Full detail in the two review comments. The behaviour-visible ones:

- **A silent failure fixed.** `--fix-contrast` over a deck whose failing runs
  `improve_contrast` declines to repair returned `Rescued(0, 12, 12)` and
  `process()` dropped the record: twelve runs measured below AA, counted clean,
  exit 0. It now reports `! legibility: N run(s) below AA and NOT repairable
  without breaking others`.
- **Three false claims corrected** — including two I wrote. A docstring
  contained a post-mortem for a bug that never shipped; `DESIGN.md`'s
  "~180KB" was wrong on every basis (measured: 153,600 bytes zipped / ~321KB
  unpacked); and `CHANGELOG.md` still listed the 205 mono runs as body-prose
  drift that was fixed.
- **Coverage that was theatre.** Mutation testing found `if write:` → `if True:`
  survived all 15 upload tests, and every disjunct of the reporting predicate
  could be replaced with `False` untouched. Both now fail.

## Test Plan

- [x] `PYTHONPATH=lib python -m pytest lib/aaif_events/tests -q` — 378 passed, 1 skipped
- [x] All 29 skill test scripts — 29/29 exit 0
- [x] `pre-commit run --all-files` — 18 hooks
- [x] `check_no_secret_args.py`, `check_workflows.py`, `extract_design_tokens.py --check`, `claude plugin validate .`
- [x] End-to-end over a real pre-sweep tracker: 26 off-system values → 0, all
      205 mono runs preserved, `audit() == []`, re-run byte-identical
- [x] Mutation-verified: reintroducing the mono rule fails 5 tests;
      `if write:` → `if True:` fails; each predicate disjunct is load-bearing

## Reviewer notes

Two judgement calls, not defects:

1. **The ~62 trackers in Drive are still flattened.** This stops future sweeps;
   restoring the mono means the `--backup-dir` archives from the #32 run.
2. **Size regresses on purpose** — ~430KB, up from ~19KB, of which ~186KB is the
   Manrope fallback rather than mono. Not embedding JetBrains Mono (as we
   already don't embed Instrument Sans) would recover it, but that is a separate
   policy decision, deliberately not made here.

Two design items were deferred on the type-design pass's own advice: splitting
`Changes` into a sum type (needs `process()`'s nine mode flags split first, and
would be worse done alone) and typing `Estate.entries`' Drive dicts.

_Generated using hero-skills._