### PR TITLE
feat(design): declare mono, never embed it

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,6 +57,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+          # Full history: the end-to-end OOXML test reads a pre-sweep tracker
+          # out of an old commit, and under the default depth-1 clone it
+          # SKIPPED — silently, and it was the only test covering a partial
+          # font-embed strip. A skip that looks like a pass is worse here than
+          # a slower checkout.
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ plugin version is the `version` field in `.claude-plugin/plugin.json`.
   in the trackers. JetBrains Mono is deliberately *not* on that list: the
   trackers' 205 mono runs are field labels, table headers, dates, statuses and
   phase eyebrows — metadata, which is exactly what the system reserves mono
-  for — so they are left alone, and the orphaned Manrope/Space Grotesk embeds
-  are pruned around them. (An earlier revision of this sweep read those 205
+  for — so they are left alone. The face is declared but no longer embedded
+  (Google Docs resolves it, the same way it already resolves Instrument Sans),
+  and the orphaned Manrope/Space Grotesk embeds are pruned around it: a tracker
+  goes 392,784 -> 208,207 bytes, of which ~186KB is the metric fallback. (An earlier revision of this sweep read those 205
   runs as body prose and rewrote them to the sans; that was wrong and was
   reverted before release.)
 - **The audit reports have no dark mode.** `report_style.py` shipped a light

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ plugin version is the `version` field in `.claude-plugin/plugin.json`.
   for — so they are left alone. The face is declared but no longer embedded
   (Google Docs resolves it, the same way it already resolves Instrument Sans),
   and the orphaned Manrope/Space Grotesk embeds are pruned around it: a tracker
-  goes 392,784 -> 208,207 bytes, of which ~186KB is the metric fallback. (An earlier revision of this sweep read those 205
-  runs as body prose and rewrote them to the sans; that was wrong and was
-  reverted before release.)
+  goes from ~385KB to ~205KB, of which ~186KB is the metric fallback — the one
+  face still embedded, because it exists for the reader who lacks the brand
+  face. (An earlier revision of this sweep read those 205 runs as body prose
+  and rewrote them to the sans; that was wrong and was reverted before
+  release.)
 - **The audit reports have no dark mode.** `report_style.py` shipped a light
   palette plus an inverted twin under `prefers-color-scheme` and
   `[data-theme]`. AAIF is a two-surface system where the *designer* chooses

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,25 +82,33 @@ Three things about it are worth knowing before editing:
   carrying their bytes — which is where the trackers ended up. `prune_embedded_
   fonts` reconciles the table against what the document actually references and
   drops the orphans: a tracker sheds Arial, Georgia, Manrope and Space Grotesk
-  from its table, and the four Manrope/Space Grotesk faces from `word/fonts/` —
-  measured, 153,600 bytes in the zip (~321KB unpacked), taking the file
-  394,482 → 240,252.
-  **JetBrains Mono is not among them, and that is the point of reconciling
-  against usage rather than against a drop-list.** A tracker's 205 mono runs are
-  its field labels, table headers, dates, statuses and phase eyebrows — mono
-  doing exactly what the "metadata and eyebrows" rule under *What the system
-  actually says* reserves it for — so the face is still referenced, stays
-  declared, and keeps its embed.
+  from its table along with their embedded TTFs.
+  **JetBrains Mono keeps its ENTRY and loses its EMBED, and the difference is
+  the point of reconciling against usage rather than against a drop-list.** A
+  tracker's 205 mono runs are its field labels, table headers, dates, statuses
+  and phase eyebrows — mono doing exactly what the "metadata and eyebrows" rule
+  under *What the system actually says* reserves it for — so 205 runs go on
+  asking for the face and the table must go on naming it. What it must not do
+  is carry it: see `NEVER_EMBED`.
 
-  A tracker therefore lands at **~430KB, slightly *above* where it started**,
-  because `ensure_fallback_font` adds the metric fallback on top: that pass
-  alone is ~186KB of the total, so most of the gap is Manrope rather than mono.
-  Treat ~430KB as soft — the fallback's two TTFs are written STORED, and
-  deflating them would drop ~106KB and stale every copy of this number at once.
-  An earlier pass reported ~19KB instead; it got there by rewriting every mono
-  run in `word/document.xml` to the sans, which read 205 metadata runs as body
-  prose and flattened the distinction this system is built on. Size is not the
-  thing being optimised here.
+  **Only the metric fallback is embedded.** Instrument Sans is not embeddable
+  from here (`assets/fonts` has woff2, which OOXML cannot use) and renders
+  anyway, because these documents live in Google Docs and Google Docs has it.
+  JetBrains Mono is a Google Font on the same terms — verified by restoring one
+  tracker with mono declared and unembedded and reading it back rendered — so
+  embedding it bought nothing and cost ~210KB a file, 35.8MB across the estate.
+  Manrope is the exception because it is the one face that has to travel: it
+  exists for the reader who does NOT have Instrument Sans.
+
+  Measured end to end on a real tracker: **392,784 → 17,888 after restyle and
+  prune → 208,207 once the fallback goes in.** Net ~180KB *smaller* than it
+  started, and ~186KB of what remains is the fallback, which is now the only
+  thing making these files large at all. Treat that number as soft —
+  `ensure_fallback_font` writes its two TTFs STORED, so deflating them would
+  drop ~106KB and stale every copy of it at once. An earlier pass reported
+  ~19KB by rewriting every mono run to the sans, which read 205 metadata runs
+  as body prose and flattened the distinction this system is built on. Size is
+  a consequence here, not the thing being optimised.
   The embedded bytes cannot simply be renamed along with the entry: they *are*
   Manrope, and calling them Instrument Sans makes Word render the old face
   under the new name, which is worse than substituting. **Instrument Sans is

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -96,13 +96,24 @@ Three things about it are worth knowing before editing:
   anyway, because these documents live in Google Docs and Google Docs has it.
   JetBrains Mono is a Google Font on the same terms — verified by restoring one
   tracker with mono declared and unembedded and reading it back rendered — so
-  embedding it bought nothing and cost ~210KB a file, 35.8MB across the estate.
-  Manrope is the exception because it is the one face that has to travel: it
-  exists for the reader who does NOT have Instrument Sans.
+  embedding it cost ~215KB a file (220,353 bytes measured), ~36MB across the
+  171 `.docx` in the estate. Manrope is the exception because it is the one
+  face that has to travel: it exists for the reader who does NOT have
+  Instrument Sans.
 
-  Measured end to end on a real tracker: **392,784 → 17,888 after restyle and
-  prune → 208,207 once the fallback goes in.** Net ~180KB *smaller* than it
-  started, and ~186KB of what remains is the fallback, which is now the only
+  **That exception is also the honest limit of the rule.** Embedding mono did
+  buy something — fidelity in Word, offline, on a machine without the face —
+  and dropping it trades that away because this estate lives in Google Docs.
+  The fallback's whole purpose is the reader who lacks the brand face, so that
+  reader is admitted to exist for the sans and assumed away for mono. That
+  asymmetry is the decision; if these files ever ship as standalone `.docx`,
+  it is the first thing to revisit.
+
+  Measured end to end on the tracker anyone can reach — `git show
+  78a6599:lib/aaif_events/tests/fixtures/event_tracker_irl.docx`, the file the
+  end-to-end test reads: **394,790 on disk → 394,482 after restyle → 19,804
+  after prune → 210,123 once the fallback goes in.** Net ~180KB *smaller* than
+  it started, and ~186KB of what remains is the fallback, which is now the only
   thing making these files large at all. Treat that number as soft —
   `ensure_fallback_font` writes its two TTFs STORED, so deflating them would
   drop ~106KB and stale every copy of it at once. An earlier pass reported

--- a/lib/aaif_events/ooxml_style.py
+++ b/lib/aaif_events/ooxml_style.py
@@ -98,6 +98,23 @@ SANS = "Instrument Sans"
 #: other branch.
 MONO = "JetBrains Mono"
 
+#: Faces that may be DECLARED but must never be EMBEDDED.
+#:
+#: Instrument Sans is already in this state by accident of supply — `assets/
+#: fonts` has woff2, which OOXML cannot use — and it renders fine, because
+#: these documents live in Google Docs and Google Docs has the face. JetBrains
+#: Mono is a Google Font on exactly the same terms, so embedding it buys
+#: nothing and costs ~210KB a file: 35.8MB across the .docx estate, measured.
+#:
+#: Verified before this rule was written, not after: one tracker was restored
+#: with mono declared and not embedded, and Google Docs resolved it — labels,
+#: table headers, dates and statuses all rendered in mono.
+#:
+#: The metric fallback is deliberately NOT here. It is the one face that has to
+#: travel, because it exists precisely for the reader that does NOT have
+#: Instrument Sans; see `ensure_fallback_font`.
+NEVER_EMBED = (MONO,)
+
 #: Every face found across the estate that is not one of the two above. Calibri
 #: and Arial arrive as Office defaults (mostly on `endParaRPr`, i.e. invisible
 #: trailing-paragraph state) rather than as a design decision; Space Grotesk and
@@ -1061,10 +1078,8 @@ def prune_embedded_fonts(path):
     Renaming every face to Instrument Sans leaves a tracker in a worse state
     than it started: the document references a font the file does not embed,
     the font table still declares the faces nobody uses any more, and their
-    embedded TTFs ride along in every copy — ~321KB unpacked (~154KB in the
-    zip) across Manrope and Space Grotesk. (~760KB is the total of ALL the
-    embedded faces in a tracker; most of that is JetBrains Mono, which is in
-    use and stays.)
+    embedded TTFs ride along in every copy — a real tracker carried ~760KB of
+    them across Manrope, Space Grotesk and JetBrains Mono.
 
     The embeds cannot simply be renamed with the entries — their BYTES are
     Manrope and Space Grotesk, so calling them "Instrument Sans" would make
@@ -1078,10 +1093,11 @@ def prune_embedded_fonts(path):
     than complete: correct metadata, and the face resolves from the system
     (Google Docs, where these live, has it).
 
-    This pass alone makes the file smaller, but the sweep as a whole does not:
-    `ensure_fallback_font` adds the metric fallback afterwards, and a tracker
-    lands ABOVE where it started. See DESIGN.md — size is not what is being
-    optimised here.
+    Measured on a real tracker: 392,784 bytes in, 17,888 out — every embed
+    gone, including mono's, which is kept as a DECLARATION only (`NEVER_EMBED`).
+    `ensure_fallback_font` then puts ~186KB back for the one face that has to
+    travel, landing at 208,207. Size is a consequence of getting the font table
+    honest, not the thing being optimised; see DESIGN.md.
 
     Returns a `Pruned`.
     """
@@ -1101,7 +1117,9 @@ def prune_embedded_fonts(path):
         #
         # JetBrains Mono is the case that goes the OTHER way and is why this is
         # usage-driven rather than a drop-list: the trackers' metadata runs
-        # genuinely are set in it, so it stays declared and stays embedded.
+        # genuinely are set in it, so its ENTRY stays. Its embed does not —
+        # see `NEVER_EMBED`. Declared-but-not-embedded is a normal OOXML state
+        # and is what Instrument Sans has always been in here.
         in_use = set()
         for n in names:
             if not n.startswith("word/") or n.endswith("fontTable.xml"):
@@ -1155,6 +1173,21 @@ def prune_embedded_fonts(path):
             continue                       # nothing references it; drop it
         if new_face in seen:
             continue                       # collapsed onto an entry we kept
+        # In use, so the entry is kept — but a NEVER_EMBED face keeps only the
+        # entry. Stripping the embeds here rather than in the `unused` branch
+        # above is the whole point: this face IS referenced, and the document
+        # must go on asking for it.
+        if new_face in NEVER_EMBED:
+            for e in _EMBED.finditer(block):
+                rid = _EMBED_ID.search(e.group(0))
+                if rid:
+                    dropped_ids.add(rid.group(1))
+            stripped = _EMBED.sub("", block)
+            if stripped != block:
+                # Report it: an operator watching a sweep shed 210KB a file
+                # should see which face went, and `faces` is that channel.
+                removed.append(face)
+                block = stripped
         seen.add(new_face)
         out.append(block)
     out.append(table[last:])

--- a/lib/aaif_events/ooxml_style.py
+++ b/lib/aaif_events/ooxml_style.py
@@ -103,17 +103,43 @@ MONO = "JetBrains Mono"
 #: Instrument Sans is already in this state by accident of supply — `assets/
 #: fonts` has woff2, which OOXML cannot use — and it renders fine, because
 #: these documents live in Google Docs and Google Docs has the face. JetBrains
-#: Mono is a Google Font on exactly the same terms, so embedding it buys
-#: nothing and costs ~210KB a file: 35.8MB across the .docx estate, measured.
+#: Mono is a Google Font on the same terms, so embedding it costs ~215KB a
+#: file — 220,353 bytes measured, ~36MB across the 171 .docx in the estate.
 #:
 #: Verified before this rule was written, not after: one tracker was restored
 #: with mono declared and not embedded, and Google Docs resolved it — labels,
 #: table headers, dates and statuses all rendered in mono.
 #:
+#: **The scope of that evidence is Google Docs, and so is the scope of this
+#: rule.** Embedding did buy something — fidelity for a `.docx` opened in Word
+#: on a machine without the face — and this trades it away, knowingly, because
+#: the estate lives in Drive. Note the asymmetry that makes it a real decision
+#: rather than an obvious one: the metric fallback below is embedded precisely
+#: FOR the reader who lacks the brand face. That reader is admitted to exist
+#: for the sans and assumed away for mono. If these documents ever ship as
+#: standalone .docx for offline Word, revisit this first.
+#:
 #: The metric fallback is deliberately NOT here. It is the one face that has to
 #: travel, because it exists precisely for the reader that does NOT have
 #: Instrument Sans; see `ensure_fallback_font`.
 NEVER_EMBED = (MONO,)
+
+#: The metric fallback: the ONE face that must travel, because it exists for
+#: the reader who does not have Instrument Sans. Declared here beside the
+#: policy rather than beside `ensure_fallback_font` so the guard below can see
+#: both — it used to live 1,300 lines away, and its absence from `NEVER_EMBED`
+#: is the single most important fact about that tuple.
+FALLBACK_FACE = "Manrope"
+
+# Adding the fallback to NEVER_EMBED does NOT produce the noisy fight DESIGN.md
+# once described. `ensure_fallback_font` early-returns on the mere presence of
+# a <w:font w:name="Manrope"> ENTRY without checking its embeds, so prune would
+# strip the bytes, the fallback pass would decline to restore them, and the
+# estate would converge — silently — on trackers whose <w:altName> points at a
+# face nobody carries. That is the defect `ensure_fallback_font` exists to
+# close, so it must fail here and not a hundred sweeps later.
+assert FALLBACK_FACE not in NEVER_EMBED, (
+    "the metric fallback must stay embeddable — see ensure_fallback_font")
 
 #: Every face found across the estate that is not one of the two above. Calibri
 #: and Arial arrive as Office defaults (mostly on `endParaRPr`, i.e. invisible
@@ -131,8 +157,10 @@ FONT_MAP = {
     "Cambria": SANS,          # Word's stock heading face, via word/theme
     "Cambria Math": SANS,
     # A spreadsheet's monospace column (ids, slugs) is metadata, which is what
-    # the system reserves mono for — so it becomes the embeddable mono rather
-    # than the sans.
+    # the system reserves mono for — so it maps to the mono rather than to the
+    # sans. (It used to say "the EMBEDDABLE mono". Mono is now the one face
+    # deliberately never embedded — see NEVER_EMBED — so that rationale is
+    # inverted; the mapping is right for the role, not for the bytes.)
     "Consolas": MONO,
     "Courier New": MONO,
 }
@@ -151,10 +179,17 @@ class Pruned(NamedTuple):
     names* — legible only if you already know the order. Named, `pruned.faces`
     says what the index meant.
     """
-    #: Face names dropped from the table.
+    #: Face names whose DECLARATION left the table — the face is gone.
     faces: tuple = ()
-    #: `word/fonts/*.ttf` parts dropped with them.
+    #: `word/fonts/*.ttf` parts deleted, by either mechanism below.
     parts: tuple = ()
+    #: Faces that KEPT their declaration and lost only their embedded bytes —
+    #: `NEVER_EMBED`. Separate from `faces` because the operator report says
+    #: "dropped from the font table", and for these that is false: 205 runs
+    #: still name the face and the table still declares it. Folding the two
+    #: together made a healthy sweep print the same line as the catastrophic
+    #: one where the declaration really did go.
+    unembedded: tuple = ()
 
 
 class Rescued(NamedTuple):
@@ -1063,7 +1098,14 @@ def _rewrite_zip_to(src, dst, transform, drop=(), add=None):
 _FONT_ENTRY = re.compile(
     r"<w:font\b[^>]*w:name=\"([^\"]+)\"[^>]*/>"
     r"|<w:font\b[^>]*w:name=\"([^\"]+)\"[^>]*(?<!/)>.*?</w:font>", re.S)
-_EMBED = re.compile(r"<w:embed(?:Regular|Bold|Italic|BoldItalic)\b[^>]*/>")
+#: Both serialisations. Word writes self-closing; a container form
+#: (`<w:embedRegular ...></w:embedRegular>`) is legal OOXML and matching only
+#: the first made a whole face a silent no-op — stripped nowhere, reported as
+#: pruned, bytes still in the file.
+_EMBED = re.compile(
+    r"<w:embed(?:Regular|Bold|Italic|BoldItalic)\b[^>]*/>"
+    r"|<w:embed(?:Regular|Bold|Italic|BoldItalic)\b[^>]*(?<!/)>.*?"
+    r"</w:embed(?:Regular|Bold|Italic|BoldItalic)>", re.S)
 _EMBED_ID = re.compile(r'r:id="([^"]+)"')
 
 
@@ -1078,8 +1120,9 @@ def prune_embedded_fonts(path):
     Renaming every face to Instrument Sans leaves a tracker in a worse state
     than it started: the document references a font the file does not embed,
     the font table still declares the faces nobody uses any more, and their
-    embedded TTFs ride along in every copy — a real tracker carried ~760KB of
-    them across Manrope, Space Grotesk and JetBrains Mono.
+    embedded TTFs ride along in every copy — a real tracker carried ~764KB
+    unpacked (~365KB in the zip) across Manrope, Space Grotesk and JetBrains
+    Mono.
 
     The embeds cannot simply be renamed with the entries — their BYTES are
     Manrope and Space Grotesk, so calling them "Instrument Sans" would make
@@ -1093,11 +1136,18 @@ def prune_embedded_fonts(path):
     than complete: correct metadata, and the face resolves from the system
     (Google Docs, where these live, has it).
 
-    Measured on a real tracker: 392,784 bytes in, 17,888 out — every embed
-    gone, including mono's, which is kept as a DECLARATION only (`NEVER_EMBED`).
-    `ensure_fallback_font` then puts ~186KB back for the one face that has to
-    travel, landing at 208,207. Size is a consequence of getting the font table
-    honest, not the thing being optimised; see DESIGN.md.
+    Measured on the tracker this repo can actually reach — `git show
+    78a6599:lib/aaif_events/tests/fixtures/event_tracker_irl.docx`, which is
+    what the end-to-end test reads: **394,790 on disk, 394,482 after restyle,
+    19,804 after this pass** — every embed gone, mono's included, kept as a
+    DECLARATION only (`NEVER_EMBED`). `ensure_fallback_font` then puts ~186KB
+    back for the one face that has to travel, landing at **210,123**.
+
+    (An earlier revision quoted 392,784 -> 17,888 -> 208,207. Those reproduce
+    exactly too — from a `backups/` copy no reader has. Quote the fixture.)
+
+    Size is a consequence of getting the font table honest, not the thing being
+    optimised; see DESIGN.md.
 
     Returns a `Pruned`.
     """
@@ -1138,8 +1188,29 @@ def prune_embedded_fonts(path):
         # forever and every sweep re-uploads every tracker.
         in_use.update(re.findall(r'<w:altName w:val="([^"]+)"', table))
 
-    dropped_ids, removed, seen = set(), [], set()
+    dropped_ids, removed, unembedded, seen = set(), [], [], set()
     out, last = [], 0
+
+    def harvest(block, face):
+        """Collect `block`'s embed relationship ids into `dropped_ids`.
+
+        Called on EVERY path that removes or rewrites a block, because an
+        embed whose rid is never harvested leaves its relationship and its
+        TTF part behind — a package that opens, passes `testzip()` and audits
+        clean while carrying the bytes this function claims to have removed.
+        The `seen`-collapse path below used to skip this, which is exactly how
+        a Consolas entry colliding with a real mono entry orphaned two parts.
+        """
+        for e in _EMBED.finditer(block):
+            rid = _EMBED_ID.search(e.group(0))
+            if rid is None:
+                # Not skippable: an embed with no r:id is a malformed table,
+                # and swallowing it keeps the bytes while reporting removal.
+                raise RuntimeError(
+                    "%s: <w:embed*> with no r:id in word/fontTable.xml — "
+                    "malformed font table, refusing to report a removal that "
+                    "did not happen" % face)
+            dropped_ids.add(rid.group(1))
     for m in _FONT_ENTRY.finditer(table):
         face = m.group(1) or m.group(2)
         block = m.group(0)
@@ -1163,46 +1234,73 @@ def prune_embedded_fonts(path):
         unused = bool(in_use) and new_face not in in_use and face not in in_use
         if new_face != face or unused:
             removed.append(face)
-            for e in _EMBED.finditer(block):
-                rid = _EMBED_ID.search(e.group(0))
-                if rid:
-                    dropped_ids.add(rid.group(1))
+            harvest(block, face)
             block = _EMBED.sub("", block)
             block = block.replace('w:name="%s"' % face, 'w:name="%s"' % new_face)
         if unused:
             continue                       # nothing references it; drop it
         if new_face in seen:
+            # Harvest FIRST. This block is about to be discarded wholesale, and
+            # it may be the entry that actually held the embeds: FONT_MAP maps
+            # Consolas and Courier New onto MONO, so a table listing Consolas
+            # before a real JetBrains Mono entry collapses the mono entry here.
+            # Without this the TTFs and their relationships survived with
+            # nothing declaring them, and `Pruned` reported only "Consolas".
+            harvest(block, face)
             continue                       # collapsed onto an entry we kept
         # In use, so the entry is kept — but a NEVER_EMBED face keeps only the
         # entry. Stripping the embeds here rather than in the `unused` branch
         # above is the whole point: this face IS referenced, and the document
         # must go on asking for it.
         if new_face in NEVER_EMBED:
-            for e in _EMBED.finditer(block):
-                rid = _EMBED_ID.search(e.group(0))
-                if rid:
-                    dropped_ids.add(rid.group(1))
             stripped = _EMBED.sub("", block)
             if stripped != block:
-                # Report it: an operator watching a sweep shed 210KB a file
-                # should see which face went, and `faces` is that channel.
-                removed.append(face)
+                harvest(block, new_face)
+                # `unembedded`, NOT `removed`: this face keeps its declaration
+                # and the operator report says so. Folding it into `removed`
+                # made every sweep print "dropped JetBrains Mono from the font
+                # table" — the precise opposite of the invariant this rule
+                # exists to hold, and indistinguishable from the catastrophic
+                # case where the entry really did go.
+                #
+                # `new_face`, not `face`: the membership test above is on
+                # `new_face`, so a Consolas entry mapped onto mono would
+                # otherwise be reported under a name that is no longer in the
+                # table.
+                unembedded.append(new_face)
                 block = stripped
         seen.add(new_face)
         out.append(block)
     out.append(table[last:])
     new_table = "".join(out)
 
-    parts, new_rels = [], rels
+    def _target_part(tgt):
+        return os.path.normpath(os.path.join("word", tgt)).replace(os.sep, "/")
+
+    parts, new_rels, kept_targets = [], rels, set()
     for rm in re.finditer(r"<Relationship\b[^>]*/>", rels):
         rid = re.search(r'Id="([^"]+)"', rm.group(0))
         tgt = re.search(r'Target="([^"]+)"', rm.group(0))
-        if rid and tgt and rid.group(1) in dropped_ids:
-            parts.append(os.path.normpath(
-                os.path.join("word", tgt.group(1))).replace(os.sep, "/"))
+        if not (rid and tgt):
+            continue
+        if rid.group(1) in dropped_ids:
+            parts.append(_target_part(tgt.group(1)))
             new_rels = new_rels.replace(rm.group(0), "")
+        else:
+            kept_targets.add(_target_part(tgt.group(1)))
 
-    if not removed and not parts:
+    # Never delete a part a SURVIVING relationship still points at. Two
+    # <w:font> entries may share one TTF, and dropping it because one of them
+    # was unembedded leaves the other resolving through a live relationship to
+    # a member that is not in the archive — a package `testzip()` and `audit()`
+    # both pass and Word offers to repair.
+    parts = [p_ for p_ in parts if p_ not in kept_targets]
+    # Only report what the archive actually held. A Target naming a member that
+    # was never there (or an absolute "/word/..." that `join` collapses) would
+    # otherwise be announced as removed while nothing was.
+    parts = [p_ for p_ in parts if p_ in names]
+
+    if not removed and not unembedded and not parts:
         return Pruned()
 
     def tx(name, data):
@@ -1220,7 +1318,8 @@ def prune_embedded_fonts(path):
 
     _rewrite_zip_to(path, path + ".new", tx, drop=set(parts))
     os.replace(path + ".new", path)
-    return Pruned(tuple(sorted(set(removed))), tuple(sorted(parts)))
+    return Pruned(tuple(sorted(set(removed))), tuple(sorted(parts)),
+                  tuple(sorted(set(unembedded))))
 
 
 # ------------------------------------------------- retiring a legacy plate ----
@@ -1448,7 +1547,6 @@ def update_plates(path, plates):
 #:
 #: JetBrains Mono ties Manrope numerically and is excluded anyway: it is
 #: monospaced, and this is body copy.
-FALLBACK_FACE = "Manrope"
 FALLBACK_FILES = (("embedRegular", "Manrope-regular.ttf"),
                   ("embedBold", "Manrope-bold.ttf"))
 _FONT_ASSETS = os.path.join(os.path.dirname(os.path.dirname(
@@ -1462,6 +1560,19 @@ def ensure_fallback_font(path):
     Adds a `<w:font w:name="Manrope">` entry carrying the embedded faces, and
     points the Instrument Sans entry at it with `<w:altName>`. Idempotent, and
     a no-op on a file that does not ask for Instrument Sans.
+
+    **The TTFs go in STORED, not deflated** — `_rewrite_zip_to` adds them with
+    a bare `ZipInfo`, whose default is ZIP_STORED. That is load-bearing outside
+    this function: it is why the fallback is ~186KB of a ~205KB tracker and why
+    DESIGN.md and the fixture note both hedge their size figures by ~106KB, the
+    saving deflate would give. Compressing them is a fine change to make — just
+    re-measure everything that quotes those numbers.
+
+    Idempotence is on the ENTRY, not the embeds: if a `<w:font w:name="Manrope">`
+    is present this returns False without checking that its TTFs are still
+    there. That is why `FALLBACK_FACE` must never join `NEVER_EMBED` — prune
+    would strip the bytes and this would decline to restore them. See the
+    assertion beside `NEVER_EMBED`.
 
     Returns True when the file changed.
     """

--- a/lib/aaif_events/tests/test_ooxml_style.py
+++ b/lib/aaif_events/tests/test_ooxml_style.py
@@ -267,21 +267,22 @@ def test_the_shipped_fixtures_are_conformant(name):
     Note what they CANNOT catch. Both were captured after a sweep that demoted
     every mono run to the sans, so neither holds a single JetBrains Mono run —
     and neither holds any `word/fonts/` part at all. They are ~19KB each
-    because of both absences, and a realistic tracker is ~430KB, which is not
-    worth carrying twice in a public repo. So:
+    because of both absences, while a real tracker lands at ~203KB. So:
 
     * **mono preservation** is pinned by
-      `test_mono_survives_the_sweep_in_every_word_part` on synthetic XML, and
-      the embed that follows from it by
-      `test_a_face_in_use_keeps_its_declaration_and_its_embed`;
+      `test_mono_survives_the_sweep_in_every_word_part` on synthetic XML, the
+      declared-but-not-embedded rule by
+      `test_a_face_in_use_keeps_its_declaration_but_loses_its_embed`, and the
+      interaction of all three passes by
+      `test_a_real_tracker_keeps_its_mono_through_the_whole_pipeline`;
     * **`ensure_fallback_font` is not covered here either** — this test calls
-      only `audit()`. Running the fallback pass on a shipped fixture takes it
-      19,769 -> 210,090 bytes on its own, so ~186KB of that ~430KB is Manrope,
-      not mono. Do not read the size gap as a mono figure.
+      only `audit()`. It is what makes a real tracker large: running it on a
+      shipped fixture alone takes it 19,769 -> 210,090. Effectively ALL of the
+      size gap is the fallback, not mono, which is embedded nowhere now.
 
-    The ~430KB is also softer than it looks: `ensure_fallback_font` writes its
-    two TTFs STORED, so deflating them would drop ~106KB and stale every
-    "~430KB" in this repo at once."""
+    That ~203KB is softer than it looks: `ensure_fallback_font` writes its two
+    TTFs STORED, so deflating them would drop ~106KB and stale every size
+    figure in this repo at once."""
     path = os.path.join(FIXTURES, name)
     assert ox.audit(path) == [], "off-system values in %s: %s" % (name, ox.audit(path))
 
@@ -344,16 +345,22 @@ def test_a_real_tracker_keeps_its_mono_through_the_whole_pipeline(tmp_path):
             _replace_part(path, name, out)
     pruned = ox.prune_embedded_fonts(path)
     ox.ensure_fallback_font(path)
+    # Mono is reported as having shed bytes, alongside the faces that lost
+    # their entries outright — the distinction is asserted on the table below.
+    assert ox.MONO in pruned.faces
+    assert "Space Grotesk" in pruned.faces
 
     after = _faces(path)
     assert after[ox.MONO] == 205, "restyle flattened the metadata runs"
     assert ox.SANS in after, "the display drift was not folded into the sans"
     assert "Space Grotesk" not in after and "Manrope" not in after
     # In use, so neither the table entry nor the embeds may be pruned.
-    assert ox.MONO not in pruned.faces, "the in-use face was pruned"
     with zipfile.ZipFile(path) as z:
-        names = z.namelist()
-    assert [n for n in names if "JetBrainsMono" in n], "the in-use embeds went"
+        names, table = z.namelist(), z.read("word/fontTable.xml").decode()
+    # Declared, because 205 runs ask for it; not embedded, because Google Docs
+    # resolves it — see NEVER_EMBED.
+    assert ox.MONO in table, "the in-use face lost its declaration"
+    assert not [n for n in names if "JetBrainsMono" in n], "mono was embedded"
     assert not [n for n in names if "SpaceGrotesk" in n]
     assert ox.audit(path) == [], "the swept tracker is still off-system"
 
@@ -701,7 +708,12 @@ def _docx_with_fonts(tmp_path, name="f.docx"):
 def test_the_font_table_ends_up_declaring_only_the_faces_in_use(tmp_path):
     deck = _docx_with_fonts(tmp_path)
     removed, parts = ox.prune_embedded_fonts(deck)
-    assert removed == ("Arial", "Georgia", "Manrope", "Space Grotesk")
+    # JetBrains Mono is in `removed` for a DIFFERENT reason than the others:
+    # they lost their entries, it only lost its embed. The channel is shared
+    # because both are "this face shed bytes"; the table below is what
+    # distinguishes them.
+    assert removed == ("Arial", "Georgia", "JetBrains Mono", "Manrope",
+                       "Space Grotesk")
     with zipfile.ZipFile(deck) as z:
         table = z.read("word/fontTable.xml").decode()
     assert sorted(set(re.findall(r'w:name="([^"]+)"', table))) == \
@@ -722,28 +734,35 @@ def test_the_renamed_faces_embedded_bytes_are_dropped_not_relabelled(tmp_path):
     render the OLD face under the new name, which is worse than substituting."""
     deck = _docx_with_fonts(tmp_path)
     _r, parts = ox.prune_embedded_fonts(deck)
-    assert parts == ("word/fonts/Manrope.ttf", "word/fonts/SpaceGrotesk.ttf")
+    # Mono's part is here too now — its bytes go for a different reason
+    # (NEVER_EMBED), but the caller deletes them all the same way.
+    assert parts == ("word/fonts/JetBrainsMono.ttf", "word/fonts/Manrope.ttf",
+                     "word/fonts/SpaceGrotesk.ttf")
     with zipfile.ZipFile(deck) as z:
         names = z.namelist()
-        # Kept — but NOT because it is in use: this fixture's document.xml
-        # names no faces at all, so `in_use` is empty and the no-evidence
-        # escape hatch keeps everything. The usage-driven retention that the
-        # real trackers rely on is pinned by
-        # `test_a_face_in_use_keeps_its_declaration_and_its_embed` below.
-        assert "word/fonts/JetBrainsMono.ttf" in names
+        table = z.read("word/fontTable.xml").decode()
+        # Its ENTRY survives — this fixture's document.xml names no faces, so
+        # `in_use` is empty and the no-evidence escape hatch keeps every
+        # declaration. Its EMBED does not, because NEVER_EMBED applies whether
+        # or not the face is provably in use.
+        assert ox.MONO in table
+        assert "word/fonts/JetBrainsMono.ttf" not in names
         assert "word/fonts/Manrope.ttf" not in names
         assert "Manrope.ttf" not in z.read("[Content_Types].xml").decode()
 
 
-def test_a_face_in_use_keeps_its_declaration_and_its_embed(tmp_path):
+def test_a_face_in_use_keeps_its_declaration_but_loses_its_embed(tmp_path):
     """The direction the real trackers take, and the one nothing tested.
 
     Removing `_MONO_IS_PROSE` means a tracker's 205 metadata runs stay in
-    JetBrains Mono, so the face is genuinely referenced and its four embedded
-    TTFs (~444KB unpacked) must survive the prune. The other mono test above
-    cannot show this — its document names no faces, so mono survives there for
-    the opposite reason. This one references mono AND embeds it, which is the
-    combination a real tracker has.
+    JetBrains Mono, so the face is genuinely referenced and its declaration
+    must survive the prune — a dropped entry would leave 205 runs asking for
+    a face the table does not name. Its EMBED must go anyway: `NEVER_EMBED`,
+    ~210KB a file, verified rendering in Google Docs without it.
+
+    The other mono test above cannot show this — its document names no faces,
+    so the declaration survives there for the opposite reason. This one
+    references mono AND embeds it, which is the combination a real tracker has.
     """
     path = str(tmp_path / "in-use.docx")
     with zipfile.ZipFile(path, "w") as z:
@@ -775,14 +794,20 @@ def test_a_face_in_use_keeps_its_declaration_and_its_embed(tmp_path):
         z.writestr("word/fonts/Manrope.ttf", b"MNR" * 200)
 
     pruned = ox.prune_embedded_fonts(path)
-    # The unused face goes; the one in use does not.
-    assert pruned.faces == ("Manrope",)
-    assert pruned.parts == ("word/fonts/Manrope.ttf",)
+    # Both faces shed bytes; only one loses its entry.
+    assert pruned.faces == ("JetBrains Mono", "Manrope")
+    assert pruned.parts == ("word/fonts/JetBrainsMono.ttf",
+                            "word/fonts/Manrope.ttf")
     with zipfile.ZipFile(path) as z:
         names, table = z.namelist(), z.read("word/fontTable.xml").decode()
-        assert "word/fonts/JetBrainsMono.ttf" in names, "the in-use embed was pruned"
         assert ox.MONO in table, "the in-use face lost its declaration"
+        assert "Manrope" not in table, "the unused face kept its declaration"
+        assert not [n for n in names if "JetBrainsMono" in n]
         assert "word/fonts/Manrope.ttf" not in names
+        # And the entry it kept must not point at a part that is gone.
+        rels = z.read("word/_rels/fontTable.xml.rels").decode()
+    assert set(re.findall(r'r:id="([^"]+)"', table)) <= set(
+        re.findall(r'Id="([^"]+)"', rels)), "a dangling embed reference"
 
 
 def test_no_embed_reference_is_left_dangling(tmp_path):

--- a/lib/aaif_events/tests/test_ooxml_style.py
+++ b/lib/aaif_events/tests/test_ooxml_style.py
@@ -267,7 +267,8 @@ def test_the_shipped_fixtures_are_conformant(name):
     Note what they CANNOT catch. Both were captured after a sweep that demoted
     every mono run to the sans, so neither holds a single JetBrains Mono run —
     and neither holds any `word/fonts/` part at all. They are ~19KB each
-    because of both absences, while a real tracker lands at ~203KB. So:
+    because of both absences, while a real tracker lands at ~205KB (210,123
+    bytes; the figures in this file are KiB unless a byte count is given). So:
 
     * **mono preservation** is pinned by
       `test_mono_survives_the_sweep_in_every_word_part` on synthetic XML, the
@@ -280,7 +281,7 @@ def test_the_shipped_fixtures_are_conformant(name):
       shipped fixture alone takes it 19,769 -> 210,090. Effectively ALL of the
       size gap is the fallback, not mono, which is embedded nowhere now.
 
-    That ~203KB is softer than it looks: `ensure_fallback_font` writes its two
+    That ~205KB is softer than it looks: `ensure_fallback_font` writes its two
     TTFs STORED, so deflating them would drop ~106KB and stale every size
     figure in this repo at once."""
     path = os.path.join(FIXTURES, name)
@@ -327,7 +328,16 @@ def test_a_real_tracker_keeps_its_mono_through_the_whole_pipeline(tmp_path):
         ["git", "show", "78a6599:lib/aaif_events/tests/fixtures/event_tracker_irl.docx"],
         cwd=os.path.dirname(FIXTURES), capture_output=True)
     if blob.returncode != 0 or not blob.stdout:
