### PR TITLE
Rework the Slack organizer audit: sections, per-row issues, drop PDF

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,7 +33,11 @@ Worth stating, because the obvious guesses are wrong:
   bold. The one exception is h5/h6 (`--t-xl`/`--t-lg` and smaller) at 600 —
   the source system's own type scale, not a report-styling deviation.
 - **Flat.** No drop shadows anywhere. Depth comes from 1px hairlines, surface
-  tinting (`--paper` → `--paper-2` → `--paper-3`) and inset strokes.
+  tinting (`--paper` → `--paper-2` → `--paper-3`) and inset strokes. Reports
+  carry that further into corners: cards, stats, tables and chips are square
+  (`border-radius: 0`) — only genuine pills and badges (buttons, `.pill`,
+  `.cnt`) keep the token scale's `--radius-pill`, because rounding is their
+  actual shape, not decoration on a box.
 - **Two first-class surfaces, and no dark mode.** White editorial and black
   plate — always know which one a component is drawn on, because the *designer*
   picks it per component. Reports are editorial, so the page is white and stays

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,7 +30,8 @@ Worth stating, because the obvious guesses are wrong:
   alike. There is no second display face. Mono is a system stack, used only for
   metadata and eyebrows — never for body copy.
 - **Headings are weight 500**, tracking `-0.02em`, line-height 1.05–1.15. Not
-  600, not bold.
+  bold. The one exception is h5/h6 (`--t-xl`/`--t-lg` and smaller) at 600 —
+  the source system's own type scale, not a report-styling deviation.
 - **Flat.** No drop shadows anywhere. Depth comes from 1px hairlines, surface
   tinting (`--paper` → `--paper-2` → `--paper-3`) and inset strokes.
 - **Two first-class surfaces, and no dark mode.** White editorial and black

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ talk to Slack or Luma.
 | `aaif-update-event` | Edit an event's details or move its date (recomputing all task due-dates), flag stale assets, optionally sync the change to Luma | Google Drive, Luma |
 | `aaif-event-status` | Report overdue / due-soon event tasks by owner, plus read-only Luma registration stats | Google Drive, Luma |
 | `aaif-sync-chapters` | Push intake decisions to the Chapters List, About docs, chapter CRMs, per-chapter Drive access and the resource map (report/propose by default) | Google Sheets/Drive/Docs, Slack |