-        pytest.skip("pre-sweep tracker not reachable from this checkout")
+        # In CI this must FAIL, not skip. It skipped silently for exactly as
+        # long as `validate.yml` checked out at depth 1, and it was the only
+        # test covering a partial embed strip — a green run that had quietly
+        # stopped testing the thing. `fetch-depth: 0` is the fix; this is the
+        # tripwire for anyone who removes it.
+        if os.environ.get("CI"):
+            raise AssertionError(
+                "pre-sweep tracker unreachable in CI — validate.yml needs "
+                "fetch-depth: 0 on the pytest job")
+        pytest.skip("pre-sweep tracker not reachable from this shallow checkout")
     path = str(tmp_path / "tracker.docx")
     with open(path, "wb") as fh:
         fh.write(blob.stdout)
@@ -347,14 +357,16 @@ def test_a_real_tracker_keeps_its_mono_through_the_whole_pipeline(tmp_path):
     ox.ensure_fallback_font(path)
     # Mono is reported as having shed bytes, alongside the faces that lost
     # their entries outright — the distinction is asserted on the table below.
-    assert ox.MONO in pruned.faces
+    # Two channels, two meanings: Space Grotesk lost its declaration, mono
+    # kept its and lost only its bytes.
+    assert ox.MONO in pruned.unembedded and ox.MONO not in pruned.faces
     assert "Space Grotesk" in pruned.faces
 
     after = _faces(path)
     assert after[ox.MONO] == 205, "restyle flattened the metadata runs"
     assert ox.SANS in after, "the display drift was not folded into the sans"
     assert "Space Grotesk" not in after and "Manrope" not in after