-| `aaif-audit-slack` | Audit the community Slack workspace — chapter/organizer channel coverage and member/channel health — as self-contained HTML + PDF reports | Slack, Google Sheets |
+| `aaif-audit-slack` | Audit the community Slack workspace — chapter/organizer channel coverage and member/channel health — as a self-contained HTML report | Slack, Google Sheets |
 
 > **Heads up — these ship with AAIF's own IDs.** The ops skills reference AAIF's
 > Google resources (the Chapters Drive, the Intake Ops spreadsheet ID, Luma slug

--- a/lib/aaif_events/report_style.py
+++ b/lib/aaif_events/report_style.py
@@ -192,6 +192,11 @@ BASE_CSS = """
 body{margin:0; background:var(--ground); color:var(--ink-soft);
   font-family:"Instrument Sans",ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
   font-size:15px; line-height:1.55; -webkit-font-smoothing:antialiased}
+/* The design system's own link treatment (`--link`/`--link-hover`) — a
+   real <a> in a report is a page-internal jump (the sections index), not a
+   web link, so no unstyled browser blue should ever show through. */
+a{color:var(--link,var(--ink-1)); text-decoration:none; border-bottom:1px solid currentColor}
+a:hover{color:var(--link-hover,var(--marker))}
 .wrap{max-width:1120px; margin:0 auto; padding:56px 28px 96px;
   display:flex; flex-direction:column; gap:44px}
 h1,h2,h3,h4{font-family:inherit; color:var(--ink-1);
@@ -206,7 +211,7 @@ h3{font-size:1.1rem}
   font-weight:500; margin-bottom:12px}
 .lede{color:var(--ink-soft); max-width:66ch; margin-top:14px}
 code.chan{font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:.82em;
-  background:var(--sunken); border:1px solid var(--line-soft); border-radius:5px;
+  background:var(--sunken); border:1px solid var(--line-soft); border-radius:0;
   padding:1px 6px; color:var(--ink-1); white-space:nowrap}
 /* Masthead + closing band — the design system's own document furniture. */
 .masthead{display:flex; align-items:center; justify-content:space-between;
@@ -219,7 +224,7 @@ code.chan{font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:.82em;
   letter-spacing:var(--tr-eyebrow,.16em); color:var(--ink-faint)}
 .closing{display:flex; align-items:center; justify-content:space-between;
   gap:24px; flex-wrap:wrap; background:var(--void,#000); color:#FFF;
-  border-radius:var(--radius-3,10px); padding:26px 30px; margin-top:8px}
+  border-radius:0; padding:26px 30px; margin-top:8px}
 .closing .cl-line{font-size:1.05rem; font-weight:500; letter-spacing:-.01em}
 .closing .cl-meta{font-family:var(--font-mono,ui-monospace,Menlo,monospace);
   font-size:12px; text-transform:uppercase;
@@ -231,12 +236,12 @@ code.chan{font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:.82em;
 .mute{color:var(--ink-faint)}
 .bad{color:var(--bad); font-weight:650}
 .caveat{background:var(--warn-bg); border:1px solid color-mix(in srgb,var(--warn) 30%,transparent);
-  border-radius:10px; padding:16px 20px; color:var(--ink-1); font-size:.9rem}
+  border-radius:0; padding:16px 20px; color:var(--ink-1); font-size:.9rem}
 .caveat strong{color:var(--warn)}
 /* Per-cell borders, not a 1px grid gap over a tinted container: a short final
    row would otherwise leave a slab of container colour where cells are missing. */
 .stats{display:grid; grid-template-columns:repeat(auto-fit,minmax(158px,1fr)); gap:10px}
-.stat{background:var(--surface); border:1px solid var(--line-1); border-radius:12px;
+.stat{background:var(--surface); border:1px solid var(--line-1); border-radius:0;
   padding:18px 20px; display:flex; flex-direction:column; gap:3px}
 .stat .v{font-size:2rem; font-weight:600; font-variant-numeric:tabular-nums;
   line-height:1.05; color:var(--ink-1); letter-spacing:-.025em}
@@ -251,7 +256,7 @@ button.f:hover{border-color:var(--accent); color:var(--ink-1)}
 button.f[aria-pressed="true"]{background:var(--accent); border-color:var(--accent);
   color:var(--ground)}
 button.f:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
-.tablewrap{overflow-x:auto; border:1px solid var(--line-1); border-radius:12px;
+.tablewrap{overflow-x:auto; border:1px solid var(--line-1); border-radius:0;
   background:var(--surface)}
 table{border-collapse:collapse; width:100%; font-size:.87rem; min-width:800px}
 th,td{text-align:left; padding:9px 14px; border-bottom:1px solid var(--line-soft);
@@ -266,11 +271,11 @@ td.n{text-align:right; font-variant-numeric:tabular-nums; white-space:nowrap}
 .num{font-size:.75rem; color:var(--ink-faint); font-variant-numeric:tabular-nums;
   margin-left:5px}
 .tag{font-size:.63rem; text-transform:uppercase; letter-spacing:.07em; padding:1px 6px;
-  border-radius:4px; margin-left:5px; white-space:nowrap; font-weight:650}
+  border-radius:0; margin-left:5px; white-space:nowrap; font-weight:650}
 .tag-reg{background:var(--warn-bg); color:var(--warn)}
 .tag-pub{background:var(--bad-bg); color:var(--bad)}
 .two{display:grid; grid-template-columns:repeat(auto-fit,minmax(330px,1fr)); gap:20px}
-.card{border:1px solid var(--line-1); border-radius:12px; background:var(--surface);
+.card{border:1px solid var(--line-1); border-radius:0; background:var(--surface);
   padding:20px 22px}
 .card h3{margin-bottom:4px}
 .card .sub{font-size:.8rem; color:var(--ink-faint)}
@@ -280,9 +285,9 @@ td.n{text-align:right; font-variant-numeric:tabular-nums; white-space:nowrap}
   padding-left:20px; color:var(--ink-1); max-width:62ch}
 .chips{display:flex; flex-wrap:wrap; gap:6px; margin-top:12px}
 .chip{font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:.72rem;
-  background:var(--sunken); border:1px solid var(--line-soft); border-radius:5px;
+  background:var(--sunken); border:1px solid var(--line-soft); border-radius:0;
   padding:2px 7px}
-.chap{border:1px solid var(--line-1); border-radius:12px; background:var(--surface);
+.chap{border:1px solid var(--line-1); border-radius:0; background:var(--surface);
   padding:18px 22px}
 .chap h3{display:flex; flex-wrap:wrap; gap:10px; align-items:baseline; margin-bottom:12px}
 .chapchans{display:flex; gap:6px; flex-wrap:wrap}
@@ -313,28 +318,28 @@ ul.plist li.none{color:var(--ink-faint); font-size:.85rem; font-style:italic}
 .bars{display:flex; flex-direction:column; gap:7px; margin-top:14px}
 .brow{display:grid; grid-template-columns:132px 1fr 62px; gap:12px; align-items:center}
 .blab{font-size:.8rem; color:var(--ink-soft); text-align:right}
-.btrack{background:var(--sunken); border-radius:4px; height:14px; position:relative;
+.btrack{background:var(--sunken); border-radius:0; height:14px; position:relative;
   border:1px solid var(--line-soft)}
-.bfill{position:absolute; inset:0 auto 0 0; border-radius:3px; min-width:3px}
+.bfill{position:absolute; inset:0 auto 0 0; border-radius:0; min-width:3px}
 .t-accent{background:var(--accent)} .t-bad{background:var(--bad)} .t-warn{background:var(--warn)}
 .bval{font-size:.8rem; font-variant-numeric:tabular-nums; color:var(--ink-1);
   font-weight:600; text-align:right}
 .funnel{display:flex; flex-direction:column; gap:10px; margin-top:18px}
 .frow{display:grid; grid-template-columns:196px 1fr 96px 52px; gap:14px; align-items:center}
 .flab{font-size:.85rem; color:var(--ink-soft); text-align:right}
-.ftrack{background:var(--sunken); border:1px solid var(--line-soft); border-radius:5px;
+.ftrack{background:var(--sunken); border:1px solid var(--line-soft); border-radius:0;
   height:22px; position:relative}
-.ffill{position:absolute; inset:0 auto 0 0; border-radius:4px}
+.ffill{position:absolute; inset:0 auto 0 0; border-radius:0}
 .fval{font-size:1.05rem; font-weight:650; font-variant-numeric:tabular-nums; text-align:right}
 .fpct{display:block; font-size:.7rem; color:var(--ink-faint); font-weight:500}
 .drop{font-size:.78rem; color:var(--bad); font-variant-numeric:tabular-nums; font-weight:650}
-.stack{display:flex; height:34px; border-radius:8px; overflow:hidden; margin-top:14px;
+.stack{display:flex; height:34px; border-radius:0; overflow:hidden; margin-top:14px;
   border:1px solid var(--line-1); gap:2px; background:var(--line-1)}
 .seg{display:flex; align-items:center; justify-content:center; font-size:.68rem;
   font-weight:700; color:var(--ground); overflow:hidden; white-space:nowrap}
 .legend{display:flex; flex-wrap:wrap; gap:14px; margin-top:10px; font-size:.78rem;
   color:var(--ink-soft)}
-.legend span.sw{width:10px; height:10px; border-radius:3px; display:inline-block;
+.legend span.sw{width:10px; height:10px; border-radius:0; display:inline-block;
   margin-right:6px; vertical-align:-1px}
 /* Prose in a print table fights the column algorithm and overflows the page box,
    so ranked actions are a grid, not a <table>. */

--- a/lib/aaif_events/report_style.py
+++ b/lib/aaif_events/report_style.py
@@ -258,12 +258,17 @@ button.f[aria-pressed="true"]{background:var(--accent); border-color:var(--accen
 button.f:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
 .tablewrap{overflow-x:auto; border:1px solid var(--line-1); border-radius:0;
   background:var(--surface)}
-table{border-collapse:collapse; width:100%; font-size:.87rem; min-width:800px}
+/* width:max-content + min-width:100% (not a flat width:100%) so a table
+   with few columns still fills its wrapper, but one whose columns need more
+   room than that GROWS past it — which is what makes .tablewrap's
+   overflow-x:auto actually engage instead of squeezing every column down to
+   fit and clipping the last one's header text. */
+table{border-collapse:collapse; width:max-content; min-width:100%; font-size:.87rem}
 th,td{text-align:left; padding:9px 14px; border-bottom:1px solid var(--line-soft);
   vertical-align:top}
 thead th{position:sticky; top:0; background:var(--sunken); font-size:.7rem;
   text-transform:uppercase; letter-spacing:.08em; color:var(--ink-faint); font-weight:650;
-  border-bottom:1px solid var(--line-1)}
+  border-bottom:1px solid var(--line-1); white-space:nowrap}
 tbody th{font-weight:600; white-space:nowrap}
 tbody tr:last-child th,tbody tr:last-child td{border-bottom:none}
 tbody tr:hover th,tbody tr:hover td{background:var(--sunken)}
@@ -288,33 +293,28 @@ td.n{text-align:right; font-variant-numeric:tabular-nums; white-space:nowrap}
   background:var(--sunken); border:1px solid var(--line-soft); border-radius:0;
   padding:2px 7px}
 .chap{border:1px solid var(--line-1); border-radius:0; background:var(--surface);
-  padding:18px 22px}
+  padding:18px 22px; min-width:0}
 .chap h3{display:flex; flex-wrap:wrap; gap:10px; align-items:baseline; margin-bottom:12px}
 .chapchans{display:flex; gap:6px; flex-wrap:wrap}
-.grid-chaps{display:grid; grid-template-columns:repeat(auto-fill,minmax(360px,1fr)); gap:16px}
-.grid-rosters{display:grid; grid-template-columns:repeat(auto-fill,minmax(340px,1fr)); gap:16px}
-ul.plist{list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:9px}
-ul.plist li{display:flex; flex-wrap:wrap; gap:4px 10px; align-items:baseline;
-  padding-bottom:9px; border-bottom:1px dashed var(--line-soft)}
-ul.plist li:last-child{border-bottom:none; padding-bottom:0}
-ul.plist li.none{color:var(--ink-faint); font-size:.85rem; font-style:italic}
-.pname{font-weight:600; font-size:.9rem}
-.pmail{font-family:ui-monospace,"SF Mono",Menlo,monospace; font-size:.72rem;
-  color:var(--ink-faint); word-break:break-all}
-.pills{display:flex; gap:5px; flex-wrap:wrap; margin-left:auto}
+/* Full-width, one chapter per row — a 2-up card grid squeezed a 9-column
+   table into ~360px and truncated it. Each chapter is its own subsection,
+   not a card competing for horizontal room with its neighbour. */
+.stack-chaps{display:flex; flex-direction:column; gap:28px}
 .pill{font-size:.66rem; padding:2px 8px; border-radius:99px; white-space:nowrap;
   font-weight:650}
 .pill-ok{background:var(--ok-bg); color:var(--ok)}
 .pill-warn{background:var(--warn-bg); color:var(--warn)}
 .pill-bad{background:var(--bad-bg); color:var(--bad)}
 .pill-mute{background:var(--sunken); color:var(--ink-faint)}
-.cnt{background:var(--accent-soft); color:var(--accent); border-radius:99px; padding:1px 7px;
-  font-size:.68rem; font-weight:700}
-.plist-x li{opacity:.82}
-.roster h3{align-items:center; font-family:ui-monospace,"SF Mono",Menlo,monospace;
-  font-size:.95rem}
-.rgrps{display:flex; flex-direction:column; gap:14px}
-.rgrp h4{display:flex; gap:8px; align-items:center; margin-bottom:8px; font-size:.8rem}
+/* A row with at least one Issues entry — tinted so a scan of the table finds
+   it without reading every cell, using the same restrained warn/bad tokens
+   the pills already use, never a new colour. */
+tr.has-issue td,tr.has-issue th{background:var(--warn-bg)}
+tr.has-issue:hover td,tr.has-issue:hover th{background:var(--warn-bg)}
+/* Not yet accepted — a fact about the ROW, not an issue by itself (a pending
+   applicant with nothing else wrong gets no has-issue tint), so it gets its
+   own, lighter signal. */
+tr.pending td,tr.pending th{font-style:italic}
 .bars{display:flex; flex-direction:column; gap:7px; margin-top:14px}
 .brow{display:grid; grid-template-columns:132px 1fr 62px; gap:12px; align-items:center}
 .blab{font-size:.8rem; color:var(--ink-soft); text-align:right}
@@ -381,11 +381,10 @@ footer{color:var(--ink-faint); font-size:.8rem; border-top:1px solid var(--line-
   .stats{grid-template-columns:repeat(5,1fr); gap:7px; break-inside:avoid}
   .stat{padding:10px 12px} .stat .v{font-size:16pt}
   .two{grid-template-columns:1fr 1fr; gap:12px}
-  .card,.chap,.roster{break-inside:avoid}
+  .card,.chap{break-inside:avoid}
   .card{padding:12px 14px}
   .chap{padding:12px 14px}
-  .grid-chaps,.grid-rosters{grid-template-columns:1fr 1fr; gap:10px}
-  .pmail{font-size:7pt}
+  .stack-chaps{gap:14px}
   .brow{grid-template-columns:106px 1fr 52px; gap:8px}
   .blab,.bval{font-size:7.5pt}
   .btrack{height:11px}

--- a/skills/aaif-audit-slack/SKILL.md
+++ b/skills/aaif-audit-slack/SKILL.md
@@ -22,7 +22,7 @@ Three engines over one workspace, same house rules — **everything is read-only
 
 | Deliverable | Script | Produces |
 |---|---|---|
-| Where to focus | `summarize_audits.py` | **the single HTML report you hand over** — a TL;DR ranking what to fix, with an index into the three full reports as sections below it |
+| Where to focus | `summarize_audits.py` | **the single HTML report you hand over** — an index into four full-report sections (Chapters, Organizers, Topics, Members), with a TL;DR ranking what to fix as the closing section |
 
 Run whichever the user asked for. "Audit Slack" with no side named means **all
 three reports**. Order is fixed: **organizers → activity → topics → members.**
@@ -441,12 +441,13 @@ repository — there is nothing to commit them to.
 python3 ${CLAUDE_SKILL_DIR}/scripts/summarize_audits.py
 ```
 
-Writes `slack-full-audit.html`: a TL;DR (ranked focus page) followed by an
-index of anchor links, then Organizers, Topics and Members as full sections —
-not appendices tacked onto a PDF. The Organizers section also links its own
-internal Chapters coverage-matrix anchor from the top index, since that table
-answers a different question ("does this chapter have a home?") than the
-person-level rosters below it in the same section.
+Writes `slack-full-audit.html`: a short index of anchor links, then four full
+sections — Chapters, Organizers, Topics, Members — with the TL;DR (ranked
+focus page) last, as a recap rather than a gate the reader scrolls past
+first. Chapters and Organizers are two separate top-level sections, not one
+nested under the other, because they answer different questions ("does this
+chapter have a home?" vs "is the right person in it?") even though both come
+from `audit_organizers.render_body()`'s two returned fragments.
 
 It **measures nothing new**: it reads the four caches the engines wrote and
 aborts naming the engine whose cache is missing, empty, or stamped with a

--- a/skills/aaif-audit-slack/SKILL.md
+++ b/skills/aaif-audit-slack/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aaif-audit-slack
-description: Audit the community Slack workspace, from either side. The organizer engine checks, for every chapter on the Chapters List, whether it has a public city channel and a private organizers channel, whether the organizers we accepted are actually in them, and who is in each organizers channel that we never accepted. The topics engine reports on the subject-matter channels — which subjects have gone quiet, which rooms overlap, which are carried by one poster, and which show a newcomer nothing — from a human-curated Topics tab. The member engine reports channel counts, sizes, descriptions and lifecycle, plus how many accounts behind the headline member count are active, deactivated, guests or bots. Each engine can produce a standalone HTML report, but the deliverable is ONE combined PDF. Use when asked about Slack coverage for chapters, whether organizers are in their channels, who is in the -organizers channels, workspace health, channel clutter, inactive channels or accounts, or the newcomer experience.
-argument-hint: '[organizers|topics|members|activity|all] [--refresh] [--out NAME] [--no-pdf]'
+description: Audit the community Slack workspace, from either side. The organizer engine checks, for every chapter on the Chapters List, whether it has a public city channel and a private organizers channel, whether the organizers we accepted are actually in them, and who is in each organizers channel that we never accepted. The topics engine reports on the subject-matter channels — which subjects have gone quiet, which rooms overlap, which are carried by one poster, and which show a newcomer nothing — from a human-curated Topics tab. The member engine reports channel counts, sizes, descriptions and lifecycle, plus how many accounts behind the headline member count are active, deactivated, guests or bots. Each engine can produce a standalone HTML report, and the deliverable is ONE combined HTML report. Use when asked about Slack coverage for chapters, whether organizers are in their channels, who is in the -organizers channels, workspace health, channel clutter, inactive channels or accounts, or the newcomer experience.
+argument-hint: '[organizers|topics|members|activity|all] [--refresh] [--out NAME]'
 ---
 
 # AAIF Slack Audit
@@ -22,7 +22,7 @@ Three engines over one workspace, same house rules — **everything is read-only
 
 | Deliverable | Script | Produces |
 |---|---|---|
-| Where to focus | `summarize_audits.py` | **the single PDF you hand over** — the ranked focus page, with all three reports behind it as appendices |
+| Where to focus | `summarize_audits.py` | **the single HTML report you hand over** — a TL;DR ranking what to fix, with an index into the three full reports as sections below it |
 
 Run whichever the user asked for. "Audit Slack" with no side named means **all
 three reports**. Order is fixed: **organizers → activity → topics → members.**
@@ -33,24 +33,25 @@ run either first and those numbers are missing from a report you have already
 handed over. Topics additionally reads the organizer engine's `audit.json` to
 exclude chapter rooms from its unclassified list, so it goes after organizers.
 
-**The output is ONE PDF.** Run the four collectors with `--no-pdf` — they exist
-to fill the cache and to be run standalone when someone wants just one side —
-then `summarize_audits.py` composes the deliverable:
+**The output is ONE HTML report.** Run the four collectors — they exist to fill
+the cache and to be run standalone when someone wants just one side — then
+`summarize_audits.py` composes the deliverable:
 
 ```bash
 for s in organizers activity topics members; do
-  python3 ${CLAUDE_SKILL_DIR}/scripts/audit_$s.py --no-pdf
+  python3 ${CLAUDE_SKILL_DIR}/scripts/audit_$s.py
 done
-python3 ${CLAUDE_SKILL_DIR}/scripts/summarize_audits.py   # -> slack-full-audit.pdf
-rm -f slack-*-audit.html                                  # scaffolding, holds PII
+python3 ${CLAUDE_SKILL_DIR}/scripts/summarize_audits.py   # -> slack-full-audit.html
+rm -f slack-organizers-audit.html slack-topics-audit.html \
+      slack-members-audit.html slack-activity-audit.html   # scaffolding, holds PII
 ```
 
-Do not hand over four PDFs. Four files drift out of step with each other the
-moment one is re-run, and the person reading them has to work out the ranking
-that `summarize_audits.py` already did. It deletes its own intermediate HTML for
-the same reason the caches are 0600 — a second copy of every member name and
-address in the working directory is a liability, not a convenience
-(`--keep-html` if you genuinely need it).
+Do not hand over four separate reports. Four files drift out of step with each
+other the moment one is re-run, and the person reading them has to work out the
+ranking that `summarize_audits.py` already did. Delete the four standalone
+files once the combined one is written, for the same reason the caches are
+0600 — a second copy of every member name and address in the working
+directory is a liability, not a convenience.
 
 **Activity is not opt-in.** Asking for the organizer or member side alone still
 runs it, because its numbers are the only measured engagement in this skill and
@@ -157,8 +158,8 @@ Joins the **Chapters List**, the **Intake Ops** organizer decisions and **Slack*
 python3 ${CLAUDE_SKILL_DIR}/scripts/audit_organizers.py
 ```
 
-Writes `slack-organizers-audit.html` + `.pdf`, and a machine-readable
-`audit.json` in the cache directory.
+Writes `slack-organizers-audit.html`, and a machine-readable `audit.json` in
+the cache directory.
 
 `--planned-ok` exists for the **pre-provisioning** state: the Chapters List
 names the channel each chapter *will* have before `provision_channels.py` has
@@ -297,7 +298,7 @@ opposed to the chapter rooms (engine 1) and the plumbing (`#general`, `#random`,
 python3 ${CLAUDE_SKILL_DIR}/scripts/audit_topics.py
 ```
 
-Writes `slack-topics-audit.html` + `.pdf`.
+Writes `slack-topics-audit.html`.
 
 Sections: where the subjects sit by theme · quiet and dead topics by last
 **human** message · proposed overlapping rooms · rooms carried by one or two
@@ -352,7 +353,7 @@ Structural audit of channels and accounts. Touches no Drive file.
 python3 ${CLAUDE_SKILL_DIR}/scripts/audit_members.py
 ```
 
-Writes `slack-members-audit.html` + `.pdf`.
+Writes `slack-members-audit.html`.
 
 Sections: channel counts and size distribution · how long since anyone set a
 topic or purpose · membership concentration in the auto-join channels vs
@@ -385,7 +386,7 @@ counts and poster ids only, in the same 0600 cache as everything else.
 python3 ${CLAUDE_SKILL_DIR}/scripts/audit_activity.py
 ```
 
-Writes `slack-activity-audit.html` + `.pdf`. Reuses the shared channel cache;
+Writes `slack-activity-audit.html`. Reuses the shared channel cache;
 its per-channel pulls are resumable within a UTC day, so an interrupted sweep
 continues instead of restarting. When `audit.json` from the organizer engine is
 present, the report includes a per-chapter activity table joined from it.
@@ -407,7 +408,6 @@ present, the report includes a per-chapter activity table joined from it.
 |---|---|
 | `--refresh` | Re-fetch from the API instead of reusing the cache |
 | `--out NAME` | Output basename |
-| `--no-pdf` | HTML only — skip the Chrome render |
 | `--cache DIR` | Where raw pulls are stored (default `.slack-audit-cache`) |
 
 **Both engines cache their raw pulls**, and the first run of each is slow:
@@ -435,37 +435,46 @@ publish the workspace directory irreversibly. It covers already-tracked files
 too, which `.gitignore` alone does not, and it allows paths outside any
 repository — there is nothing to commit them to.
 
-# 5. The single-PDF deliverable
+# 5. The single-HTML deliverable
 
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/summarize_audits.py
 ```
 
-Writes `slack-full-audit.pdf`, deleting the intermediate HTML it renders from
-(`--keep-html` retains it; `--no-pdf` writes only the HTML and no PDF).
+Writes `slack-full-audit.html`: a TL;DR (ranked focus page) followed by an
+index of anchor links, then Organizers, Topics and Members as full sections —
+not appendices tacked onto a PDF. The Organizers section also links its own
+internal Chapters coverage-matrix anchor from the top index, since that table
+answers a different question ("does this chapter have a home?") than the
+person-level rosters below it in the same section.
 
 It **measures nothing new**: it reads the four caches the engines wrote and
 aborts naming the engine whose cache is missing, empty, or stamped with a
 different workspace, rather than estimating a number nobody measured. It does
 re-read the **Topics tab** over `gws` — the classification is config, not a
 measurement, and is not cached — and it re-runs `classify`/`attach_activity`
-once so the focus page and Appendix B select from the *same* records. They used
-to derive separately and immediately disagreed about how many rooms were quiet. The focus page
-ranks findings by what it costs to leave them alone (a public organizers channel
-outranks everything; a quiet topic room outranks a missing purpose line), and
-each appendix is the engine's own report body, unmodified.
+once so the focus page and the Topics section select from the *same* records.
+They used to derive separately and immediately disagreed about how many rooms
+were quiet. The focus page ranks findings by what it costs to leave them alone
+(a public organizers channel outranks everything; a quiet topic room outranks
+a missing purpose line), and each section is the engine's own report body,
+unmodified — plus that engine's own "Issues" → "To-do" subsection, built
+directly from lists the report already computes (never new prioritization
+logic invented for the combined document).
 
 The seam is `render_body` / `build_body` in the three engines: they return the
 page fragment, and their `render` / `build_report` wrap it for standalone use.
-Keep both paths — a change to a report body must show up in the combined PDF and
-the standalone one at once, which is the whole point of composing fragments
-rather than stitching generated HTML.
+Keep both paths — a change to a report body must show up in the combined
+document and the standalone one at once, which is the whole point of
+composing fragments rather than stitching generated HTML.
 
 The organizer report's filter buttons are removed from the combined document on
 purpose — **both** the script and the markup. The script hides rows via a global
-`tbody tr` query and would reach into the other appendices; dropping it alone
+`tbody tr` query and would reach into the other sections; dropping it alone
 left five controls that look interactive and do nothing, so
-`audit_organizers.strip_controls()` takes the markup too.
+`audit_organizers.strip_controls()` takes the markup too. That is a real trade
+in the combined document — a standalone `audit_organizers.py` run keeps
+working, interactive filters.
 
 ---
 

--- a/skills/aaif-audit-slack/scripts/audit_activity.py
+++ b/skills/aaif-audit-slack/scripts/audit_activity.py
@@ -235,7 +235,6 @@ def main():
                     help="trailing window for message counts (default 90)")
     ap.add_argument("--refresh", action="store_true",
                     help="re-pull every channel even if pulled today")
-    ap.add_argument("--no-pdf", action="store_true")
     args = ap.parse_args()
 
     # The report names channels and how dead they are; the cache holds only
@@ -265,9 +264,6 @@ def main():
     html_path = args.out + ".html"
     rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
-    if not args.no_pdf:
-        print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),
-                                     os.path.abspath(args.out + ".pdf")))
 
 
 if __name__ == "__main__":

--- a/skills/aaif-audit-slack/scripts/audit_activity.py
+++ b/skills/aaif-audit-slack/scripts/audit_activity.py
@@ -239,7 +239,7 @@ def main():
 
     # The report names channels and how dead they are; the cache holds only
     # counts. Same public-repo rule as the other two audits regardless.
-    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html", args.out + ".pdf")
+    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html")
     os.makedirs(args.cache, exist_ok=True)
     os.chmod(args.cache, 0o700)
 

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -416,7 +416,7 @@ def main():
 
     # Before any collection: the cache holds the entire member directory,
     # including email addresses and 2FA/admin flags, and this repo is public.
-    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html", args.out + ".pdf")
+    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html")
     os.makedirs(args.cache, exist_ok=True)
     os.chmod(args.cache, 0o700)
 

--- a/skills/aaif-audit-slack/scripts/audit_members.py
+++ b/skills/aaif-audit-slack/scripts/audit_members.py
@@ -2,7 +2,7 @@
 """Audit the Slack workspace from the member's side: channels and accounts.
 
 Collects channel metadata and the full user directory, then renders a
-self-contained HTML report and (unless --no-pdf) a PDF beside it.
+self-contained HTML report.
 
 Everything here is read-only, and this engine reads no messages itself. When
 audit_activity.py's cache is present it reports a posted-recently FLOOR from
@@ -216,6 +216,34 @@ replies are invisible to the API, private channels are limited to the audit acco
 {caveat}
 
 <section>
+  <div class="eyebrow">Issues</div>
+  <h2>What this page can already name</h2>
+  <p class="lede">The to-do list right below is these same counts, turned into
+  verbs — no judgement is made here that isn't a table or a stat further down
+  this page.</p>
+  <ul>
+    <li><b>{len(nodesc)} live channel(s)</b> never had a topic or purpose set.</li>
+    <li><b>{len(small)} live channel(s)</b> have 8 or fewer members.</li>
+    <li><b>{unconf} active human(s)</b> have an unconfirmed email address.</li>
+    <li><b>{guests} active human(s)</b> are guests (restricted or ultra-restricted).</li>
+  </ul>
+  <h2>To-do</h2>
+  {rs.actions([t for t in [
+      ("Set a purpose or topic on %d channel(s)" % len(nodesc),
+       "Never described: %s." % ", ".join(
+           "#" + c["name"] for c in nodesc[:6]),
+       "minutes each", "channel owner", "next") if nodesc else None,
+      ("Decide the fate of %d small channel(s)" % len(small),
+       "8 or fewer members: %s." % ", ".join(
+           "#" + c["name"] for c in small[:6]),
+       "minutes each", "workspace admin", "later") if small else None,
+      ("Follow up on %d unconfirmed email address(es)" % unconf,
+       "Active humans who never confirmed their address.",
+       "minutes", "workspace admin", "later") if unconf else None,
+  ] if t]) or '<p class="mute">Nothing outstanding.</p>'}
+</section>
+
+<section>
   <div class="eyebrow">Channels</div>
   <h2>{len(chans)} channels, {len(arch)} of them retired</h2>
   <div class="stats" style="margin-top:18px">
@@ -384,7 +412,6 @@ def main():
     ap.add_argument("--cache", default=".slack-audit-cache",
                     help="directory for raw API pulls")
     ap.add_argument("--refresh", action="store_true", help="re-fetch even if cached")
-    ap.add_argument("--no-pdf", action="store_true", help="write HTML only")
     args = ap.parse_args()
 
     # Before any collection: the cache holds the entire member directory,
@@ -449,8 +476,6 @@ def main():
     html_path = args.out + ".html"
     rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
-    if not args.no_pdf:
-        print("wrote %s" % rs.to_pdf(os.path.abspath(html_path), os.path.abspath(args.out + ".pdf")))
 
 
 if __name__ == "__main__":

--- a/skills/aaif-audit-slack/scripts/audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/audit_organizers.py
@@ -21,6 +21,7 @@ import sys
 import time
 import unicodedata
 from collections import defaultdict
+from typing import NamedTuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib"))
 
@@ -456,19 +457,22 @@ def match_channels(chapters, chans, cfg):
         if not pub:
             reg, regional_how = _resolve_alias(city, cfg["regional"], by_name)
             regional = reg["name"] if reg else None
-        # Same resolution, but unconditional — the Chapters summary table wants
-        # "what country room serves this chapter" even when a local room also
-        # exists (Madrid has both #madrid and, via Spain, an implicit tie to a
-        # country room). `regional` above stays gated on `not pub` because
-        # existing callers (the funnel counts, "regional only" filter) read it
-        # as "this chapter has NO local room, only a country one" — widening
-        # that meaning would silently change what those already mean.
-        reg_always, regional_always_how = _resolve_alias(city, cfg["regional"], by_name)
+        # Same resolution, but unconditional, under a DELIBERATELY DIFFERENT
+        # name (`country_channel`, not a `regional`-prefixed sibling) — the
+        # Chapters summary table wants "what country room serves this
+        # chapter" even when a local room also exists (Madrid has both
+        # #madrid and, via Spain, an implicit tie to a country room).
+        # `regional` above stays gated on `not pub` because existing callers
+        # (the funnel counts, "regional only" filter) read it as "this
+        # chapter has NO local room, only a country one" — a same-prefix name
+        # for this unconditional value would invite a future caller to read
+        # the wrong one and have it type-check fine (both are Optional[str]).
+        reg_always, country_channel_how = _resolve_alias(city, cfg["regional"], by_name)
 
         out.append({
             "city": city, "regional": regional,
-            "regional_always": reg_always["name"] if reg_always else None,
-            "regional_always_id": reg_always["id"] if reg_always else None,
+            "country_channel": reg_always["name"] if reg_always else None,
+            "country_channel_id": reg_always["id"] if reg_always else None,
             "public_how": how, "organizers_how": org_how,
             "regional_how": regional_how,
             "public": pub["name"] if pub else None,
@@ -619,11 +623,12 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
     """Join the sheet data to the Slack data, per chapter.
 
     Each chapter record gains `accepted` (people, each with `slack_id`,
-    `slack_account`, `in_public`, `in_organizers`, `in_local_champs`) and
-    `unaccounted` (everyone in the organizers channel we never accepted, each
-    with `is_staff`, `unresolved`, `in_local_champs`, and — when their email
-    matches an intake row — `intake_status` and `intake_city`). Every key from
-    match_channels() survives unchanged.
+    `slack_account`, `handle`, `in_public`, `in_organizers`, `in_local_champs`,
+    `in_country_channel`) and `unaccounted` (everyone in the organizers
+    channel we never accepted, each with `handle`, `is_staff`, `unresolved`,
+    `in_local_champs`, `in_public`, `in_country_channel`, and — when their
+    email matches an intake row — `intake_status` and `intake_city`). Every
+    key from match_channels() survives unchanged.
 
     `intake_status` is what separates "a stranger is in the private room" from
     "someone we are still deciding on is in the private room, doing the work,
@@ -632,6 +637,14 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
     `local_champs_ids` is the one workspace-wide room's membership (a flat id
     set, not per-chapter) — `None` reads as "unknown" (never as "nobody"), so a
     caller that skipped the pull doesn't silently report every person absent.
+    `in_local_champs` on each person carries that same tri-state through:
+    `None` = unknown, `True`/`False` = a real answer.
+
+    `in_country_channel` is the same tri-state for a different reason: `None`
+    means the chapter has no country channel at all (`country_channel` is
+    falsy), not that membership is unmeasured — there's nothing to be a member
+    of. Both fields must be read as tri-state; neither collapses `None` and
+    `False` into one meaning anywhere downstream.
     """
     lc_ids = local_champs_ids
     lookup = {}
@@ -663,8 +676,8 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
         # .get(), not [...]: `r` reaches here from match_channels() in the real
         # run, but test fixtures build minimal chapter dicts by hand and don't
         # carry every optional key — a country channel is genuinely optional.
-        regional_always = r.get("regional_always")
-        country_ids = set(membership[regional_always]) if regional_always else set()
+        country_channel = r.get("country_channel")
+        country_ids = set(membership[country_channel]) if country_channel else set()
 
         accepted = []
         for person in by_city.get(r["city"], []):
@@ -675,7 +688,7 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
                              "in_public": bool(uid and uid in pub_ids),
                              "in_organizers": bool(uid and uid in org_ids),
                              "in_country_channel": bool(uid and uid in country_ids)
-                                                   if regional_always else None,
+                                                   if country_channel else None,
                              "in_local_champs": None if lc_ids is None
                                                 else bool(uid and uid in lc_ids)})
 
@@ -685,12 +698,12 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
             u = directory.get(uid)
             in_lc = None if lc_ids is None else bool(uid in lc_ids)
             in_pub = uid in pub_ids
-            in_country = (uid in country_ids) if regional_always else None
+            in_country = (uid in country_ids) if country_channel else None
             if u is None:
                 # Naming failed for this member. Render them as unidentified
                 # rather than filing them under a group whose label asserts a
                 # judgement we never made about them.
-                extras.append({"id": uid, "name": uid, "email": "",
+                extras.append({"id": uid, "name": uid, "email": "", "handle": "",
                                "is_staff": False, "unresolved": True,
                                "intake_status": "", "intake_city": "",
                                "in_local_champs": in_lc, "in_public": in_pub,
@@ -733,6 +746,58 @@ def rooms_to_create(audit):
             and not c["public_how"].startswith(("planned:", "held-private:"))]
 
 
+def person_issues(p, c, is_accepted):
+    """Every mismatch worth a human's attention for one roster row.
+
+    Framed as findings, not accusations — "not in X yet" rather than "missing",
+    because for a pending applicant the room they're not in yet may not be
+    theirs to join (Drive access is gated on acceptance, not membership).
+
+    Module-level (not nested in render_body) so it's directly testable —
+    the exact per-row logic that decides which rows get tinted deserves its
+    own tests, not just an assertion on rendered HTML.
+    """
+    issues = []
+    if is_accepted:
+        if not p["slack_account"]:
+            issues.append("no Slack account under their intake email")
+            return issues          # nothing else is checkable without one
+        if c["public"] and not p["in_public"]:
+            issues.append("not in #%s (their chapter's public channel)" % c["public"])
+        if c["organizers_channel"] and not p["in_organizers"]:
+            issues.append("not in #%s (their organizer channel)" % c["organizers_channel"])
+        # Deliberately NOT an issue: local-champs is a small, curated
+        # leadership channel, not a room every accepted organizer belongs
+        # in. Flagging its absence here would tint nearly every row —
+        # the column above already shows it, which is the right amount
+        # of visibility for a fact that isn't a problem.
+    else:
+        status = p.get("intake_status") or ""
+        if not status:
+            if p["in_local_champs"]:
+                issues.append("in #%s with no intake submission at all"
+                              % LOCAL_CHAMPS_CHANNEL)
+            else:
+                issues.append("in the organizer channel with no intake row")
+        elif status in DECIDED_NO:
+            issues.append("intake status is %r — should not still be in this "
+                          "channel" % status)
+        else:
+            issues.append("applied (%s), awaiting a decision — no Drive access "
+                          "until accepted" % status)
+    return issues
+
+
+class RenderedBody(NamedTuple):
+    """render_body()'s return — a NamedTuple, not a bare 3-tuple of strings,
+    so a caller can't silently misread which fragment is which (all three
+    positions are plain `str`; a reorder of the return statement would
+    type-check and unpack fine either way)."""
+    chapters: str
+    organizers: str
+    js: str
+
+
 def render_body(audit, orphans, dupes, today):
     """Return (chapters_body, organizers_body, js) — two fragments, not one.
 
@@ -772,43 +837,6 @@ def render_body(audit, orphans, dupes, today):
                       '<span class="fval">%d<span class="fpct">%.0f%%</span></span>%s</div>'
                       % (e(lbl), tone, pct, v, pct, drop))
 
-    def person_issues(p, c, is_accepted):
-        """Every mismatch worth a human's attention for one roster row.
-
-        Framed as findings, not accusations — "not in X yet" rather than "missing",
-        because for a pending applicant the room they're not in yet may not be
-        theirs to join (Drive access is gated on acceptance, not membership).
-        """
-        issues = []
-        if is_accepted:
-            if not p["slack_account"]:
-                issues.append("no Slack account under their intake email")
-                return issues          # nothing else is checkable without one
-            if c["public"] and not p["in_public"]:
-                issues.append("not in #%s (their chapter's public channel)" % c["public"])
-            if c["organizers_channel"] and not p["in_organizers"]:
-                issues.append("not in #%s (their organizer channel)" % c["organizers_channel"])
-            # Deliberately NOT an issue: local-champs is a small, curated
-            # leadership channel, not a room every accepted organizer belongs
-            # in. Flagging its absence here would tint nearly every row —
-            # the column above already shows it, which is the right amount
-            # of visibility for a fact that isn't a problem.
-        else:
-            status = p.get("intake_status") or ""
-            if not status:
-                if p["in_local_champs"]:
-                    issues.append("in #%s with no intake submission at all"
-                                  % LOCAL_CHAMPS_CHANNEL)
-                else:
-                    issues.append("in the organizer channel with no intake row")
-            elif status in DECIDED_NO:
-                issues.append("intake status is %r — should not still be in this "
-                              "channel" % status)
-            else:
-                issues.append("applied (%s), awaiting a decision — no Drive access "
-                              "until accepted" % status)
-        return issues
-
     matrix, total_issues, worst_issues = [], 0, []
     for c in audit:
         state = "own" if c["public"] else ("regional" if c["regional"] else "none")
@@ -816,6 +844,10 @@ def render_body(audit, orphans, dupes, today):
         inp = sum(1 for p in c["accepted"] if p["in_public"])
         ino = sum(1 for p in c["accepted"] if p["in_organizers"])
         inlc = sum(1 for p in c["accepted"] if p["in_local_champs"])
+        # None (the pull was skipped) must never render as a confident 0 —
+        # that's the exact collapse local_champs_ids' own contract forbids.
+        lc_unknown = bool(c["accepted"]) and all(
+            p["in_local_champs"] is None for p in c["accepted"])
         nos = sum(1 for p in c["accepted"] if not p["slack_account"])
         n_issues = (sum(len(person_issues(p, c, True)) for p in c["accepted"])
                     + sum(len(person_issues(p, c, False)) for p in c["unaccounted"]
@@ -835,8 +867,8 @@ def render_body(audit, orphans, dupes, today):
                ('<span class="num">%s</span>'
                 % ("?" if c["public_members"] is None else c["public_members"]))
                if c["public"] else "",
-               ('<code class="chan">#%s</code>' % e(c.get("regional_always")))
-               if c.get("regional_always") else '<span class="nil">none</span>',
+               ('<code class="chan">#%s</code>' % e(c.get("country_channel")))
+               if c.get("country_channel") else '<span class="nil">none</span>',
                ('<code class="chan">#%s</code>' % e(c["organizers_channel"]))
                if c["organizers_channel"] else '<span class="nil">none</span>',
                '<span class="tag tag-pub">public!</span>'
@@ -844,7 +876,8 @@ def render_body(audit, orphans, dupes, today):
                n or '<span class="nil">0</span>',
                ("%d/%d" % (inp, n)) if n else '<span class="nil">—</span>',
                ("%d/%d" % (ino, n)) if n and c["organizers_channel"] else '<span class="nil">—</span>',
-               ("%d/%d" % (inlc, n)) if n else '<span class="nil">—</span>',
+               ('<span class="num">?</span>' if lc_unknown
+                else ("%d/%d" % (inlc, n)) if n else '<span class="nil">—</span>'),
                ('<span class="bad">%d</span>' % nos) if nos else '<span class="nil">0</span>',
                ('<span class="bad">%d</span>' % n_issues) if n_issues else '<span class="nil">0</span>'))
 
@@ -889,7 +922,7 @@ def render_body(audit, orphans, dupes, today):
                    status_html,
                    yn(in_pub) if c["public"] else '<span class="nil">—</span>',
                    yn(in_org) if c["organizers_channel"] else '<span class="nil">—</span>',
-                   yn(p["in_country_channel"]) if c.get("regional_always")
+                   yn(p["in_country_channel"]) if c.get("country_channel")
                    else '<span class="nil">—</span>',
                    yn(p["in_local_champs"]),
                    ("; ".join(e(x) for x in issues) if issues
@@ -898,8 +931,8 @@ def render_body(audit, orphans, dupes, today):
             ('<code class="chan">#%s</code>' % e(c["public"])) if c["public"] else "",
             ('<code class="chan">#%s</code>' % e(c["organizers_channel"]))
             if c["organizers_channel"] else "",
-            ('<code class="chan">#%s</code>' % e(c.get("regional_always")))
-            if c.get("regional_always") else ""] if x)
+            ('<code class="chan">#%s</code>' % e(c.get("country_channel")))
+            if c.get("country_channel") else ""] if x)
         table = (('<div class="tablewrap"><table><thead><tr><th>Name</th>'
                  '<th>Handle</th><th>Email</th>'
                  '<th>Intake status</th><th class="n">In public</th>'
@@ -907,7 +940,7 @@ def render_body(audit, orphans, dupes, today):
                  '<th class="n">In %s</th>'
                  '<th>Issues</th></tr></thead><tbody>%s</tbody></table></div>'
                  % (LOCAL_CHAMPS_CHANNEL, "".join(rows_html)))
-                if rows_html else '<p class="none">No accepted organizers, and nobody else in the '
+                if rows_html else '<p class="nil">No accepted organizers, and nobody else in the '
                                    'organizer channel, for this chapter</p>')
         detail.append('<section class="chap"><h3>%s<span class="chapchans">%s</span></h3>'
                       '%s</section>'
@@ -1143,7 +1176,7 @@ btns.forEach(b=>b.addEventListener('click',()=>{
   });
 }));
 """
-    return chapters_body, organizers_body, js
+    return RenderedBody(chapters_body, organizers_body, js)
 
 
 def strip_controls(body):
@@ -1179,7 +1212,7 @@ def main():
     cfg = load_config()
     # Before any collection: these paths will hold organizer names, email
     # addresses and private-channel rosters, and this repo is public.
-    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html", args.out + ".pdf")
+    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html")
     os.makedirs(args.cache, exist_ok=True)
     os.chmod(args.cache, 0o700)
 
@@ -1266,7 +1299,7 @@ def main():
     for r in rows:
         for name, cid in ((r["public"], r["public_id"]),
                           (r["organizers_channel"], r["organizers_id"]),
-                          (r["regional_always"], r["regional_always_id"])):
+                          (r["country_channel"], r["country_channel_id"])):
             if name:
                 targets[name] = cid
     # local-champs is one workspace-wide room, not per-chapter — resolved by
@@ -1281,7 +1314,11 @@ def main():
               "unknown for everyone." % LOCAL_CHAMPS_CHANNEL, file=sys.stderr)
     print("  pulling membership for %d channels ..." % len(targets))
     membership = {name: members(api, cid) for name, cid in sorted(targets.items())}
-    local_champs_ids = set(membership.get(LOCAL_CHAMPS_CHANNEL, []))
+    # None, not set() — membership.get(..., []) would silently turn "the pull
+    # was skipped" into "the pull succeeded and found nobody", which is
+    # exactly the collapse build_audit()'s own docstring says never to make.
+    local_champs_ids = (set(membership[LOCAL_CHAMPS_CHANNEL])
+                        if local_champs_chan else None)
     # conversations.list already told us how big each channel is; comparing
     # that against what conversations.members returned is a free floor on a
     # short paged pull, which would otherwise render as "accepted but absent"

--- a/skills/aaif-audit-slack/scripts/audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/audit_organizers.py
@@ -66,6 +66,11 @@ INTAKE_TAB = "Organizers"
 #: "Existing" alone would miss every MLOps row, so keep the full value.
 ACCEPTED = ("Accepted", "Existing (from MLOps)")
 
+#: The one workspace-wide private room for community leads, distinct from any
+#: chapter's own "<city>-organizers" channel. Resolved by name off the live
+#: channel list, same as every other channel here — never hardcoded to an id.
+LOCAL_CHAMPS_CHANNEL = "local-champs"
+
 #: Intake statuses that are a decided NO. Someone in an organizers room carrying
 #: one of these is not "awaiting a decision" — the decision was made, and their
 #: presence in a private channel is the thing to look at.
@@ -451,9 +456,19 @@ def match_channels(chapters, chans, cfg):
         if not pub:
             reg, regional_how = _resolve_alias(city, cfg["regional"], by_name)
             regional = reg["name"] if reg else None
+        # Same resolution, but unconditional — the Chapters summary table wants
+        # "what country room serves this chapter" even when a local room also
+        # exists (Madrid has both #madrid and, via Spain, an implicit tie to a
+        # country room). `regional` above stays gated on `not pub` because
+        # existing callers (the funnel counts, "regional only" filter) read it
+        # as "this chapter has NO local room, only a country one" — widening
+        # that meaning would silently change what those already mean.
+        reg_always, regional_always_how = _resolve_alias(city, cfg["regional"], by_name)
 
         out.append({
             "city": city, "regional": regional,
+            "regional_always": reg_always["name"] if reg_always else None,
+            "regional_always_id": reg_always["id"] if reg_always else None,
             "public_how": how, "organizers_how": org_how,
             "regional_how": regional_how,
             "public": pub["name"] if pub else None,
@@ -600,19 +615,25 @@ def check_membership_floor(membership, chans, chans_cached, refetch, note=print)
 
 
 def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
-                applicants=None):
+                applicants=None, local_champs_ids=None):
     """Join the sheet data to the Slack data, per chapter.
 
     Each chapter record gains `accepted` (people, each with `slack_id`,
-    `slack_account`, `in_public`, `in_organizers`) and `unaccounted` (everyone in
-    the organizers channel we never accepted, each with `is_staff` and
-    `unresolved`, and — when their email matches an intake row — `intake_status`
-    and `intake_city`). Every key from match_channels() survives unchanged.
+    `slack_account`, `in_public`, `in_organizers`, `in_local_champs`) and
+    `unaccounted` (everyone in the organizers channel we never accepted, each
+    with `is_staff`, `unresolved`, `in_local_champs`, and — when their email
+    matches an intake row — `intake_status` and `intake_city`). Every key from
+    match_channels() survives unchanged.
 
     `intake_status` is what separates "a stranger is in the private room" from
     "someone we are still deciding on is in the private room, doing the work,
     and locked out of the Drive folder because acceptance is what grants it".
+
+    `local_champs_ids` is the one workspace-wide room's membership (a flat id
+    set, not per-chapter) — `None` reads as "unknown" (never as "nobody"), so a
+    caller that skipped the pull doesn't silently report every person absent.
     """
+    lc_ids = local_champs_ids
     lookup = {}
     for r in rows:
         key = fold_tight(r["city"])
@@ -639,35 +660,54 @@ def build_audit(rows, people, slack_ids, membership, directory, staff_domain,
         # under "has a room and nobody in it".
         pub_ids = set(membership[r["public"]]) if r["public"] else set()
         org_ids = set(membership[r["organizers_channel"]]) if r["organizers_channel"] else set()
+        # .get(), not [...]: `r` reaches here from match_channels() in the real
+        # run, but test fixtures build minimal chapter dicts by hand and don't
+        # carry every optional key — a country channel is genuinely optional.
+        regional_always = r.get("regional_always")
+        country_ids = set(membership[regional_always]) if regional_always else set()
 
         accepted = []
         for person in by_city.get(r["city"], []):
-            uid = (slack_ids.get(person["email"]) or {}).get("id")
+            hit = slack_ids.get(person["email"]) or {}
+            uid = hit.get("id")
             accepted.append({**person, "slack_id": uid, "slack_account": bool(uid),
+                             "handle": hit.get("name", ""),
                              "in_public": bool(uid and uid in pub_ids),
-                             "in_organizers": bool(uid and uid in org_ids)})
+                             "in_organizers": bool(uid and uid in org_ids),
+                             "in_country_channel": bool(uid and uid in country_ids)
+                                                   if regional_always else None,
+                             "in_local_champs": None if lc_ids is None
+                                                else bool(uid and uid in lc_ids)})
 
         known = {p["slack_id"] for p in accepted if p["slack_id"]}
         extras = []
         for uid in sorted(org_ids - known):
             u = directory.get(uid)
+            in_lc = None if lc_ids is None else bool(uid in lc_ids)
+            in_pub = uid in pub_ids
+            in_country = (uid in country_ids) if regional_always else None
             if u is None:
                 # Naming failed for this member. Render them as unidentified
                 # rather than filing them under a group whose label asserts a
                 # judgement we never made about them.
                 extras.append({"id": uid, "name": uid, "email": "",
                                "is_staff": False, "unresolved": True,
-                               "intake_status": "", "intake_city": ""})
+                               "intake_status": "", "intake_city": "",
+                               "in_local_champs": in_lc, "in_public": in_pub,
+                               "in_country_channel": in_country})
                 continue
             addr = (u.get("email") or "").lower()
             app = (applicants or {}).get(addr) or {}
             extras.append({"id": uid,
                            "name": u.get("real_name") or u.get("name") or uid,
                            "email": u.get("email", ""),
+                           "handle": u.get("name", ""),
                            "is_staff": addr.endswith("@" + staff_domain),
                            "unresolved": False,
+                           "in_country_channel": in_country,
                            "intake_status": app.get("status", ""),
-                           "intake_city": app.get("city", "")})
+                           "intake_city": app.get("city", ""),
+                           "in_local_champs": in_lc, "in_public": in_pub})
         out.append({**r, "accepted": accepted, "unaccounted": extras})
     return out, dict(orphans)
 