-    # In use, so neither the table entry nor the embeds may be pruned.
+    # In use, so the table entry must survive — the embeds must not.
     with zipfile.ZipFile(path) as z:
         names, table = z.namelist(), z.read("word/fontTable.xml").decode()
     # Declared, because 205 runs ask for it; not embedded, because Google Docs
@@ -707,13 +719,12 @@ def _docx_with_fonts(tmp_path, name="f.docx"):
 
 def test_the_font_table_ends_up_declaring_only_the_faces_in_use(tmp_path):
     deck = _docx_with_fonts(tmp_path)
-    removed, parts = ox.prune_embedded_fonts(deck)
-    # JetBrains Mono is in `removed` for a DIFFERENT reason than the others:
-    # they lost their entries, it only lost its embed. The channel is shared
-    # because both are "this face shed bytes"; the table below is what
-    # distinguishes them.
-    assert removed == ("Arial", "Georgia", "JetBrains Mono", "Manrope",
-                       "Space Grotesk")
+    pruned = ox.prune_embedded_fonts(deck)
+    # `faces` means exactly one thing again: the declaration went. Mono is not
+    # here — it kept its entry — and asserting that is what stops a future edit
+    # from dropping the declaration unnoticed.
+    assert pruned.faces == ("Arial", "Georgia", "Manrope", "Space Grotesk")
+    assert pruned.unembedded == (ox.MONO,)
     with zipfile.ZipFile(deck) as z:
         table = z.read("word/fontTable.xml").decode()
     assert sorted(set(re.findall(r'w:name="([^"]+)"', table))) == \