@@ -694,6 +734,15 @@ def rooms_to_create(audit):
 
 
 def render_body(audit, orphans, dupes, today):
+    """Return (chapters_body, organizers_body, js) — two fragments, not one.
+
+    "Does the room exist" (Chapters: the numbers, the coverage matrix) and
+    "is the right person in it" (Organizers: the leak, rosters, person-by-
+    person, what-to-do) are different questions with different audiences, so
+    the combined document (summarize_audits.py) gives each its own top-level
+    section. The standalone report (`render`, below) concatenates both back
+    into one page — nothing is lost running this file on its own.
+    """
     allp = [p for c in audit for p in c["accepted"]]
     S = {
         "chapters": len(audit),
@@ -723,17 +772,62 @@ def render_body(audit, orphans, dupes, today):
                       '<span class="fval">%d<span class="fpct">%.0f%%</span></span>%s</div>'
                       % (e(lbl), tone, pct, v, pct, drop))
 
-    matrix = []
+    def person_issues(p, c, is_accepted):
+        """Every mismatch worth a human's attention for one roster row.
+
+        Framed as findings, not accusations — "not in X yet" rather than "missing",
+        because for a pending applicant the room they're not in yet may not be
+        theirs to join (Drive access is gated on acceptance, not membership).
+        """
+        issues = []
+        if is_accepted:
+            if not p["slack_account"]:
+                issues.append("no Slack account under their intake email")
+                return issues          # nothing else is checkable without one
+            if c["public"] and not p["in_public"]:
+                issues.append("not in #%s (their chapter's public channel)" % c["public"])
+            if c["organizers_channel"] and not p["in_organizers"]:
+                issues.append("not in #%s (their organizer channel)" % c["organizers_channel"])
+            # Deliberately NOT an issue: local-champs is a small, curated
+            # leadership channel, not a room every accepted organizer belongs
+            # in. Flagging its absence here would tint nearly every row —
+            # the column above already shows it, which is the right amount
+            # of visibility for a fact that isn't a problem.
+        else:
+            status = p.get("intake_status") or ""
+            if not status:
+                if p["in_local_champs"]:
+                    issues.append("in #%s with no intake submission at all"
+                                  % LOCAL_CHAMPS_CHANNEL)
+                else:
+                    issues.append("in the organizer channel with no intake row")
+            elif status in DECIDED_NO:
+                issues.append("intake status is %r — should not still be in this "
+                              "channel" % status)
+            else:
+                issues.append("applied (%s), awaiting a decision — no Drive access "
+                              "until accepted" % status)
+        return issues
+
+    matrix, total_issues, worst_issues = [], 0, []
     for c in audit:
         state = "own" if c["public"] else ("regional" if c["regional"] else "none")
         n = len(c["accepted"])
         inp = sum(1 for p in c["accepted"] if p["in_public"])
         ino = sum(1 for p in c["accepted"] if p["in_organizers"])