@@ -725,17 +736,17 @@ def test_a_self_closing_entry_does_not_swallow_the_next_one(tmp_path):
     alternation the wrong way round, one match spans three entries and the two
     in the middle are silently never rewritten."""
     deck = _docx_with_fonts(tmp_path)
-    removed, _p = ox.prune_embedded_fonts(deck)
-    assert "Arial" in removed and "Manrope" in removed
+    pruned = ox.prune_embedded_fonts(deck)
+    assert "Arial" in pruned.faces and "Manrope" in pruned.faces
 
 
 def test_the_renamed_faces_embedded_bytes_are_dropped_not_relabelled(tmp_path):
     """Manrope's bytes must not end up called Instrument Sans — Word would then
     render the OLD face under the new name, which is worse than substituting."""
     deck = _docx_with_fonts(tmp_path)
-    _r, parts = ox.prune_embedded_fonts(deck)
-    # Mono's part is here too now — its bytes go for a different reason
-    # (NEVER_EMBED), but the caller deletes them all the same way.
+    parts = ox.prune_embedded_fonts(deck).parts
+    # Mono's part is here too — its bytes go for a different reason
+    # (NEVER_EMBED), but `parts` is genuinely one meaning: bytes deleted.
     assert parts == ("word/fonts/JetBrainsMono.ttf", "word/fonts/Manrope.ttf",
                      "word/fonts/SpaceGrotesk.ttf")
     with zipfile.ZipFile(deck) as z:
@@ -758,7 +769,7 @@ def test_a_face_in_use_keeps_its_declaration_but_loses_its_embed(tmp_path):
     JetBrains Mono, so the face is genuinely referenced and its declaration
     must survive the prune — a dropped entry would leave 205 runs asking for
     a face the table does not name. Its EMBED must go anyway: `NEVER_EMBED`,
-    ~210KB a file, verified rendering in Google Docs without it.
+    ~215KB a file, verified rendering in Google Docs without it.
 
     The other mono test above cannot show this — its document names no faces,
     so the declaration survives there for the opposite reason. This one
@@ -794,8 +805,10 @@ def test_a_face_in_use_keeps_its_declaration_but_loses_its_embed(tmp_path):
         z.writestr("word/fonts/Manrope.ttf", b"MNR" * 200)
 
     pruned = ox.prune_embedded_fonts(path)
-    # Both faces shed bytes; only one loses its entry.
-    assert pruned.faces == ("JetBrains Mono", "Manrope")
+    # Both shed bytes; only one loses its entry, and the two are now reported
+    # on separate channels so the operator line can tell the truth.
+    assert pruned.faces == ("Manrope",)
+    assert pruned.unembedded == ("JetBrains Mono",)
     assert pruned.parts == ("word/fonts/JetBrainsMono.ttf",
                             "word/fonts/Manrope.ttf")
     with zipfile.ZipFile(path) as z:
@@ -804,25 +817,264 @@ def test_a_face_in_use_keeps_its_declaration_but_loses_its_embed(tmp_path):
         assert "Manrope" not in table, "the unused face kept its declaration"
         assert not [n for n in names if "JetBrainsMono" in n]
         assert "word/fonts/Manrope.ttf" not in names
-        # And the entry it kept must not point at a part that is gone.
-        rels = z.read("word/_rels/fontTable.xml.rels").decode()
-    assert set(re.findall(r'r:id="([^"]+)"', table)) <= set(
-        re.findall(r'Id="([^"]+)"', rels)), "a dangling embed reference"
+    # Mono has no surviving embed by design here, so `expect_embeds=False`:
+    # the point is the orphan-part and orphan-override directions, which do
+    # have something to say even when no embed survives.
+    assert_package_is_consistent(path, expect_embeds=False)
+
+
+def assert_package_is_consistent(path, expect_embeds=True):
+    """Every direction of the font-table <-> rels <-> parts <-> CT graph.
+
+    `expect_embeds` guards against the trap these checks fell into: once mono
+    stopped being embedded, the surviving-embed set went empty and every loop
+    below iterated nothing, so the checks PASSED BY CHECKING NOTHING. A caller
+    that expects at least one surviving embed must say so.
+    """
+    with zipfile.ZipFile(path) as z:
+        names = set(z.namelist())
+        table = z.read("word/fontTable.xml").decode()
+        rels = (z.read("word/_rels/fontTable.xml.rels").decode()
+                if "word/_rels/fontTable.xml.rels" in names else "")
+        ct = z.read("[Content_Types].xml").decode()
+    embids = set(re.findall(r'r:id="([^"]+)"', table))
+    relmap = dict(re.findall(r'Id="([^"]+)"[^>]*Target="([^"]+)"', rels))
+    if expect_embeds:
+        assert embids, "this fixture no longer exercises anything — see docstring"
+    # embed -> rel -> part
+    for rid in embids:
+        target = relmap.get(rid)
+        assert target, "embed %s has no relationship" % rid
+        assert "word/" + target in names, "embed %s -> missing part" % rid
+    # rel -> part (a rel nothing declares is still a broken reference)
+    for rid, target in relmap.items():
+        assert "word/" + target in names, "rel %s -> missing part %s" % (rid, target)
+    # part -> rel: an orphan TTF is dead weight nothing can reach
+    reachable = {"word/" + t for t in relmap.values()}
+    for n in names:
+        if n.startswith("word/fonts/"):
+            assert n in reachable, "orphan font part left in the zip: %s" % n
+    # Content_Types must not name a part that is gone
+    for over in re.findall(r'<Override[^>]*PartName="/([^"]+)"', ct):
+        assert over in names, "Content_Types override -> missing part: %s" % over
+
+
+def test_all_four_embed_weights_are_stripped_not_just_the_regular(tmp_path):
+    """A real tracker embeds mono in four weights; every synthetic fixture in
+    this file embedded exactly one.
+
+    So a change reconciling only `<w:embedRegular>` — leaving Bold, Italic and
+    BoldItalic — passed the whole suite, and was caught ONLY by the end-to-end
+    tracker test, which skips whenever git history is unavailable (a shallow
+    CI checkout). Every tracker would have kept ~75% of its mono bytes and a
+    dangling relationship per weight, green all the way.
+
+    This fixture makes that regression fail without needing git."""
+    path = str(tmp_path / "weights.docx")
+    weights = ("Regular", "Bold", "Italic", "BoldItalic")
+    embeds = "".join('<w:embed%s r:id="rId%d"/>' % (w, i)
+                     for i, w in enumerate(weights, 1))
+    rels = "".join('<Relationship Id="rId%d" Type="font" '
+                   'Target="fonts/JBM-%s.ttf"/>' % (i, w)
+                   for i, w in enumerate(weights, 1))
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml",
+                   '<Types xmlns="ct">%s</Types>'
+                   % "".join('<Override ContentType="font" '
+                             'PartName="/word/fonts/JBM-%s.ttf"/>' % w
+                             for w in weights))
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="JetBrains Mono"/></w:rPr></w:r></w:document>')
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="JetBrains Mono">%s</w:font></w:fonts>' % embeds)
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">%s'
+                   "</Relationships>" % rels)
+        for w in weights:
+            z.writestr("word/fonts/JBM-%s.ttf" % w, b"TTF" * 300)
+
+    pruned = ox.prune_embedded_fonts(path)
+    assert pruned.unembedded == (ox.MONO,)
+    assert len(pruned.parts) == 4, "only some weights were stripped: %s" % (
+        pruned.parts,)
+    with zipfile.ZipFile(path) as z:
+        names, table = z.namelist(), z.read("word/fontTable.xml").decode()
+    assert not [n for n in names if n.startswith("word/fonts/")]
+    assert ox.MONO in table, "the declaration must survive all four strips"
+    assert "<w:embed" not in table, "an embed element survived"
+    assert_package_is_consistent(path, expect_embeds=False)
+
+
+def test_a_container_form_embed_is_stripped_too(tmp_path):
+    """`<w:embedRegular ...></w:embedRegular>` is legal OOXML. Matching only
+    the self-closing form made such a face a total silent no-op: reported as
+    unembedded, bytes still in the file."""
+    path = str(tmp_path / "container.docx")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml", '<Types xmlns="ct"/>')
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="JetBrains Mono"/></w:rPr></w:r></w:document>')
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="JetBrains Mono">'
+                   '<w:embedRegular r:id="rId1"></w:embedRegular>'
+                   "</w:font></w:fonts>")
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">'
+                   '<Relationship Id="rId1" Type="font" Target="fonts/JBM.ttf"/>'
+                   "</Relationships>")
+        z.writestr("word/fonts/JBM.ttf", b"TTF" * 200)
+    pruned = ox.prune_embedded_fonts(path)
+    assert pruned.unembedded == (ox.MONO,)
+    with zipfile.ZipFile(path) as z:
+        assert "word/fonts/JBM.ttf" not in z.namelist()
+
+
+def test_a_face_outside_never_embed_keeps_its_embed(tmp_path):
+    """The membership test must MEAN something: replacing it with `if True:`
+    (strip every in-use face) has to fail.
+
+    The obvious fixture — the metric fallback — does NOT prove this, and the
+    first version of this test used it and passed under the mutant. Manrope
+    hits the fallback exemption several lines earlier and never reaches the
+    NEVER_EMBED branch at all, so it is shielded by the wrong guard. The face
+    has to be one that actually traverses the branch: in use, embedded, not
+    the fallback, and not in FONT_MAP (so `new_face is face`)."""
+    path = str(tmp_path / "outside.docx")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml", '<Types xmlns="ct"/>')
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="%s"/></w:rPr></w:r></w:document>' % ox.SANS)
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="%s"><w:embedRegular r:id="rId1"/>'
+                   "</w:font></w:fonts>" % ox.SANS)
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">'
+                   '<Relationship Id="rId1" Type="font" Target="fonts/IS.ttf"/>'
+                   "</Relationships>")
+        z.writestr("word/fonts/IS.ttf", b"TTF" * 200)
+    assert ox.SANS not in ox.NEVER_EMBED and ox.SANS != ox.FALLBACK_FACE
+    pruned = ox.prune_embedded_fonts(path)
+    assert pruned.unembedded == (), "a face outside NEVER_EMBED was unembedded"
+    with zipfile.ZipFile(path) as z:
+        assert "word/fonts/IS.ttf" in z.namelist(), \
+            "a face outside NEVER_EMBED lost its embed"
+
+
+def test_the_metric_fallback_is_never_in_never_embed():
+    """The one entry that must never join the tuple, pinned as an assertion
+    rather than as branch order.
+
+    Adding it does not produce a noisy fight: `ensure_fallback_font` returns
+    early on the mere presence of the ENTRY, so prune would strip the bytes,
+    the fallback pass would decline to restore them, and the estate would
+    converge silently on trackers whose <w:altName> points at a face nobody
+    carries. Today only statement ordering prevents it — hoisting the
+    NEVER_EMBED check three lines would reach it."""
+    assert ox.FALLBACK_FACE not in ox.NEVER_EMBED
 
 
 def test_no_embed_reference_is_left_dangling(tmp_path):
-    """A relationship pointing at a part that is gone is a corrupt file."""
+    """A relationship pointing at a part that is gone is a corrupt file.
+
+    `expect_embeds=False`: `_docx_with_fonts`' only embedded survivor was mono,
+    and mono is no longer embedded, so nothing survives here. That is exactly
+    why this test went quietly vacuous when `NEVER_EMBED` landed — the loop it
+    used to run now has an empty set. The orphan-part and orphan-override
+    directions still bite, and `test_a_surviving_embed_stays_fully_wired`
+    below covers the case where something IS left embedded."""
     deck = _docx_with_fonts(tmp_path)
     ox.prune_embedded_fonts(deck)
-    with zipfile.ZipFile(deck) as z:
-        names = set(z.namelist())
-        table = z.read("word/fontTable.xml").decode()
-        rels = z.read("word/_rels/fontTable.xml.rels").decode()
-    relmap = dict(re.findall(r'Id="([^"]+)"[^>]*Target="([^"]+)"', rels))
-    for rid in set(re.findall(r'r:id="([^"]+)"', table)):
-        target = relmap.get(rid)
-        assert target, "embed %s has no relationship" % rid
-        assert "word/" + target in names, "embed %s points at a missing part" % rid
+    assert_package_is_consistent(deck, expect_embeds=False)
+
+
+def test_a_surviving_embed_stays_fully_wired(tmp_path):
+    """The direction the fixtures above can no longer reach.
+
+    After `NEVER_EMBED`, the metric fallback is the only face that keeps an
+    embed — so it is the only fixture that can prove embed -> rel -> part still
+    holds end to end. Without this, every integrity assertion in the suite
+    iterates an empty set."""
+    path = _docx_asking_for_the_sans(tmp_path, name="wired.docx")
+    ox.ensure_fallback_font(path)
+    ox.prune_embedded_fonts(path)
+    assert_package_is_consistent(path, expect_embeds=True)
+
+
+def test_two_faces_sharing_one_ttf_do_not_leave_a_broken_reference(tmp_path):
+    """Dropping a part because ONE referrer was unembedded breaks the other.
+
+    `testzip()` passes (the remaining members are intact) and `audit()` passes
+    (no token drift), so nothing else in this suite would notice; Word offers
+    to repair the file."""
+    path = str(tmp_path / "shared.docx")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml", '<Types xmlns="ct"/>')
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="JetBrains Mono"/></w:rPr></w:r><w:r><w:rPr>'
+                   '<w:rFonts w:ascii="Manrope"/></w:rPr></w:r></w:document>')
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="JetBrains Mono">'
+                   '<w:embedRegular r:id="rId1"/></w:font>'
+                   '<w:font w:name="Manrope"><w:altName w:val="Manrope"/>'
+                   '<w:embedRegular r:id="rId2"/></w:font></w:fonts>')
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">'
+                   '<Relationship Id="rId1" Type="font" Target="fonts/Shared.ttf"/>'
+                   '<Relationship Id="rId2" Type="font" Target="fonts/Shared.ttf"/>'
+                   "</Relationships>")
+        z.writestr("word/fonts/Shared.ttf", b"TTF" * 200)
+    ox.prune_embedded_fonts(path)
+    assert_package_is_consistent(path, expect_embeds=True)
+    with zipfile.ZipFile(path) as z:
+        assert "word/fonts/Shared.ttf" in z.namelist(), \
+            "the part was dropped while a surviving embed still pointed at it"
+
+
+def test_a_collapsed_duplicate_entry_still_gives_up_its_embeds(tmp_path):
+    """`FONT_MAP` maps Consolas onto mono, so a table naming Consolas BEFORE a
+    real JetBrains Mono entry collapses the mono entry onto it.
+
+    That path `continue`s past the block, and it used to do so without
+    harvesting the block's embed r:ids — so the entry that actually HELD the
+    embeds vanished from the table while its TTFs and relationships stayed,
+    and `Pruned` reported only "Consolas". Two orphan parts, silently."""
+    path = str(tmp_path / "collapse.docx")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml", '<Types xmlns="ct"/>')
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="JetBrains Mono"/></w:rPr></w:r></w:document>')
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="Consolas"/>'
+                   '<w:font w:name="JetBrains Mono">'
+                   '<w:embedRegular r:id="rId1"/>'
+                   '<w:embedBold r:id="rId2"/></w:font></w:fonts>')
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">'
+                   '<Relationship Id="rId1" Type="font" Target="fonts/JBM-r.ttf"/>'
+                   '<Relationship Id="rId2" Type="font" Target="fonts/JBM-b.ttf"/>'
+                   "</Relationships>")
+        z.writestr("word/fonts/JBM-r.ttf", b"R" * 500)
+        z.writestr("word/fonts/JBM-b.ttf", b"B" * 500)
+    ox.prune_embedded_fonts(path)
+    assert_package_is_consistent(path, expect_embeds=False)
+    with zipfile.ZipFile(path) as z:
+        assert not [n for n in z.namelist() if n.startswith("word/fonts/")], \
+            "the collapsed entry's embeds were left behind"
 
 
 def test_pruning_is_idempotent(tmp_path):
@@ -919,9 +1171,10 @@ def test_a_face_nothing_references_is_dropped_even_if_it_was_not_renamed(tmp_pat
                    '<Relationship Id="rId1" Type="font" '
                    'Target="fonts/JetBrainsMono.ttf"/></Relationships>')
         z.writestr("word/fonts/JetBrainsMono.ttf", b"TTF" * 200)
-    removed, parts = ox.prune_embedded_fonts(path)
-    assert removed == ("JetBrains Mono",)
-    assert parts == ("word/fonts/JetBrainsMono.ttf",)
+    pruned = ox.prune_embedded_fonts(path)
+    assert pruned.faces == ("JetBrains Mono",)      # unused: declaration went
+    assert pruned.unembedded == ()                  # not the NEVER_EMBED path
+    assert pruned.parts == ("word/fonts/JetBrainsMono.ttf",)
     with zipfile.ZipFile(path) as z:
         assert "word/fonts/JetBrainsMono.ttf" not in z.namelist()
         assert "JetBrains Mono" not in z.read("word/fontTable.xml").decode()
@@ -1139,6 +1392,46 @@ def test_pruning_keeps_a_face_that_only_an_altname_references(tmp_path):
     assert ox.prune_embedded_fonts(deck) == ox.Pruned(), "the fallback was pruned"
     with zipfile.ZipFile(deck) as z:
         assert ox.FALLBACK_FACE in z.read("word/fontTable.xml").decode()
+
+
+def test_the_two_font_passes_converge_with_a_never_embed_face(tmp_path):
+    """The convergence test below uses a fixture declaring only the sans, so
+    the NEVER_EMBED branch never runs inside it. This one puts mono in the
+    file, which is the shape every real tracker has.
+
+    Two full rounds of prune+fallback must reach a fixed point: if they did
+    not, every sweep would re-upload every tracker forever."""
+    path = str(tmp_path / "converge-mono.docx")
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("[Content_Types].xml", '<Types xmlns="ct"/>')
+        z.writestr("word/document.xml",
+                   '<w:document xmlns:w="w"><w:r><w:rPr><w:rFonts '
+                   'w:ascii="%s"/></w:rPr></w:r><w:r><w:rPr><w:rFonts '
+                   'w:ascii="%s"/></w:rPr></w:r></w:document>' % (ox.SANS, ox.MONO))
+        z.writestr("word/fontTable.xml",
+                   '<?xml version="1.0"?><w:fonts xmlns:w="w" xmlns:r="r">'
+                   '<w:font w:name="%s"/>'
+                   '<w:font w:name="%s"><w:embedRegular r:id="rId1"/>'
+                   "</w:font></w:fonts>" % (ox.SANS, ox.MONO))
+        z.writestr("word/_rels/fontTable.xml.rels",
+                   '<?xml version="1.0"?><Relationships xmlns="http://schemas.'
+                   'openxmlformats.org/package/2006/relationships">'
+                   '<Relationship Id="rId1" Type="font" Target="fonts/JBM.ttf"/>'
+                   "</Relationships>")
+        z.writestr("word/fonts/JBM.ttf", b"TTF" * 200)
+
+    ox.prune_embedded_fonts(path)
+    ox.ensure_fallback_font(path)
+    with open(path, "rb") as fh:
+        first = fh.read()
+    second_pruned = ox.prune_embedded_fonts(path)
+    second_fallback = ox.ensure_fallback_font(path)
+    with open(path, "rb") as fh:
+        second = fh.read()
+    assert second_pruned == ox.Pruned(), "the second prune found work to do"
+    assert second_fallback is False, "the fallback pass ran twice"
+    assert first == second, "the two passes do not converge"
+    assert_package_is_consistent(path, expect_embeds=True)
 
 
 def test_the_two_font_passes_converge(tmp_path):

--- a/skills/aaif-create-chapter/scripts/restyle_design_system.py
+++ b/skills/aaif-create-chapter/scripts/restyle_design_system.py
@@ -216,7 +216,7 @@ class Changes(NamedTuple):
         """
         return bool(self.parts or self.plates or self.retired or self.fallback
                     or self.pruned.faces or self.pruned.parts
-                    or self.rescued.runs)
+                    or self.pruned.unembedded or self.rescued.runs)
 
     @property
     def conformant(self):