+        inlc = sum(1 for p in c["accepted"] if p["in_local_champs"])
         nos = sum(1 for p in c["accepted"] if not p["slack_account"])
+        n_issues = (sum(len(person_issues(p, c, True)) for p in c["accepted"])
+                    + sum(len(person_issues(p, c, False)) for p in c["unaccounted"]
+                          if not p["unresolved"] and not p["is_staff"]))
+        total_issues += n_issues
+        if n_issues:
+            worst_issues.append((c["city"], n_issues))
         shown = c["public"] or c["regional"]
         matrix.append(
             '<tr data-state="%s" data-org="%s"><th scope="row">%s</th>'
-            '<td>%s%s%s</td><td>%s%s</td><td class="n">%s</td><td class="n">%s</td>'
+            '<td>%s%s%s</td><td>%s</td><td>%s%s</td><td class="n">%s</td>'
+            '<td class="n">%s</td><td class="n">%s</td><td class="n">%s</td>'
             '<td class="n">%s</td><td class="n">%s</td></tr>'
             % (state, "yes" if c["organizers_channel"] else "no", e(c["city"]),
                ('<code class="chan">#%s</code>' % e(shown)) if shown else '<span class="nil">none</span>',
@@ -741,6 +835,8 @@ def render_body(audit, orphans, dupes, today):
                ('<span class="num">%s</span>'
                 % ("?" if c["public_members"] is None else c["public_members"]))
                if c["public"] else "",
+               ('<code class="chan">#%s</code>' % e(c.get("regional_always")))
+               if c.get("regional_always") else '<span class="nil">none</span>',
                ('<code class="chan">#%s</code>' % e(c["organizers_channel"]))
                if c["organizers_channel"] else '<span class="nil">none</span>',
                '<span class="tag tag-pub">public!</span>'
@@ -748,88 +844,74 @@ def render_body(audit, orphans, dupes, today):
                n or '<span class="nil">0</span>',
                ("%d/%d" % (inp, n)) if n else '<span class="nil">—</span>',
                ("%d/%d" % (ino, n)) if n and c["organizers_channel"] else '<span class="nil">—</span>',
-               ('<span class="bad">%d</span>' % nos) if nos else '<span class="nil">0</span>'))
+               ("%d/%d" % (inlc, n)) if n else '<span class="nil">—</span>',
+               ('<span class="bad">%d</span>' % nos) if nos else '<span class="nil">0</span>',
+               ('<span class="bad">%d</span>' % n_issues) if n_issues else '<span class="nil">0</span>'))
 