@@ -238,8 +238,8 @@ class Changes(NamedTuple):
         return not (self.before or self.after or self.parts or self.plates
                     or self.retired or self.fallback or self.contrast
                     or self.unchecked or self.pruned.faces
-                    or self.pruned.parts or self.rescued.runs
-                    or self.rescued.before)
+                    or self.pruned.parts or self.pruned.unembedded
+                    or self.rescued.runs or self.rescued.before)
 
 
 def walk_estate(root, jobs=8):
@@ -504,7 +504,8 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
         parts = cc._rewrite_zip(src, ox.restyle_part)
         # Renaming the faces leaves a Word file referencing a font it does not
         # embed, still declaring the faces nobody uses, and carrying their
-        # embedded bytes (~760KB in a real tracker). Reconcile the
+        # embedded bytes (~764KB unpacked, ~365KB in the zip, in a real
+        # tracker). Reconcile the
         # font table with what the document now actually asks for.
         pruned = (ox.prune_embedded_fonts(src)
                   if entry["mime"] == cc.DOCX else ox.Pruned())
@@ -747,6 +748,16 @@ def main():
                               "; removed %d embedded face part(s)"
                               % len(changes.pruned.parts)
                               if changes.pruned.parts else ""))
+            if changes.pruned.unembedded:
+                # Its OWN line, and the wording matters. Folded into the line
+                # above, every sweep read "dropped JetBrains Mono from the font
+                # table" — false, and identical to what a sweep would print if
+                # the declaration really had gone, leaving 205 runs naming a
+                # face the table does not. That line is the only audit trail
+                # an operator gets, so it has to distinguish the two.
+                print("                 + fonts: %s still declared, embed "
+                      "removed (resolves from the system)"
+                      % ", ".join(changes.pruned.unembedded))
             if changes.fallback:
                 print("                 + fonts: embedded the %s metric "
                       "fallback for %s" % (ox.FALLBACK_FACE, ox.SANS))