-    def plist(items, extra=""):
-        return ('<ul class="plist %s">%s</ul>' % (extra, "".join(
-            '<li><span class="pname">%s</span><span class="pmail">%s</span></li>'
-            % (e(x["name"]), e(x["email"]) or "—") for x in items)))
-
-    rosters = []
-    for c in sorted([x for x in audit if x["organizers_channel"]],
-                    key=lambda x: -(x["organizers_channel_members"] or 0)):
-        present = [p for p in c["accepted"] if p["in_organizers"]]
-        absent = [p for p in c["accepted"] if not p["in_organizers"]]
-        unresolved = [x for x in c["unaccounted"] if x["unresolved"]]
-        staff = [x for x in c["unaccounted"] if not x["unresolved"] and x["is_staff"]]
-        # Split the not-accepted into two, because they call for opposite
-        # actions. Someone with a live intake row APPLIED and is waiting on a
-        # decision — they are in the private room doing the work and, since
-        # acceptance is what grants Drive, locked out of their own folder.
-        # Someone with no intake row at all is a stranger in a private channel.
-        # One line reading "not an accepted organizer" hid both.
-        pending = [x for x in c["unaccounted"]
-                   if not x["unresolved"] and not x["is_staff"]
-                   and x.get("intake_status") and x["intake_status"] not in DECIDED_NO]
-        others = [x for x in c["unaccounted"]
-                  if not x["unresolved"] and not x["is_staff"] and x not in pending]
-        groups = []
-        for items, pill, label, cls in (
-                (present, "ok", "accepted organizer", ""),
-                (staff, "mute", "staff", "plist-x"),
-                (pending, "warn", "APPLIED — awaiting a decision, no Drive access",
-                 "plist-x"),
-                (others, "warn", "no intake row at all", "plist-x"),
-                (absent, "bad", "accepted but absent", "plist-x"),
-                # Distinct from "not an accepted organizer": we could not look
-                # these accounts up, so we know nothing about them. Saying so is
-                # not the same as accusing them.
-                (unresolved, "mute", "could not identify", "plist-x")):
-            if items:
-                groups.append('<div class="rgrp"><h4><span class="pill pill-%s">%s</span>'
-                              '<span class="cnt">%d</span></h4>%s</div>'
-                              % (pill, label, len(items), plist(items, cls)))
-        rosters.append(
-            '<section class="chap roster"><h3>#%s%s<span class="chapchans">'
-            '<span class="nil">%s &middot; %s members</span></span></h3>'
-            '<div class="rgrps">%s</div></section>'
-            % (e(c["organizers_channel"]),
-               "" if c["organizers_private"] else '<span class="tag tag-pub">public!</span>',
-               e(c["city"]),
-               "?" if c["organizers_channel_members"] is None
-               else c["organizers_channel_members"], "".join(groups)))
+    def yn(v):
+        if v is None:
+            return '<span class="nil">?</span>'
+        return '<span class="pill pill-%s">%s</span>' % (("ok", "yes") if v else ("bad", "no"))
 
     detail = []
     for c in audit:
-        if not c["accepted"] and not c["organizers_channel"]:
+        roster = [(p, True) for p in c["accepted"]]
+        roster += [(p, False) for p in c["unaccounted"]
+                  if not p["unresolved"] and not p["is_staff"]]
+        if not roster and not c["organizers_channel"]:
             continue
-        items = []
-        if not c["accepted"]:
-            items.append('<li class="none">No accepted organizers for this chapter</li>')
-        for p in c["accepted"]:
-            if not p["slack_account"]:
-                pills = '<span class="pill pill-bad">no Slack account</span>'
-            elif c["public"]:
-                pills = ('<span class="pill pill-%s">%s #%s</span>'
-                         % ("ok" if p["in_public"] else "warn",
-                            "in" if p["in_public"] else "not in", e(c["public"])))
+        rows_html = []
+        for p, is_accepted in sorted(roster, key=lambda pair: (not pair[1], pair[0]["name"].lower())):
+            issues = person_issues(p, c, is_accepted)
+            if is_accepted:
+                status_html = "Accepted"
+            elif p.get("intake_status"):
+                status_html = e(p["intake_status"])
             else:
-                pills = '<span class="pill pill-mute">no city channel</span>'
-            if p["slack_account"] and c["organizers_channel"]:
-                pills += ('<span class="pill pill-%s">%sorganizers</span>'
-                          % ("ok" if p["in_organizers"] else "warn",
-                             "" if p["in_organizers"] else "not in "))
-            items.append('<li><span class="pname">%s</span><span class="pmail">%s</span>'
-                         '<span class="pills">%s</span></li>'
-                         % (e(p["name"]), e(p["email"]), pills))
+                status_html = '<span class="nil">no intake row</span>'
+            # A not-yet-accepted person is IN this table only because they are
+            # already a member of the organizer channel (that's how the
+            # roster found them) — "in organizers" is trivially yes for them.
+            in_pub = p["in_public"]
+            in_org = p["in_organizers"] if is_accepted else True
+            row_classes = " ".join(cls for cls in
+                                   ("pending" if not is_accepted else "",
+                                    "has-issue" if issues else "") if cls)
+            rows_html.append(
+                '<tr%s><td>%s</td><td>%s</td><td>%s</td><td>%s</td>'
+                '<td class="n">%s</td><td class="n">%s</td><td class="n">%s</td>'
+                '<td class="n">%s</td><td>%s</td></tr>'
+                % (' class="%s"' % row_classes if row_classes else "",
+                   e(p["name"]),
+                   ('@%s' % e(p["handle"])) if p.get("handle")
+                   else '<span class="nil">—</span>',
+                   e(p["email"]) if p.get("email") else '<span class="nil">—</span>',
+                   status_html,
+                   yn(in_pub) if c["public"] else '<span class="nil">—</span>',
+                   yn(in_org) if c["organizers_channel"] else '<span class="nil">—</span>',
+                   yn(p["in_country_channel"]) if c.get("regional_always")
+                   else '<span class="nil">—</span>',
+                   yn(p["in_local_champs"]),
+                   ("; ".join(e(x) for x in issues) if issues
+                    else '<span class="nil">none</span>')))
         chips = " ".join(x for x in [
             ('<code class="chan">#%s</code>' % e(c["public"])) if c["public"] else "",
             ('<code class="chan">#%s</code>' % e(c["organizers_channel"]))
-            if c["organizers_channel"] else ""] if x)
+            if c["organizers_channel"] else "",
+            ('<code class="chan">#%s</code>' % e(c.get("regional_always")))
+            if c.get("regional_always") else ""] if x)
+        table = (('<div class="tablewrap"><table><thead><tr><th>Name</th>'
+                 '<th>Handle</th><th>Email</th>'
+                 '<th>Intake status</th><th class="n">In public</th>'
+                 '<th class="n">In organizers</th><th class="n">In country</th>'
+                 '<th class="n">In %s</th>'
+                 '<th>Issues</th></tr></thead><tbody>%s</tbody></table></div>'
+                 % (LOCAL_CHAMPS_CHANNEL, "".join(rows_html)))
+                if rows_html else '<p class="none">No accepted organizers, and nobody else in the '
+                                   'organizer channel, for this chapter</p>')
         detail.append('<section class="chap"><h3>%s<span class="chapchans">%s</span></h3>'
-                      '<ul class="plist">%s</ul></section>'
-                      % (e(c["city"]), chips or '<span class="nil">no channels</span>',
-                         "".join(items)))
+                      '%s</section>'
+                      % (e(c["city"]), chips or '<span class="nil">no channels</span>', table))
 
     create = rooms_to_create(audit)
     unreachable = [c for c in audit if c["accepted"]
@@ -850,7 +932,16 @@ def render_body(audit, orphans, dupes, today):
     absent_total = sum(1 for c in audit for p in c["accepted"]
                        if c["organizers_channel"] and not p["in_organizers"])
 
-    todo = [
+    todo = []
+    if total_issues:
+        worst_issues.sort(key=lambda t: -t[1])
+        todo.append((
+            "Work through %d issue(s) flagged in the Chapters table"
+            % total_issues,
+            "Worst first: %s. Each row's own Issues column names the exact "
+            "gap." % ", ".join("%s (%d)" % (city, n) for city, n in worst_issues[:6]),
+            "varies", "chapter organizer / ops", "next"))
+    todo += [
         ("Make Slack part of accepting an organizer",
          "%d of %d accepted organizers have no Slack account under their intake email, and only "
          "%d are in their own city channel. Acceptance already triggers a Drive grant and a CRM "
@@ -947,13 +1038,13 @@ def render_body(audit, orphans, dupes, today):
                                              for c in cand[:8])))
 
     stamp = today.strftime("%-d %B %Y")
-    body = f"""
+    chapters_body = f"""
 <header>
-  <div class="eyebrow">Organizer-side Slack audit &middot; {stamp}</div>
-  <h1>The organizer side: coverage, rosters and the leak</h1>
+  <div class="eyebrow">Chapter coverage &middot; {stamp}</div>
+  <h1>Does each chapter have a home?</h1>
   <p class="lede">For every chapter on the Chapters List: does it have a public city channel, does
-  it have a private organizers channel, and are the organizers we accepted actually in them?
-  Organizers are matched to Slack accounts by the email on their intake row.</p>
+  it have a private organizers channel, and a country channel serving it? This is the "does the
+  room exist" question — see the Organizers section for who is actually in each room.</p>
 </header>
 
 <div class="caveat"><strong>Read the organizers column carefully.</strong> A user token only sees
@@ -972,6 +1063,34 @@ complete.</div>
     <div class="stat s-bad"><span class="v">{S['org']}</span><span class="k">Organizers channel</span></div>
   </div>
 </section>
+
+<section>
+  <div class="eyebrow">Coverage matrix</div>
+  <h2>Every chapter, both channels</h2>
+  <div class="controls" style="margin:16px 0 12px">
+    <span class="lbl">Show</span>
+    <button class="f" data-filter="all" aria-pressed="true">All {S['chapters']}</button>
+    <button class="f" data-filter="own" aria-pressed="false">Own channel {S['own']}</button>
+    <button class="f" data-filter="regional" aria-pressed="false">Regional only {S['regional']}</button>
+    <button class="f" data-filter="none" aria-pressed="false">No channel {S['none']}</button>
+    <button class="f" data-filter="noorg" aria-pressed="false">No organizers channel {S['chapters'] - S['org']}</button>
+  </div>
+  <div class="tablewrap"><table>
+    <thead><tr><th>Chapter</th><th>Slack channel</th><th>Country channel</th>
+    <th>Organizer channel</th>
+    <th class="n">Accepted</th><th class="n">In public</th><th class="n">In organizers</th>
+    <th class="n">In {LOCAL_CHAMPS_CHANNEL}</th>
+    <th class="n">No Slack</th><th class="n">Issues</th></tr></thead>
+    <tbody>{''.join(matrix)}</tbody></table></div>
+</section>
+"""
+    organizers_body = f"""
+<header>
+  <div class="eyebrow">Organizer-side Slack audit &middot; {stamp}</div>
+  <h1>Are the organizers we accepted actually in their rooms?</h1>
+  <p class="lede">Organizers are matched to Slack accounts by the email on their intake row. See
+  the Chapters section for whether each room exists at all.</p>
+</header>
 
 <section>
   <div class="eyebrow">The leak</div>
@@ -995,33 +1114,6 @@ complete.</div>
 </section>
 
 <section>
-  <div class="eyebrow">Coverage matrix</div>
-  <h2>Every chapter, both channels</h2>
-  <div class="controls" style="margin:16px 0 12px">
-    <span class="lbl">Show</span>
-    <button class="f" data-filter="all" aria-pressed="true">All {S['chapters']}</button>
-    <button class="f" data-filter="own" aria-pressed="false">Own channel {S['own']}</button>
-    <button class="f" data-filter="regional" aria-pressed="false">Regional only {S['regional']}</button>
-    <button class="f" data-filter="none" aria-pressed="false">No channel {S['none']}</button>
-    <button class="f" data-filter="noorg" aria-pressed="false">No organizers channel {S['chapters'] - S['org']}</button>
-  </div>
-  <div class="tablewrap"><table>
-    <thead><tr><th>Chapter</th><th>Public channel</th><th>Organizers channel</th>
-    <th class="n">Accepted</th><th class="n">In public</th><th class="n">In organizers</th>
-    <th class="n">No Slack</th></tr></thead>
-    <tbody>{''.join(matrix)}</tbody></table></div>
-</section>
-
-<section>
-  <div class="eyebrow">Organizer channel rosters</div>
-  <h2>Who is actually in each organizers channel</h2>
-  <p class="lede">The full membership of all {S['org']} organizer channels, split by whether we ever
-  accepted that person. {distinct} distinct people hold {seats} of these seats without having been
-  accepted — some are staff who belong there, others are legacy leads nobody has reviewed.</p>
-  <div class="grid-rosters" style="margin-top:20px">{''.join(rosters)}</div>
-</section>
-
-<section>
   <div class="eyebrow">What to do</div>
   <h2>Ranked by what it unblocks, not by effort</h2>
   {rs.actions(todo)}
@@ -1030,7 +1122,7 @@ complete.</div>
 <section>
   <div class="eyebrow">Person by person</div>
   <h2>Accepted organizers and where they actually are</h2>
-  <div class="grid-chaps" style="margin-top:20px">{''.join(detail)}</div>
+  <div class="stack-chaps" style="margin-top:20px">{''.join(detail)}</div>
 </section>
 
 {('<section><div class="eyebrow">Data quality</div><h2>Fix these, then re-run</h2>'
@@ -1051,25 +1143,27 @@ btns.forEach(b=>b.addEventListener('click',()=>{
   });
 }));
 """
-    return body, js
+    return chapters_body, organizers_body, js
 
 
 def strip_controls(body):
     """Remove the interactive filter row from a report body.
 
-    For the combined PDF (summarize_audits.py), which drops the script that
-    drives these buttons because its `tbody tr` query is global and would reach
-    into the other appendices. Dropping the script alone leaves controls that
-    look interactive and do nothing, so the markup goes too.
+    For the combined document (summarize_audits.py), which drops the script
+    that drives these buttons because its `tbody tr` query is global and would
+    reach into the other sections. Dropping the script alone leaves controls
+    that look interactive and do nothing, so the markup goes too. The buttons
+    live in the Chapters fragment (the coverage matrix), not Organizers.
     """
     return re.sub(r'<div class="controls".*?</div>', "", body, flags=re.S)
 
 
 def render(audit, orphans, dupes, today):
-    """The standalone document. `render_body` is the seam the combined
-    single-PDF summary composes from — see summarize_audits.py."""
-    body, js = render_body(audit, orphans, dupes, today)
-    return rs.page("Slack Organizers Audit", body, script=js)
+    """The standalone document — Chapters and Organizers concatenated back
+    into one page. `render_body` is the seam the combined summary composes
+    from — see summarize_audits.py."""
+    chapters_body, organizers_body, js = render_body(audit, orphans, dupes, today)
+    return rs.page("Slack Organizers Audit", chapters_body + organizers_body, script=js)
 
 
 def main():
@@ -1077,7 +1171,6 @@ def main():
     ap.add_argument("--out", default="slack-organizers-audit")
     ap.add_argument("--cache", default=".slack-audit-cache")
     ap.add_argument("--refresh", action="store_true", help="re-fetch even if cached")
-    ap.add_argument("--no-pdf", action="store_true")
     ap.add_argument("--planned-ok", action="store_true",
                     help="pre-provisioning: treat sheet-named channels that do "
                          "not exist yet as planned instead of aborting")
@@ -1172,11 +1265,23 @@ def main():
     targets = {}
     for r in rows:
         for name, cid in ((r["public"], r["public_id"]),
-                          (r["organizers_channel"], r["organizers_id"])):
+                          (r["organizers_channel"], r["organizers_id"]),
+                          (r["regional_always"], r["regional_always_id"])):
             if name:
                 targets[name] = cid
+    # local-champs is one workspace-wide room, not per-chapter — resolved by
+    # name like everything else here, never hardcoded to an id, so a rename
+    # or a re-created room is a miss (reported), not a silently wrong count.
+    local_champs_chan = next((c for c in chans if c["name"] == LOCAL_CHAMPS_CHANNEL
+                              and not c["is_archived"]), None)
+    if local_champs_chan:
+        targets[LOCAL_CHAMPS_CHANNEL] = local_champs_chan["id"]
+    else:
+        print("  WARNING: #%s not found — local-champs membership will read as "
+              "unknown for everyone." % LOCAL_CHAMPS_CHANNEL, file=sys.stderr)
     print("  pulling membership for %d channels ..." % len(targets))
     membership = {name: members(api, cid) for name, cid in sorted(targets.items())}
+    local_champs_ids = set(membership.get(LOCAL_CHAMPS_CHANNEL, []))
     # conversations.list already told us how big each channel is; comparing
     # that against what conversations.members returned is a free floor on a
     # short paged pull, which would otherwise render as "accepted but absent"
@@ -1224,7 +1329,8 @@ def main():
                      ", ".join(sorted({err for _, err in failed}))), file=sys.stderr)
 
     audit, orphans = build_audit(rows, people, slack_ids, membership, directory,
-                                 cfg["staff_email_domain"], applicants)
+                                 cfg["staff_email_domain"], applicants,
+                                 local_champs_ids)
     write_cache(os.path.join(args.cache, "audit.json"),
                 {"chapters": audit, "orphan_cities": orphans, "duplicates": dupes},
                 team_id)
@@ -1233,9 +1339,6 @@ def main():
     html_path = args.out + ".html"
     rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
-    if not args.no_pdf:
-        print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),
-                                     os.path.abspath(args.out + ".pdf")))
 
 
 if __name__ == "__main__":

--- a/skills/aaif-audit-slack/scripts/audit_topics.py
+++ b/skills/aaif-audit-slack/scripts/audit_topics.py
@@ -368,6 +368,24 @@ organizer engine's business and are excluded here.</p>
   <div class="stat"><span class="v">%(n_unfiled)s</span><span class="k">unclassified rooms</span></div>
 </div>
 
+<h2>Issues</h2>
+<p class="lede">Every row below is a room this page can already name — the
+to-do list two paragraphs down is nothing more than these, turned into
+verbs. No new judgement is made here that isn't visible in a table further
+down this page.</p>
+<ul>
+<li><b>%(n_dead)s dead</b> — silent for a year or more (of %(n_quiet_total)s
+measured quiet).</li>
+<li><b>%(n_purpose)s</b> with no purpose set.</li>
+<li><b>%(n_unfiled)s unclassified</b> — live and public, no row on the
+%(tab)s tab.</li>
+<li><b>%(n_thin)s carried by one or two people</b> — active, but one
+departure from dead.</li>
+</ul>
+
+<h2>To-do</h2>
+%(todo)s
+
 <h2>Where the subjects sit</h2>
 %(themes)s
 <p class="mute">%(kinds)s</p>
@@ -430,6 +448,31 @@ because someone wrote it on the %(tab)s tab; the engine never inferred one.</li>
         "window": act_meta["days"] if act_meta else 0,
         "n_purpose": format(len(no_purpose), ","),
         "n_unfiled": format(len(unfiled), ","),
+        "n_dead": format(len(dead), ","),
+        "n_quiet_total": format(len(quiet) + len(never), ","),
+        "n_thin": format(len(thin), ","),
+        "todo": rs.actions([
+            t for t in [
+                (("Decide the fate of %d dead topic room(s)" % len(dead)),
+                 "Silent for a year or more: %s." % ", ".join(
+                     "#" + s["name"] for s in
+                     sorted(dead, key=lambda x: -num(x))[:6]),
+                 "minutes each", "chapter/community lead", "next")
+                if dead else None,
+                (("Set a purpose on %d room(s)" % len(no_purpose)),
+                 "No purpose line: %s." % ", ".join(
+                     "#" + s["name"] for s in no_purpose[:6]),
+                 "minutes each", "room owner", "next")
+                if no_purpose else None,
+                (("File %d unclassified room(s) on the %s tab"
+                  % (len(unfiled), TOPICS_TAB)),
+                 "Live, public, and not a topic: %s." % ", ".join(
+                     "#" + c["name"] for c in
+                     sorted(unfiled, key=lambda c: -(c["num_members"] or 0))[:6]),
+                 "minutes each", "whoever curates the tab", "next")
+                if unfiled else None,
+            ] if t
+        ]) or '<p class="mute">Nothing outstanding.</p>',
         "themes": rs.bars(theme_rows[:14]),
         "kinds": e("Kinds on the tab: " + ", ".join(
             "%s %d" % (k, n) for k, n in kinds.most_common())
@@ -489,7 +532,6 @@ def main():
     ap.add_argument("--cache", default=".slack-audit-cache",
                     help="directory for raw API pulls")
     ap.add_argument("--refresh", action="store_true", help="re-fetch even if cached")
-    ap.add_argument("--no-pdf", action="store_true", help="write HTML only")
     args = ap.parse_args()
 
     # Before any collection — this repo is public and the cache holds the
@@ -547,9 +589,6 @@ def main():
     html_path = args.out + ".html"
     rs.write_private(html_path, html_doc)
     print("wrote %s" % html_path)
-    if not args.no_pdf:
-        print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),
-                                     os.path.abspath(args.out + ".pdf")))
 
 
 if __name__ == "__main__":

--- a/skills/aaif-audit-slack/scripts/audit_topics.py
+++ b/skills/aaif-audit-slack/scripts/audit_topics.py
@@ -536,7 +536,7 @@ def main():
 
     # Before any collection — this repo is public and the cache holds the
     # directory. Same gate as the other two engines.
-    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html", args.out + ".pdf")
+    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html")
     os.makedirs(args.cache, exist_ok=True)
     os.chmod(args.cache, 0o700)
 

--- a/skills/aaif-audit-slack/scripts/summarize_audits.py
+++ b/skills/aaif-audit-slack/scripts/summarize_audits.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""The deliverable: ONE PDF, opening on **where should we focus?**
+"""The deliverable: ONE HTML report, opening on **where should we focus?**
 
 Not a fourth audit. It ranks what the three engines already measured — biggest
 cost first, with the evidence and the effort attached — and then carries the
@@ -16,6 +16,7 @@ import datetime as dt
 import html
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib"))
@@ -121,7 +122,7 @@ def topic_findings(subjects, today):
 
     This function used to build its own parallel subject shape and re-read the
     Topics tab, and it drifted immediately: it counted rooms the sweep never
-    reached as "quiet", so the focus page and Appendix B of the SAME PDF
+    reached as "quiet", so the focus page and the Topics section of the SAME document
     reported different numbers and the inflated one was on the cover. Selecting
     from `audit_topics`' own records through its own `state_of` makes that
     divergence unwriteable.
@@ -366,8 +367,9 @@ Read-only throughout; no message text was retained.</footer>
     return body
 
 
-#: Appendices carry their own <h1>, so each starts a fresh printed page and the
-#: PDF reads as four documents in one file rather than one long scroll.
+#: Appendices carry their own <h1>, so each starts a fresh printed page if the
+#: HTML is ever printed, and the document reads as four reports in one file
+#: rather than one long scroll.
 APPENDIX_CSS = """
 /* The appendix must re-create .wrap's vertical rhythm. .wrap is a flex column
    whose 44px gap reaches its DIRECT children only, and an appendix nests its
@@ -381,23 +383,52 @@ APPENDIX_CSS = """
 .appendix > .tag{margin-bottom:-32px}
 .appendix > .tag{display:inline-block;font-size:.72rem;letter-spacing:.08em;
   text-transform:uppercase;opacity:.6;margin-bottom:.4rem}
+/* The sections index: a jump list, not prose — no bullets, no browser-blue
+   links (BASE_CSS's a{} already handles the color; this is layout only). */
+.toc{border:1px solid var(--line-1,#E5E5E2); padding:20px 24px}
+.toc > .tag{display:block; margin-bottom:10px; font-size:.72rem;
+  letter-spacing:.08em; text-transform:uppercase; color:var(--ink-faint,#8C8C8C)}
+.toc ul{list-style:none; margin:0; padding:0; display:flex;
+  flex-direction:column; gap:8px}
+.toc li{font-size:.95rem}
 """
 
 
+def slug(label):
+    return re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+
+
 def appendix(label, body):
-    return ('<section class="appendix"><span class="tag">%s</span>%s</section>'
-            % (e(label), body))
+    return ('<section class="appendix" id="%s"><span class="tag">%s</span>%s</section>'
+            % (e(slug(label)), e(label), body))
 
 
 def build_document(focus_body, appendices):
-    """Focus page + the three full reports, as one self-contained document.
+    """The four full reports, then a TL;DR summary — sections before the recap.
 
-    The organizer report's filter buttons are deliberately dropped: its script
+    A reader arrives wanting the detail; the summary at the end is what they
+    carry away, not a gate they have to scroll past. A short index up top is
+    the only thing that comes before the sections — pure navigation, not
+    content — so the reports themselves are what the document leads with.
+
+    Chapters ("does the room exist?") and Organizers ("is the right person in
+    it?") are two different questions and two different sections, even though
+    both come from `audit_organizers.render_body`'s two fragments — see that
+    function's docstring.
+
+    The Chapters section's filter buttons are deliberately dropped: its script
     hides rows by a global `tbody tr` query, which in a combined document would
-    reach into the other two appendices. Nothing is lost — this output is a PDF,
-    where the buttons were never clickable anyway.
+    reach into the other sections. That is a real trade — the combined HTML
+    loses interactive filtering an organizers-only run still has — traded for
+    a document where every section reads correctly.
     """
-    parts = [focus_body] + [appendix(lbl, b) for lbl, b in appendices]
+    # Summary is a real section too — appended after the four reports — so the
+    # index is built from the full list, not just the four passed in.
+    all_sections = list(appendices) + [("Summary", focus_body)]
+    index = ('<nav class="toc"><span class="tag">Sections</span><ul>%s</ul></nav>'
+            % "".join('<li><a href="#%s">%s</a></li>' % (e(slug(lbl)), e(lbl))
+                     for lbl, _ in all_sections))
+    parts = [index] + [appendix(lbl, b) for lbl, b in all_sections]
     return rs.page("AAIF Slack Audit", "".join(parts), extra_css=APPENDIX_CSS)
 
 
@@ -406,12 +437,9 @@ def main():
     ap.add_argument("--out", default="slack-full-audit",
                     help="output basename (default: slack-full-audit)")
     ap.add_argument("--cache", default=".slack-audit-cache", help="cache directory")
-    ap.add_argument("--no-pdf", action="store_true", help="write HTML only")
-    ap.add_argument("--keep-html", action="store_true",
-                    help="keep the intermediate .html beside the PDF")
     args = ap.parse_args()
 
-    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html", args.out + ".pdf")
+    rs.assert_git_ignored(args.cache + os.sep, args.out + ".html")
 
     audit = need(args.cache, "audit.json", "audit_organizers.py")
     act = need(args.cache, "activity.json", "audit_activity.py")
@@ -425,7 +453,7 @@ def main():
     today = dt.datetime.now(dt.timezone.utc)
     # load_topics() is a LIVE Sheets read. Doing it once matters twice over:
     # two reads cost two round-trips, and they can straddle an edit, so the
-    # focus page and Appendix B could describe two different classifications.
+    # focus page and the Topics section could describe two different classifications.
     claimed = audit_topics.chapter_claimed(args.cache, team_id)
     subjects, filed_out, unfiled = audit_topics.classify(
         chans, load_topics(), claimed)
@@ -435,15 +463,15 @@ def main():
     print("  %d chapters, %d subject rooms (%d quiet), %d organizer gaps"
           % (o["chapters"], len(t["subj"]), len(t["quiet"]), len(o["gaps"])))
 
-    print("  composing the appendices ...")
-    org_body, _ = audit_organizers.render_body(
+    print("  composing the sections ...")
+    chapters_body, org_body, _ = audit_organizers.render_body(
         audit["chapters"], audit.get("orphan_cities") or {},
         audit.get("duplicates") or 0, today)
-    # The organizer body ships filter buttons driven by a script we deliberately
-    # drop (its `tbody tr` query is global and would reach into the other two
-    # appendices). Dropping the script alone left five dead controls in the PDF
-    # that look interactive; strip the markup too, so "nothing is lost" is true.
-    org_body = audit_organizers.strip_controls(org_body)
+    # The Chapters body ships filter buttons driven by a script we deliberately
+    # drop (its `tbody tr` query is global and would reach into the other
+    # sections). Dropping the script alone left five dead controls in the
+    # document that look interactive; strip the markup too.
+    chapters_body = audit_organizers.strip_controls(chapters_body)
 
     # window_days is INDEXED, not .get(...,90): a record without the key is
     # schema drift, and defaulting would mint the very number the page then
@@ -459,27 +487,19 @@ def main():
                 "channels": len(act), "age": ages["activity"]} if ids else None
     # The same completeness tripwire audit_members.main() runs. Calling
     # build_body directly would publish a short user pull with no guard, and
-    # every count on Appendix C plus the member total in action #1 would
+    # every count on the Members section plus the member total in action #1 would
     # understate without saying so.
     audit_members.assert_directory_complete(chans, directory, note=print)
     mem_body = audit_members.build_body(chans, directory, today, activity)
 
     doc = build_document(build(o, t, directory, today, ages),
-                         [("Appendix A — organizers", org_body),
-                          ("Appendix B — topics", top_body),
-                          ("Appendix C — members", mem_body)])
+                         [("Chapters", chapters_body),
+                          ("Organizers", org_body),
+                          ("Topics", top_body),
+                          ("Members", mem_body)])
     html_path = args.out + ".html"
     rs.write_private(html_path, doc)
     print("wrote %s" % html_path)
-    if not args.no_pdf:
-        print("wrote %s" % rs.to_pdf(os.path.abspath(html_path),
-                                     os.path.abspath(args.out + ".pdf")))
-        # One PDF is the deliverable. The HTML is scaffolding, and leaving it
-        # behind means a second copy of the same member names and addresses
-        # sitting in the working directory.
-        if not args.keep_html:
-            os.remove(html_path)
-            print("removed %s (--keep-html to retain it)" % html_path)
 
 
 if __name__ == "__main__":

--- a/skills/aaif-audit-slack/scripts/test_audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/test_audit_organizers.py
@@ -344,13 +344,15 @@ def test_header_index_aborts_on_missing_and_duplicate():
 
 # -------------------------------------------------------------------- join ---
 
-def _row(city, public=None, org=None):
+def _row(city, public=None, org=None, country_channel=None):
     return {"city": city, "regional": None, "public_how": "", "organizers_how": "",
             "regional_how": "",
             "public": public, "public_id": "C1", "public_members": 5,
             "public_candidates": [], "organizers_channel": org,
             "organizers_id": "C2", "organizers_channel_members": 3,
-            "organizers_private": True}
+            "organizers_private": True,
+            "country_channel": country_channel,
+            "country_channel_id": "C3" if country_channel else None}
 
 
 def test_colliding_chapter_names_abort():
@@ -380,6 +382,78 @@ def test_membership_and_staff_split():
           [(x["name"], x["is_staff"]) for x in audit[0]["unaccounted"]],
           [("Outsider", False), ("Staff", True)])
     check("no orphans", orphans, {})
+
+
+def test_local_champs_unpulled_reads_as_unknown_not_absent():
+    """`local_champs_ids=None` (the pull was skipped) must not collapse to
+    "confirmed not a member" — that exact collapse is the bug this suite
+    guards against (main() once computed an empty set instead of None)."""
+    rows = [_row("Boston", public="boston", org="boston-organizers")]
+    people = [{"name": "A", "email": "a@x.com", "status": "Accepted", "city": "Boston"}]
+    slack_ids = {"a@x.com": {"id": "U1"}}
+    membership = {"boston": ["U1"], "boston-organizers": ["U1"]}
+    audit, _ = ao.build_audit(rows, people, slack_ids, membership, {},
+                              "mlops.community", local_champs_ids=None)
+    (a,) = audit[0]["accepted"]
+    check("unpulled local-champs reads as None, not False",
+          a["in_local_champs"], None)
+
+
+def test_local_champs_known_set_marks_real_membership():
+    rows = [_row("Boston", public="boston", org="boston-organizers")]
+    people = [{"name": "A", "email": "a@x.com", "status": "Accepted", "city": "Boston"},
+              {"name": "B", "email": "b@x.com", "status": "Accepted", "city": "Boston"}]
+    slack_ids = {"a@x.com": {"id": "U1"}, "b@x.com": {"id": "U2"}}
+    membership = {"boston": ["U1", "U2"], "boston-organizers": ["U1", "U2"]}
+    audit, _ = ao.build_audit(rows, people, slack_ids, membership, {},
+                              "mlops.community", local_champs_ids={"U1"})
+    a, b = audit[0]["accepted"]
+    check("member of local-champs reads True", a["in_local_champs"], True)
+    check("non-member reads False, not None", b["in_local_champs"], False)
+
+
+def test_country_channel_is_none_when_chapter_has_none():
+    rows = [_row("Boston", public="boston", org="boston-organizers")]
+    people = [{"name": "A", "email": "a@x.com", "status": "Accepted", "city": "Boston"}]
+    slack_ids = {"a@x.com": {"id": "U1"}}
+    membership = {"boston": ["U1"], "boston-organizers": ["U1"]}
+    audit, _ = ao.build_audit(rows, people, slack_ids, membership, {}, "mlops.community")
+    (a,) = audit[0]["accepted"]
+    check("no country channel on the chapter reads as None, not False",
+          a["in_country_channel"], None)
+
+
+def test_country_channel_membership_is_a_real_bool_when_present():
+    rows = [_row("Boston", public="boston", org="boston-organizers",
+                 country_channel="united-states")]
+    people = [{"name": "A", "email": "a@x.com", "status": "Accepted", "city": "Boston"},
+              {"name": "B", "email": "b@x.com", "status": "Accepted", "city": "Boston"}]
+    slack_ids = {"a@x.com": {"id": "U1"}, "b@x.com": {"id": "U2"}}
+    membership = {"boston": ["U1", "U2"], "boston-organizers": ["U1", "U2"],
+                  "united-states": ["U1"]}
+    audit, _ = ao.build_audit(rows, people, slack_ids, membership, {}, "mlops.community")
+    a, b = audit[0]["accepted"]
+    check("in the country channel reads True", a["in_country_channel"], True)
+    check("not in the country channel reads False", b["in_country_channel"], False)
+
+
+def test_person_issues_flags_absence_and_no_slack_account():
+    rows = [_row("Boston", public="boston", org="boston-organizers")]
+    people = [{"name": "A", "email": "a@x.com", "status": "Accepted", "city": "Boston"},
+              {"name": "B", "email": "b@x.com", "status": "Accepted", "city": "Boston"}]
+    slack_ids = {"a@x.com": {"id": "U1"}}
+    membership = {"boston": [], "boston-organizers": ["U1"]}
+    audit, _ = ao.build_audit(rows, people, slack_ids, membership, {}, "mlops.community")
+    a, b = audit[0]["accepted"]
+    check("no Slack account is the only issue reported for B",
+          ao.person_issues(b, audit[0], True),
+          ["no Slack account under their intake email"])
+    check("present in organizers but absent from public channel is flagged for A",
+          ao.person_issues(a, audit[0], True),
+          ["not in #boston (their chapter's public channel)"])
+    check("local-champs absence is never flagged as an issue",
+          any("local-champs" in x or "local_champs" in x
+              for x in ao.person_issues(a, audit[0], True)), False)
 
 
 def test_unnamed_member_is_marked_unresolved_not_accused():

--- a/skills/aaif-audit-slack/scripts/test_audit_organizers.py
+++ b/skills/aaif-audit-slack/scripts/test_audit_organizers.py
@@ -522,8 +522,10 @@ def test_unidentified_members_are_excluded_from_the_accusing_counts():
     flags = sorted(x["unresolved"] for x in audit[0]["unaccounted"])
     check("one identified, one not", flags, [False, True])
     html = ao.render(audit, {}, 0, dt.datetime(2026, 8, 9, tzinfo=dt.timezone.utc))
-    check("only the identified person is counted as unaccounted",
-          "1 distinct people hold 1 of these seats" in html, True)
+    check("the identified person appears in the person-by-person table",
+          "Known" in html, True)
+    check("the unidentified member's raw id is not rendered as a roster row",
+          "<td>U7</td>" in html, False)
     check("the unidentified are surfaced in Data quality",
           "could not be identified" in html, True)
 

--- a/skills/aaif-sync-chapters/scripts/invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/invite_organizers.py
@@ -122,7 +122,7 @@ def collect(city_filter=None):
     _, _, chapters = read_grid(city_filter)
     chans = {c["name"]: c for c in slackmod.channels(api) if not c["is_archived"]}
 
-    people, _ = ao.read_intake()
+    people, _, _ = ao.read_intake()
     by_city = {}
     for p in people:
         if p["city"]:

--- a/skills/aaif-sync-chapters/scripts/prune_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/prune_organizers.py
@@ -152,7 +152,7 @@ def classify(city_filter=None):
     _, _, chapters = read_grid(city_filter)
     chans = {c["name"]: c for c in slackmod.channels(api) if not c["is_archived"]}
 
-    people, _ = ao.read_intake()
+    people, _, _ = ao.read_intake()
     emails = {p["email"].lower() for p in people if p["email"]}
     # Name index for the cross-check. Folded the same way every other engine
     # folds, so "Padmé Naberrie" and "Padme Naberrie" are one person.

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -914,7 +914,7 @@ def propose_handles(chapters, ao, api, slackmod):
     Order follows the intake, matching the `Organizers` name column beside it, so
     the two read as the same list in the same order.
     """
-    people, _ = ao.read_intake()
+    people, _, _ = ao.read_intake()
     by_city = {}
     for p in people:
         if p["city"]:

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -429,6 +429,46 @@ with _ctx.redirect_stderr(_err):
     inv.set_redaction(False)
 check("turning redaction off is silent", _err.getvalue(), "")
 check("set_redaction(False) leaves REDACT off", inv.REDACT, False)
+
+
+# --- collect() actually calls ao.read_intake() — the 3-value unpacking at
+# invite_organizers.py's collect() is the same fix class as prune_organizers.py's
+# (both once unpacked a stale 2-tuple), but only prune_organizers.py's copy had
+# a test exercising it. A regression here would raise ValueError with nothing
+# local or in CI to catch it. ---------------------------------------------------
+from unittest import mock as _mock  # noqa: E402
+
+_INTAKE = [{"email": "a@x.com", "name": "Ada", "city": "Boston"}]
+
+
+class _FakeInviteApi:
+    def __init__(self, *a, **kw):
+        pass
+
+    def require_scopes(self, *a):
+        pass
+
+
+def _run_collect():
+    chapters = [{"city": "Boston", "current": {"Organizer Channel": "boston-organizers"}}]
+    chans = [{"name": "boston-organizers", "id": "C1", "is_private": True,
+             "is_archived": False}]
+    with _mock.patch.object(inv, "read_grid", lambda c: (None, None, chapters)), \
+         _mock.patch.object(inv.slackmod, "Slack", _FakeInviteApi), \
+         _mock.patch.object(inv.slackmod, "channels", lambda api: chans), \
+         _mock.patch.object(inv.slackmod, "members", lambda api, cid: ["U1"]), \
+         _mock.patch.object(inv.slackmod, "lookup_emails",
+                            lambda api, emails: {"a@x.com": {"id": "U1"}}), \
+         _mock.patch.object(inv.ao, "read_intake", lambda: (_INTAKE, 0, {})):
+        return inv.collect()
+
+
+_rows, _unresolved, _no_channel = _run_collect()
+check("collect() runs to completion against a 3-tuple read_intake()",
+      len(_rows), 1)
+check("the one roster member already present is not double-counted as missing",
+      (_rows[0]["missing"], [n for n, _ in _rows[0]["present"]]), ([], ["Ada"]))
+
 if FAILS:
     print("\nFAIL (%d)" % len(FAILS))
     for f in FAILS:

--- a/skills/aaif-sync-chapters/scripts/test_prune_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_prune_organizers.py
@@ -70,7 +70,7 @@ def run_classify(members, keep=frozenset(), keep_ids=frozenset(),
          mock.patch.object(pr, "read_keeplist",
                            lambda: (set(keep), set(keep_ids), True)), \
          mock.patch.object(pr, "read_grid", lambda c: (None, None, chapters)), \
-         mock.patch.object(pr.ao, "read_intake", lambda: (INTAKE, 0)):
+         mock.patch.object(pr.ao, "read_intake", lambda: (INTAKE, 0, {})):
         return pr.classify()
 
 

--- a/skills/aaif-sync-chapters/scripts/test_sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_resources.py
@@ -379,6 +379,28 @@ with mock.patch.object(sr, "fold_city", sr.fold_city):
 check("the handles guard constant matches the shared sentinel",
       sync_chapters.NO_RESOURCE, "none")
 
+
+# --- propose_handles() actually calls ao.read_intake() — the 3-value unpacking
+# is the same fix class prune_organizers.py/invite_organizers.py needed; this
+# one takes `ao` as a plain argument rather than a module attribute, so no
+# mock.patch is needed — a fake object with the right shape is enough. -------
+class _FakeAO:
+    def read_intake(self):
+        return ([{"name": "Ada", "email": "a@x.com", "city": "Oslo"}], 0, {})
+
+
+class _FakeSlackmod:
+    def lookup_emails(self, api, emails):
+        return {"a@x.com": {"id": "U1", "name": "ada"}}
+
+
+_proposals, _unresolved = sr.propose_handles(
+    [ch("Oslo", row=7, handles="")], _FakeAO(), None, _FakeSlackmod())
+check("propose_handles() runs to completion against a 3-tuple read_intake()",
+      len(_proposals), 1)
+check("the resolved organizer's handle is proposed",
+      _proposals[0]["value"], "@ada")
+
 # --- the CI default is a real boolean, and masking announces itself ------------
 import io as _io  # noqa: E402
 import contextlib as _ctx  # noqa: E402

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -34,7 +34,18 @@ queue** — the person is triaged on their original row, and the duplicate is pa
 rather than denied (a `Denied` row reads as a decision about the person, which this
 is not). It is not a sync status: nothing carries a `Duplicate` row to the chapters
 feed, a CRM or a Drive grant. Rows are only ever marked by hand — the form can't
-know it has seen someone before, so no automation sets this value. A
+know it has seen someone before, so no automation sets this value.
+
+**Two rows sharing an email is not, by itself, evidence of a duplicate — read the
+content before parking a row.** A repeat is the *same ask sent again* (identical
+or near-identical answers, most often a form resubmitted after a mistake or a
+timeout). It is a different row, and not a duplicate, when the same person is
+legitimately doing two things: applying for two roles (organizer **and**
+speaker — `sync_crm`'s SECURITY check already treats this as expected, see
+`aaif-sync-chapters`), or pitching two distinct proposals in the same role (two
+different talk titles/abstracts from one speaker). Marking either `Duplicate`
+silently discards a live application; check `Talk title` / `Headline` /
+`Abstract` (or the equivalent per-role fields) actually differ before deciding.
 **blank** Status cell is treated as `Prospect`, and so is the **legacy value `New`** —
 the pre-2026-08-22 name for the same state, renamed because `New` misread as
 "new organizer" while `Prospect` matches the term the CRM sync already writes.

--- a/skills/aaif-triage-intake/SKILL.md
+++ b/skills/aaif-triage-intake/SKILL.md
@@ -46,7 +46,8 @@ speaker — `sync_crm`'s SECURITY check already treats this as expected, see
 different talk titles/abstracts from one speaker). Marking either `Duplicate`
 silently discards a live application; check `Talk title` / `Headline` /
 `Abstract` (or the equivalent per-role fields) actually differ before deciding.
-**blank** Status cell is treated as `Prospect`, and so is the **legacy value `New`** —
+
+A **blank** Status cell is treated as `Prospect`, and so is the **legacy value `New`** —
 the pre-2026-08-22 name for the same state, renamed because `New` misread as
 "new organizer" while `Prospect` matches the term the CRM sync already writes.
 `migrate_status_prospect.py` (in `aaif-sync-chapters`) rewrites the dropdowns,


### PR DESCRIPTION
## Summary
Reworks the Slack organizer audit into a single combined HTML report with proper Chapters/Organizers/Topics/Members sections (each with its own Issues → To-do subsection), fixes several real bugs found along the way (a duplicated bad unpacking pattern that shipped in three places, a data-collapse bug that silently turned "unmeasured" into "confirmed absent", off-brand report styling), and drops PDF generation entirely in favor of one clean HTML deliverable.

## Changesets

### 1. `fix(sync-chapters): fix read_intake() 3-value unpacking in three scripts`
**Files:** `invite_organizers.py`, `prune_organizers.py`, `sync_resources.py`
All three unpacked `audit_organizers.read_intake()` as `(people, _)` — it returns `(people, dupes, applicants)`, so each one raised `ValueError` on first real use since `applicants` was added.

### 2. `docs(triage-intake): clarify Duplicate vs multi-role/multi-pitch applications`
**Files:** `skills/aaif-triage-intake/SKILL.md`
Two intake rows sharing an email isn't automatically a duplicate — someone can legitimately apply for two roles or pitch two distinct proposals in the same role. Clarified after this ambiguity briefly caused a real speaker's two different talk submissions to be mis-flagged as a duplicate.

### 3. `fix(reports): flatten rounded corners, style links, fix missing Summary link`
**Files:** `lib/aaif_events/report_style.py`, `skills/aaif-audit-slack/scripts/summarize_audits.py`
The shared report stylesheet had hardcoded border-radius guesses instead of AAIF's flat, hairline-only aesthetic — flattened every rectangular container (kept true pills/badges at their pill shape). Added the design system's own link treatment, since the new sections index was rendering as unstyled default-blue links. Fixed the index never listing "Summary".

### 4. `feat(audit-slack): rework organizer audit — chapters/organizers split, per-row issues, drop PDF`
**Files:** all five `audit_*.py`/`summarize_audits.py` scripts, `SKILL.md`, `DESIGN.md`
- Chapters ("does the room exist?") and Organizers ("is the right person in it?") are now two separate top-level sections instead of one nested under the other.
- Tracks membership in the real `local-champs` channel and each chapter's country channel — previously conflated with per-chapter `-organizers` channels.
- Replaced the two-column card-grid roster views with one full-width, independently horizontally-scrollable table per chapter, with issue-derived rows tinted for scanning.
- Every engine's "Issues" list now feeds a same-data "To-do" subsection directly.
- PDF generation dropped entirely — HTML is the only output.

### 5. `fix: repair two tests broken by this PR's own changes (CI-only failure mode)`
**Files:** `test_audit_organizers.py`, `test_prune_organizers.py`
Both files use a hand-rolled `check()`/`FAILS`-list harness that never raises — under `pytest`, every `test_*` function reports "passed" regardless of outcome. Only running them as plain scripts (`python3 test_file.py`, what CI actually does) surfaces a real failure. Fixed a stale assertion and a stale 2-tuple mock, confirmed by running CI's exact loop over every `skills/*/scripts/test_*.py` locally.

### 6. `fix: address self-review findings`
**Files:** 11 files across the audit-slack skill, `DESIGN.md`, `README.md`
Full self-review via `hero-skills:review-pr` (5 pr-review-toolkit agents + a security pass). One Critical bug found independently by 3 of 6 agents: `local_champs_ids` was computed as an empty set, never `None`, when `#local-champs` wasn't found — silently collapsing "the pull was skipped" into "confirmed nobody is a member" for every person, contradicting `build_audit()`'s own documented contract. Fixed the source and the coverage matrix's rendering (now shows "?" instead of a confident `0/n`), hoisted the previously-untestable `person_issues()` to module level, and added direct test coverage for the local-champs tri-state, `in_country_channel`, and the same `read_intake()` fix pattern in `invite_organizers.py`/`sync_resources.py` that only one of the three affected files had a test for. Also fixed a stale `SKILL.md` document-structure description, a dropped article, an orphaned CSS class, and stale PDF references in `README.md` and four engines.

## Test plan
- [x] `PYTHONPATH=lib python3 -m pytest lib/aaif_events/tests -q` — 386 passed, 1 skipped
- [x] **Every** `skills/*/scripts/test_*.py` and `scripts/test_*.py` run as a plain script (`python3 test_file.py`, matching CI's actual invocation — `pytest` alone does not catch failures in these hand-rolled-harness files) — all green
- [x] `pre-commit run --all-files` and `--hook-stage pre-push --all-files`
- [x] Ran all four collectors + `summarize_audits.py` against live data, visually verified the combined report in Chrome (sections, index, corners, links, row coloring, per-table horizontal scroll)
- [x] Full self-review via `hero-skills:review-pr` (6 agents), all findings fixed

_Generated using hero-skills._