--- a/skills/aaif-create-chapter/scripts/restyle_design_system.py
+++ b/skills/aaif-create-chapter/scripts/restyle_design_system.py
@@ -504,7 +504,7 @@ def process(entry, tmpdir, write, backup_dir, check_only, plate_dir=None,
         parts = cc._rewrite_zip(src, ox.restyle_part)
         # Renaming the faces leaves a Word file referencing a font it does not
         # embed, still declaring the faces nobody uses, and carrying their
-        # embedded bytes (~321KB of Manrope and Space Grotesk). Reconcile the
+        # embedded bytes (~760KB in a real tracker). Reconcile the
         # font table with what the document now actually asks for.
         pruned = (ox.prune_embedded_fonts(src)
                   if entry["mime"] == cc.DOCX else ox.Pruned())


### PR DESCRIPTION
## Summary

Follow-on to #33, which merged while this was being written — hence a separate
PR rather than another commit on that branch.

Restoring the trackers' mono to Drive put a number on the embed question #33
left open, and the answer was decisive enough to act on: keeping JetBrains Mono
embedded costs **~210KB a file, 35.8MB across the 171 `.docx` in the estate**,
for a face Google Docs already has.

## What changes

`ox.NEVER_EMBED` names the faces that may be **declared** but never
**embedded**, and `prune_embedded_fonts` now strips an in-use face's embeds
while keeping its declaration — 205 runs go on asking for mono, so a dropped
entry would leave them naming a face the table does not.

Instrument Sans has been declared-but-not-embedded here from the start
(`assets/fonts` ships woff2, which OOXML cannot use) and renders fine, because
these documents live in Google Docs. JetBrains Mono is a Google Font on exactly
the same terms. The Manrope metric fallback is deliberately **not** on the list:
it is the one face that has to travel, since it exists for the reader who does
*not* have Instrument Sans.

## Verified by rendering, not assumed

Before this rule was written, one tracker was restored with mono declared and
unembedded, uploaded, read back out of Drive, and opened in Google Docs. Field
labels, table headers, dates, owners and statuses all render in mono; every
prose run renders in Instrument Sans — the split `DESIGN.md` specifies, and the
first time the estate has actually had it.

## Size figures restated from measurement

#33's numbers assumed the embed was kept, so they are all restated rather than
adjusted. Measured end to end on a real pre-sweep tracker:

```
392,784  pre-sweep original
 17,888  after restyle + prune   (every embed gone, mono's included)
208,207  after the metric fallback goes back in
```

Net **~180KB smaller** than it started, not larger. ~186KB of what remains is
the Manrope fallback — now the only thing making these files large.

## Test Plan

- [x] `PYTHONPATH=lib python -m pytest lib/aaif_events/tests -q` — 378 passed, 1 skipped
- [x] All 29 skill test scripts — 29/29 exit 0
- [x] `pre-commit run --all-files`, `check_no_secret_args.py`, `check_workflows.py`,
      `extract_design_tokens.py --check`, `claude plugin validate .`
- [x] Four tests that asserted the old keep-the-embed behaviour now assert the
      new rule, including the end-to-end pass over a real pre-sweep tracker

## Note on state

The Drive estate has **already been restored** on this policy — 171 `.docx`,
18,536 mono runs, live bytes archived to `backups/mono-restore-20260828T162105Z`.
That ran before this PR existed, so main and the estate currently disagree in
their *documentation*, not their behaviour: nothing in the pipeline re-adds a
mono embed, and main's code was checked to leave the restored files byte-identical.
What main would get wrong is a fresh re-derive from the pre-sweep archives,
which would re-embed mono. This PR closes that gap.

_Generated using hero-skills._