### PR TITLE
Add country-channel organizer invites and directory posts

### DIFF
--- a/skills/aaif-audit-slack/scripts/summarize_audits.py
+++ b/skills/aaif-audit-slack/scripts/summarize_audits.py
@@ -97,14 +97,25 @@ def org_findings(audit):
     no_pub = [c for c in ch if not c["public"]]
     no_org = [c for c in ch if not c["organizers_channel"]]
     zero = [c for c in ch if c["organizers_channel"] and not c["accepted"]]
-    gaps = []
+    # A person with no Slack account (`slack_account` False) is unconditionally
+    # `in_organizers: False` — there's no uid to be a member with — but that is
+    # not the same finding as "has an account and wasn't invited". audit_organizers'
+    # own person_issues() draws this line (a missing account returns early and never
+    # also reports "not in #channel"); folding both into one "gaps" bucket here
+    # inflates the invite backlog with people invite_organizers.py can never act on.
+    gaps, no_account = [], []
     for c in ch:
         acc = c["accepted"] or []
         if acc and c["organizers_channel"]:
             out = [a for a in acc if not a.get("in_organizers")]
-            if out:
-                gaps.append((c["city"], len(out), len(acc)))
+            invitable = [a for a in out if a.get("slack_account")]
+            no_acct = [a for a in out if not a.get("slack_account")]
+            if invitable:
+                gaps.append((c["city"], len(invitable), len(acc)))
+            if no_acct:
+                no_account.append((c["city"], len(no_acct), len(acc)))
     gaps.sort(key=lambda g: -g[1])
+    no_account.sort(key=lambda g: -g[1])
     # `unresolved` records are members whose directory lookup FAILED. The
     # organizer engine reports them as "could not identify", explicitly not as
     # unaccounted people, because filing them under "nobody reviewed them"
@@ -114,7 +125,8 @@ def org_findings(audit):
               and not u["intake_status"]
               for city in (c["city"],)]
     return {"chapters": len(ch), "pub_org": pub_org, "no_pub": no_pub,
-            "no_org": no_org, "zero": zero, "gaps": gaps, "no_row": no_row}
+            "no_org": no_org, "zero": zero, "gaps": gaps,
+            "no_account": no_account, "no_row": no_row}
 
 
 def topic_findings(subjects, today):
@@ -191,6 +203,17 @@ def build(o, t, directory, today, ages):
             % (len(o["gaps"]),
                "; ".join("%s (%d of %d)" % g for g in top_gaps[:3])),
             "an afternoon", "ops", "next"))
+    if o["no_account"]:
+        acts.append((
+            "Chase %d accepted organizers with no Slack account"
+            % sum(g[1] for g in o["no_account"]),
+            "Across %d chapters, the intake email we hold for an accepted "
+            "organizer matches no Slack account — not a room they can be "
+            "invited to, an address that needs confirming or fixing first: %s."
+            % (len(o["no_account"]),
+               "; ".join("%s (%d of %d)" % g
+                         for g in o["no_account"][:3])),
+            "an afternoon", "ops", "later"))
     if o["no_org"]:
         acts.append((
             "Provision %d missing organizer channels" % len(o["no_org"]),

--- a/skills/aaif-audit-slack/scripts/summarize_audits.py
+++ b/skills/aaif-audit-slack/scripts/summarize_audits.py
@@ -106,14 +106,22 @@ def org_findings(audit):
     gaps, no_account = [], []
     for c in ch:
         acc = c["accepted"] or []
-        if acc and c["organizers_channel"]:
+        if not acc:
+            continue
+        # No-account is a finding about the PERSON, not the channel — a
+        # chapter with no organizers channel yet still has organizers with no
+        # Slack account under their intake email, and gating this on
+        # `organizers_channel` (as `gaps` correctly does, since a gap
+        # presupposes a channel to be missing from) silently dropped exactly
+        # the newest chapters, where an unconfirmed address is most likely.
+        no_acct = [a for a in acc if not a.get("slack_account")]
+        if no_acct:
+            no_account.append((c["city"], len(no_acct), len(acc)))
+        if c["organizers_channel"]:
             out = [a for a in acc if not a.get("in_organizers")]
             invitable = [a for a in out if a.get("slack_account")]
-            no_acct = [a for a in out if not a.get("slack_account")]
             if invitable:
                 gaps.append((c["city"], len(invitable), len(acc)))
-            if no_acct:
-                no_account.append((c["city"], len(no_acct), len(acc)))
     gaps.sort(key=lambda g: -g[1])
     no_account.sort(key=lambda g: -g[1])
     # `unresolved` records are members whose directory lookup FAILED. The

--- a/skills/aaif-audit-slack/scripts/test_summarize_audits.py
+++ b/skills/aaif-audit-slack/scripts/test_summarize_audits.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Self-tests for org_findings()'s gaps/no_account split.
+
+Standalone (not pytest) to match the other skills' script tests, which CI picks
+up via `for t in skills/*/scripts/test_*.py`.
+
+Covers the one property that has already broken silently once: a person with
+no Slack account and a person who has an account but wasn't invited must land
+in exactly one of `gaps`/`no_account`, never both, never neither, and never
+dropped because their chapter has no organizers channel yet.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import summarize_audits as sa  # noqa: E402
+
+FAILS = []
+
+
+def check(label, got, want):
+    if got != want:
+        FAILS.append("%s\n     got:  %r\n     want: %r" % (label, got, want))
+    print("%s %s" % ("ok  " if got == want else "FAIL", label))
+
+
+def person(slack_account, in_organizers):
+    return {"slack_account": slack_account, "in_organizers": in_organizers}
+
+
+def chapter(city, organizers_channel, accepted):
+    return {"city": city, "organizers_channel": organizers_channel,
+            "organizers_private": True, "public": "x", "accepted": accepted,
+            "unaccounted": []}
+
+
+# --- the split is exhaustive: every non-invited accepted person lands in
+# exactly one bucket -----------------------------------------------------------
+audit = {"chapters": [
+    chapter("Ahmedabad", "ahmedabad-organizers",
+            [person(True, True), person(True, True), person(True, True),
+             person(True, True), person(False, False), person(False, False),
+             person(False, False)]),
+]}
+o = sa.org_findings(audit)
+check("no-account people never appear in gaps", o["gaps"], [])
+check("they appear in no_account instead", o["no_account"],
+      [("Ahmedabad", 3, 7)])
+
+# --- an invitable person (has an account, just not in the channel) lands in
+# gaps, never no_account --------------------------------------------------------
+audit = {"chapters": [
+    chapter("Lagos", "lagos-organizers",
+            [person(True, False), person(True, True)]),
+]}
+o = sa.org_findings(audit)
+check("an invitable gap lands in gaps", o["gaps"], [("Lagos", 1, 2)])
+check("and not in no_account", o["no_account"], [])
+
+# --- a no-account organizer is counted even with no organizers channel yet —
+# the bug this fixes: gating no_account on organizers_channel dropped exactly
+# the newest chapters, where an unconfirmed intake email is most likely --------
+audit = {"chapters": [
+    chapter("Kinshasa", "", [person(False, False)]),
+]}
+o = sa.org_findings(audit)
+check("a chapter with no channel yet still counts its no-account organizer",
+      o["no_account"], [("Kinshasa", 1, 1)])
+check("but is not a gap — there is no channel to be missing from",
+      o["gaps"], [])
+
+if FAILS:
+    print("\nFAIL (%d)" % len(FAILS))
+    for f in FAILS:
+        print("  - %s" % f)
+    sys.exit(1)
+print("\nsummarize_audits: all checks passed")

--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -966,11 +966,18 @@ the column. A Slack handle is a display name a person can change, so resolving
 `@someone` back to an account would break the day they rename themselves — and an
 organizer would quietly stop being invited to their own chapter's room.
 
-Scope is deliberately narrow:
+`--scope {organizer,country,both}` picks the target column, default
+`organizer` — the private Organizer Channel only, unchanged from the policy
+below. `--scope country` targets the public Country Channel instead (several
+chapters routinely share one, `#españa` serves Madrid/Barcelona/Bilbao — the
+roster is the union of every contributing chapter's accepted organizers,
+deduplicated by email), which is a deliberate, narrower version of the same
+override Rahul made 2026-08-25 for public *city* channels: being an organizer
+of your own chapter's public room is part of the role, the room is public
+anyway, leaving is one click. `--scope both` runs both passes off one fetch.
 
-- **Organizer channels only.** The public chapter channel is for people to join
-  when they choose; being an organizer is not consent to be placed in a public
-  room.
+Otherwise, scope is deliberately narrow:
+
 - **Adds, never removes.** Someone in the channel the intake doesn't know is
   reported and left alone — an audit finding, not a cleanup task.
 - **Batched per channel**, so Slack renders one event rather than N join lines.
@@ -982,6 +989,30 @@ mail share notices by default: an invitation is a notification to a real person,
 and a hundred arriving at once reads as a phishing wave. Needs
 `groups:write.invites` / `channels:write.invites`, which the audit token does not
 carry.
+
+## Keeping each country channel's chapter directory current (`post_country_directory.py`)
+
+A shared Country Channel needs its own standing post pointing members at their
+city's channel — `#india` serves 8 chapters, and a newcomer landing there needs
+to know which of the 8 is theirs. This script keeps that post complete as
+chapters are added, without ever rewriting the wording a human chose:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/post_country_directory.py                          # what would change
+python3 ${CLAUDE_SKILL_DIR}/scripts/post_country_directory.py --write --i-have-approval
+```
+
+**Additive only — never `chat.update`.** The workspace already carries at
+least three different human phrasings of this post (a plain "This country has
+N chapters" template, a "The Nordics have N chapters" variant, and a "we've
+opened a dedicated city channel for X" announcement). Picking one canonical
+wording and overwriting the others would replace text a human chose on purpose
+for no functional gain. So a channel with no directory-style post at all gets a
+brand-new one; a channel whose existing self-authored post is missing a chapter
+gets a short add-on message naming only what's new; a post authored by someone
+else is reported and left alone. Run it after `invite_organizers.py --scope
+country` (or `both`) — the channel needs its people before it needs a sign
+pointing new arrivals at them.
 
 ## Removing non-organizers (`prune_organizers.py`)
 
@@ -1035,6 +1066,7 @@ After any run (and after editing the engine):
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_access.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_sync_resources.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_invite_organizers.py
+  python3 ${CLAUDE_SKILL_DIR}/scripts/test_post_country_directory.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_prune_organizers.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_nightly.py
   python3 ${CLAUDE_SKILL_DIR}/scripts/test_migrate_status_prospect.py

--- a/skills/aaif-sync-chapters/scripts/invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/invite_organizers.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Put each chapter's accepted organizers into its organizer Slack channel.
+"""Put each chapter's accepted organizers into a Slack channel they belong in.
 
 Answers two questions, and the first is useful on its own:
 
 1. **Who is missing?** For every chapter, who the intake says is an organizer,
-   who is actually in that chapter's `Organizer Channel`, and the difference.
-   Read-only, and the report is the default.
+   who is actually in the target channel, and the difference. Read-only, and
+   the report is the default.
 2. **Add them.** Behind `--write --i-have-approval`, and nothing else.
 
 ## Identity comes from the intake, not from the sheet's handles
@@ -17,16 +17,28 @@ can change at any time, so resolving `@someone` back to an account would break
 silently the day they rename themselves — and "silently" here means an organizer
 quietly stops being invited to their own chapter's room.
 
-## Scope, deliberately narrow
+## Scope: `--scope organizer` (default), `--scope country`, or `--scope both`
 
-- **Organizer channels only.** The public chapter channel is for anyone to join
-  when they choose; being an organizer is not consent to be placed in a public
-  room. Only the private room their role actually requires.
-- **Adds, never removes.** Someone in the channel the intake has never heard of
-  is *reported* and left alone — that is what an audit needs to see, and
-  `aaif-audit-slack` reports the same set from the other direction.
-- **Never touches a channel the sheet does not name**, and skips any channel that
-  does not exist yet with a reason (run `provision_channels.py` first).
+- **`organizer`** targets each chapter's private `Organizer Channel` only. The
+  public chapter channel is for anyone to join when they choose; being an
+  organizer is not consent to be placed in a public room — that policy is
+  unchanged and is the default.
+- **`country`** targets `Country Channel` instead — also a *public* room, and
+  several chapters usually share one (`#españa` serves Madrid, Barcelona and
+  Bilbao). This is the same class of override Rahul made 2026-08-25 for public
+  city channels (being an organizer of your own chapter's public room is part
+  of the role, the room is public anyway, leaving is one click) — extended
+  here to the country room, and built as a standing `--scope` rather than a
+  throwaway script so it doesn't need rebuilding each time. Roster for a
+  shared country channel is the union of every contributing chapter's accepted
+  organizers, deduplicated by email.
+- **`both`** runs both passes in one report/apply.
+- **Adds, never removes**, in every scope. Someone in the channel the intake
+  has never heard of is *reported* and left alone — that is what an audit
+  needs to see, and `aaif-audit-slack` reports the same set from the other
+  direction.
+- **Never touches a channel the sheet does not name**, and skips any channel
+  that does not exist yet with a reason (run `provision_channels.py` first).
 
 ## Why this is gated harder than a sheet write
 
@@ -36,9 +48,10 @@ from mailing share notices by default. `--write` alone is not enough;
 `--i-have-approval` must be passed too, and the report must have been read.
 
 Usage:
-    python3 invite_organizers.py                         # who is missing
-    python3 invite_organizers.py --city Berlin
-    python3 invite_organizers.py --write --i-have-approval
+    python3 invite_organizers.py                         # who is missing (organizer channels)
+    python3 invite_organizers.py --scope country
+    python3 invite_organizers.py --scope both --city Berlin
+    python3 invite_organizers.py --scope both --write --i-have-approval
 """
 
 import argparse
@@ -100,11 +113,13 @@ NEEDED_SCOPES = ("groups:write.invites", "channels:write.invites")
 MAX_PER_CALL = 1000
 
 
-def collect(city_filter=None):
-    """Return (rows, unresolved, no_channel) — who is missing from where.
+def fetch(city_filter=None):
+    """One Slack/Sheets round trip: (api, chapters, chans, by_city, resolved).
 
-    rows = [{city, channel, channel_id, missing: [(name, id)], present: [...],
-             unaccounted: [ids]}].
+    Split out of collect() so a multi-column run (`--scope both`) fetches this
+    once, not once per column — the grid read, live-channel list, full intake
+    read and email-resolution batch are identical between an Organizer Channel
+    pass and a Country Channel pass; only the per-column grouping differs.
     """
     # Same read-token fallback as provision_channels.main(): this estate's CLI
     # credential expired for good in 2026-08, and the env write token carries
@@ -130,26 +145,61 @@ def collect(city_filter=None):
 
     resolved = slackmod.lookup_emails(
         api, {p["email"] for p in people if p["email"]})
+    return api, chapters, chans, by_city, resolved
 
+
+def collect(city_filter=None, column="Organizer Channel", fetched=None):
+    """Return (rows, unresolved, no_channel) — who is missing from where.
+
+    rows = [{city, channel, channel_id, missing: [(name, id)], present: [...],
+             unaccounted: [ids]}].
+
+    Grouped by the target *channel*, not by chapter row: an `Organizer Channel`
+    is normally 1:1 with a city, but a `Country Channel` is routinely shared by
+    several chapters, and inviting per-chapter would send the same person two
+    separate `conversations.invite` calls for the one channel they're both
+    pointed at. `city` on the returned row is the sorted, comma-joined list of
+    every chapter that names this channel — one city in the common case.
+
+    `fetched` reuses a prior fetch() call (see there) instead of hitting Slack
+    and the sheet again — pass it when collecting more than one column.
+    """
+    api, chapters, chans, by_city, resolved = fetched or fetch(city_filter)
+
+    # Group chapters by the channel NAME they name in `column`, not by row:
+    # several chapters can point at the same Country Channel.
     rows, unresolved, no_channel = [], [], []
+    groups = {}
     for ch in chapters:
-        roster = by_city.get(fold_city(ch["city"]), [])
-        if not roster:
+        if not by_city.get(fold_city(ch["city"])):
             continue                      # nobody accepted yet; nothing to do
-        name = ch["current"]["Organizer Channel"]
+        name = ch["current"][column]
         if not name or name == NO_RESOURCE:
-            no_channel.append((ch["city"], "no Organizer Channel on the sheet"))
+            no_channel.append((ch["city"], "no %s on the sheet" % column))
             continue
+        groups.setdefault(name, []).append(ch["city"])
+
+    for name, cities in sorted(groups.items()):
+        label = ", ".join(sorted(cities))
         chan = chans.get(name)
         if not chan:
             # Two indistinguishable causes: the channel genuinely doesn't exist,
             # or it is private and this token's user is not a member —
             # conversations.list hides those (see lib/aaif_events/slack.py).
             no_channel.append(
-                (ch["city"], "#%s not visible — not created yet (run "
+                (label, "#%s not visible — not created yet (run "
                  "provision_channels.py), or private and this token's user "
                  "is not in it" % name))
             continue
+
+        roster, seen_emails = [], set()
+        for city in cities:
+            for p in by_city.get(fold_city(city), []):
+                if p["email"] and p["email"] in seen_emails:
+                    continue               # same person via >1 contributing chapter
+                if p["email"]:
+                    seen_emails.add(p["email"])
+                roster.append(p)
 
         members = set(slackmod.members(api, chan["id"]))
         missing, present = [], []
@@ -159,24 +209,23 @@ def collect(city_filter=None):
             if not uid:
                 # Not a failure of this script: they have no account under the
                 # address the intake holds. Reported, never silently dropped.
-                unresolved.append((ch["city"], p["name"]))
+                unresolved.append((label, p["name"]))
             elif uid in members:
                 present.append((p["name"], uid))
             else:
                 missing.append((p["name"], uid))
 
         known = {uid for _, uid in missing + present}
-        rows.append({"city": ch["city"], "channel": name,
+        rows.append({"city": label, "channel": name,
                      "channel_id": chan["id"], "is_private": chan["is_private"],
                      "missing": missing, "present": present,
                      "unaccounted": sorted(members - known)})
     return rows, unresolved, no_channel
 
 
-def report(rows, unresolved, no_channel):
+def report(rows, unresolved, no_channel, label="Organizer channel"):
     total = sum(len(r["missing"]) for r in rows)
-    print("Organizer channel membership — %d chapter(s) with a live channel\n"
-          % len(rows))
+    print("%s membership — %d live channel(s)\n" % (label, len(rows)))
     for r in sorted(rows, key=lambda x: x["city"]):
         if not r["missing"]:
             print("  %-18s #%-28s all %d in" % (r["city"], r["channel"],
@@ -200,7 +249,7 @@ def report(rows, unresolved, no_channel):
 
     extra = sum(len(r["unaccounted"]) for r in rows)
     if extra:
-        print("\n%d person(s) in an organizer channel the intake does not list. "
+        print("\n%d person(s) in a channel the intake does not list them for. "
               "NOT removed —\nthat is an audit finding, not a cleanup task; see "
               "aaif-audit-slack." % extra)
     print("\nTotal to add: %d" % total)
@@ -243,6 +292,15 @@ def apply(rows, token):
     return done, failed
 
 
+#: What each --scope value targets, and the label used in the report header.
+SCOPE_COLUMNS = {
+    "organizer": [("Organizer Channel", "Organizer channel")],
+    "country": [("Country Channel", "Country channel")],
+    "both": [("Organizer Channel", "Organizer channel"),
+             ("Country Channel", "Country channel")],
+}
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--write", action="store_true")
@@ -250,33 +308,46 @@ def main():
                     help="required alongside --write; an invitation is a "
                          "notification to a real person and cannot be unsent")
     ap.add_argument("--city", help="limit to one chapter")
+    ap.add_argument("--scope", choices=sorted(SCOPE_COLUMNS), default="organizer",
+                    help="which channel to target: the private Organizer "
+                         "Channel (default), the public Country Channel, or "
+                         "both")
     add_redact_flag(ap)
     a = ap.parse_args()
     set_redaction(a.redact)
 
-    rows, unresolved, no_channel = collect(a.city)
-    total = report(rows, unresolved, no_channel)
+    # One fetch for the whole run — `--scope both` collects two columns from
+    # the SAME chapters/channels/intake, not two independent sweeps of Slack
+    # and the sheet.
+    fetched = fetch(a.city)
+
+    all_rows, total = [], 0
+    for column, label in SCOPE_COLUMNS[a.scope]:
+        rows, unresolved, no_channel = collect(a.city, column=column, fetched=fetched)
+        total += report(rows, unresolved, no_channel, label=label)
+        all_rows += rows
+        print()
 
     if not a.write:
-        print("\nReport only. Nobody was invited to anything.")
+        print("Report only. Nobody was invited to anything.")
         return 0
     if not total:
-        print("\nNothing to do.")
+        print("Nothing to do.")
         return 0
     if not a.i_have_approval:
-        sys.exit("\nREFUSING: --write needs --i-have-approval too. This sends a "
+        sys.exit("REFUSING: --write needs --i-have-approval too. This sends a "
                  "Slack notification to %d real people." % total)
 
     token = write_token()
     have = slackmod.Slack(token=token).scopes()
     missing = [s for s in NEEDED_SCOPES if s not in have]
     if missing:
-        sys.exit("\nREFUSING: the write token lacks %s." % ", ".join(missing))
+        sys.exit("REFUSING: the write token lacks %s." % ", ".join(missing))
 
     assert "conversations.invite" in WRITE_METHODS, (
         "conversations.invite must be in the write allowlist")
 
-    done, failed = apply(rows, token)
+    done, failed = apply(all_rows, token)
     print("\nInvited %d, %d invite(s) failed." % (done, len(failed)))
     for f in failed:
         print("  %s" % f)

--- a/skills/aaif-sync-chapters/scripts/invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/invite_organizers.py
@@ -202,7 +202,7 @@ def collect(city_filter=None, column="Organizer Channel", fetched=None):
                 roster.append(p)
 
         members = set(slackmod.members(api, chan["id"]))
-        missing, present = [], []
+        missing, present, seen_uids = [], [], set()
         for p in roster:
             hit = resolved.get(p["email"]) or {}
             uid = hit.get("id")
@@ -210,9 +210,13 @@ def collect(city_filter=None, column="Organizer Channel", fetched=None):
                 # Not a failure of this script: they have no account under the
                 # address the intake holds. Reported, never silently dropped.
                 unresolved.append((label, p["name"]))
+            elif uid in seen_uids:
+                continue          # same account via a second email on file
             elif uid in members:
+                seen_uids.add(uid)
                 present.append((p["name"], uid))
             else:
+                seen_uids.add(uid)
                 missing.append((p["name"], uid))
 
         known = {uid for _, uid in missing + present}
@@ -301,6 +305,25 @@ SCOPE_COLUMNS = {
 }
 
 
+def run_scope(scope, city_filter=None):
+    """Collect and report every column `scope` targets, off ONE fetch.
+
+    Returns (all_rows, total) — `all_rows` concatenates every column's rows
+    (for `apply()`), `total` sums every column's missing-invite count (the
+    write gate below asks "how many people", not "how many columns").
+    Factored out of main() so a --scope both regression (e.g. `total =`
+    silently replacing `total +=`) fails a unit test, not a live run.
+    """
+    fetched = fetch(city_filter)
+    all_rows, total = [], 0
+    for column, label in SCOPE_COLUMNS[scope]:
+        rows, unresolved, no_channel = collect(city_filter, column=column, fetched=fetched)
+        total += report(rows, unresolved, no_channel, label=label)
+        all_rows += rows
+        print()
+    return all_rows, total
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--write", action="store_true")
@@ -316,17 +339,7 @@ def main():
     a = ap.parse_args()
     set_redaction(a.redact)
 
-    # One fetch for the whole run — `--scope both` collects two columns from
-    # the SAME chapters/channels/intake, not two independent sweeps of Slack
-    # and the sheet.
-    fetched = fetch(a.city)
-
-    all_rows, total = [], 0
-    for column, label in SCOPE_COLUMNS[a.scope]:
-        rows, unresolved, no_channel = collect(a.city, column=column, fetched=fetched)
-        total += report(rows, unresolved, no_channel, label=label)
-        all_rows += rows
-        print()
+    all_rows, total = run_scope(a.scope, a.city)
 
     if not a.write:
         print("Report only. Nobody was invited to anything.")

--- a/skills/aaif-sync-chapters/scripts/post_country_directory.py
+++ b/skills/aaif-sync-chapters/scripts/post_country_directory.py
@@ -38,12 +38,24 @@ A directory-style post authored by someone else (not this token) is reported
 and never touched — same reasoning as `invite_organizers.py` leaving people
 the intake doesn't list alone.
 
+Detection reads the word "chapter" — a channel where a human wrote the post
+in another language (Spanish, Portuguese, German — several of these rooms are
+named in that language) could miss it and get a second, English post. Nothing
+today does, but this is a known gap, not a guarantee. `HISTORY_SCAN_CAP`
+bounds the other side of the same risk: if nothing directory-shaped turns up
+in the first 2000 messages, the channel is reported for a human to check by
+hand rather than assumed empty — defaulting to "create" on an unconfirmed
+absence is exactly the duplicate-post failure this design exists to avoid.
+
 ## Which channels are skipped, and why
 
-A Country Channel that IS the chapter's own public channel (Singapore,
-Luxembourg) or that has no separate city channel to point to at all
-(Wellington's Slack Channel is `none`) has nothing to direct anyone to — the
-country room already is the whole answer. These are never posted to.
+A Country Channel with no distinct, live city channel among its chapters has
+nothing to direct anyone to — the country room already is the whole answer.
+This covers a chapter whose Country Channel IS its own public channel
+(Singapore, Luxembourg) and one with no separate city channel at all
+(Wellington's Slack Channel is `none`) through the same check, not a
+hardcoded list of countries: naming specific countries here would stop being
+true the day one of them opens a real city room.
 
 ## Why this is gated harder than a sheet write
 
@@ -83,11 +95,6 @@ def _looks_like_directory_post(text):
     return bool(text) and "chapter" in text.lower() and _MENTION_RE.search(text)
 
 
-#: Country Channels that ARE the one room they'd otherwise point at, or that
-#: have no separate city channel to point to. Nothing to say here that the
-#: channel itself doesn't already say.
-SINGLE_ROOM_CHANNELS = {"singapore", "luxembourg", "new-zealand"}
-
 #: Country -> the label to use in a brand-new post when several countries
 #: share one channel. A channel with exactly one Country value uses that
 #: value verbatim.
@@ -95,14 +102,45 @@ MULTI_COUNTRY_LABELS = {
     frozenset({"Denmark", "Finland", "Norway", "Sweden"}): "the Nordic countries",
 }
 
+#: The four things a row can need, and the only four values `action` ever
+#: holds — compared with `==`/`in` at several sites below, so a typo in any
+#: one of those comparisons must fail an import, not silently miscount a
+#: bucket forever.
+ACTION_CREATE = "create"
+ACTION_ADD_ON = "add-on"
+ACTION_UP_TO_DATE = "up to date"
+ACTION_HUMAN_AUTHORED = "human-authored — not touched"
 
-def new_post_text(label, mentions):
-    return ("%s This country has %d chapter%s — join your city's channel: %s\n"
+MARKER = ":wave: Looking for your local AAIF community?"
+
+#: How much history a channel with NO conclusive finding yet gets scanned
+#: before this run gives up rather than guesses. Matches the order of
+#: magnitude of `history_activity()`'s own default (5000) in
+#: lib/aaif_events/slack.py — a directory post lives near the top of a
+#: channel's history by construction (it is posted once, early), so this is
+#: a generous bound, not a tight one.
+HISTORY_SCAN_CAP = 2000
+
+
+def new_post_text(label, mentions, is_multi):
+    """The brand-new-channel post. `is_multi` picks the opening sentence.
+
+    A single-country channel never names the country (`#kenya`'s post already
+    says "Kenya" the moment someone sees the channel) — matching the wording
+    of every existing single-country post in the workspace. A channel shared
+    by several countries (the Nordics today) has no such implicit name, so it
+    opens with `label` instead ("The Nordic countries have N chapters").
+    """
+    opening = (("%s have %d chapter%s" % (label, len(mentions),
+                                          "" if len(mentions) == 1 else "s"))
+               if is_multi else
+               ("This country has %d chapter%s"
+                % (len(mentions), "" if len(mentions) == 1 else "s")))
+    return ("%s %s — join your city's channel: %s\n"
             "Upcoming events for every chapter live at "
             "https://aaif.io/events?tab=community. No chapter near you yet? "
             "Ask here — we love helping new ones start."
-            % (":wave: Looking for your local AAIF community?", len(mentions),
-               "" if len(mentions) == 1 else "s", ", ".join(mentions)))
+            % (MARKER, opening, ", ".join(mentions)))
 
 
 def addendum_text(mentions):
@@ -114,8 +152,8 @@ def collect():
     """Return (rows, skipped) — what each live country channel needs.
 
     rows = [{channel, channel_id, mentions (ALL desired), missing (not yet
-             mentioned anywhere), action, post_text}], action in
-    ("create", "add-on", "up to date", "human-authored — not touched").
+             mentioned anywhere), action, post_text}], action one of the
+    ACTION_* constants above.
     `skipped` = [(channel, why)] for Country Channels never posted to at all.
     """
     token = os.environ.get("AAIF_SLACK_WRITE_TOKEN", "").strip()
@@ -124,6 +162,11 @@ def collect():
               "Slack CLI credential, which on this estate is expired. If auth "
               "fails, export AAIF_SLACK_WRITE_TOKEN.", file=sys.stderr)
     api = slackmod.Slack(token=token or None)
+    # Before any collection, same as every other script here that reads
+    # history — a missing scope must fail in the first second, not partway
+    # through a sweep across 30+ country channels.
+    api.require_scopes("channels:read", "groups:read",
+                       "channels:history", "groups:history")
     self_id = api.ok("auth.test").get("user_id")
 
     _, _, chapters = read_grid()
@@ -144,10 +187,6 @@ def collect():
         chan = chans.get(name)
         if not chan:
             skipped.append((name, "not visible on Slack"))
-            continue
-        if name in SINGLE_ROOM_CHANNELS:
-            skipped.append((name, "single-room variant — nothing separate to "
-                                  "point members at"))
             continue
 
         # Ordered by city name, de-duplicated by channel id (San Francisco AND
@@ -170,17 +209,20 @@ def collect():
         # change the outcome ("up to date"), so stop paging through history —
         # the common case on every run after the first, and the one that
         # would otherwise re-scan a busy channel's full history for nothing.
-        mentioned, found_any = set(), False
+        mentioned, found_any, scanned, hit_cap = set(), False, 0, False
         for m in api.paged("conversations.history", "messages", channel=chan["id"],
                            limit=200):
+            scanned += 1
             text = m.get("text") or ""
-            if not _looks_like_directory_post(text):
-                continue
-            found_any = True
-            if m.get("user") == self_id:
-                mentioned |= set(_MENTION_RE.findall(text))
-                if set(wanted_ids) <= mentioned:
-                    break
+            if _looks_like_directory_post(text):
+                found_any = True
+                if m.get("user") == self_id:
+                    mentioned |= set(_MENTION_RE.findall(text))
+                    if set(wanted_ids) <= mentioned:
+                        break
+            if scanned >= HISTORY_SCAN_CAP:
+                hit_cap = True
+                break
 
         # wanted_ids preserves city-name order (built from sorted(g["cities"])
         # above) — iterate it directly, not sorted(), or the message would
@@ -189,20 +231,31 @@ def collect():
         all_mentions = ["<#%s>" % cid for cid in wanted_ids]
         missing_mentions = ["<#%s>" % cid for cid in missing_ids]
 
+        if not found_any and hit_cap:
+            # The one case a cap can't resolve safely: nothing directory-shaped
+            # turned up in the first HISTORY_SCAN_CAP messages, but there might
+            # still be one further back that this run never reached. Defaulting
+            # to "create" here is exactly the failure mode the additive-only
+            # design exists to prevent — a duplicate greeting in a public room.
+            skipped.append((name, "scanned %d messages with no directory post "
+                                  "found and no more messages read — can't "
+                                  "confirm one doesn't exist further back; "
+                                  "check by hand" % scanned))
+            continue
         if not found_any:
-            label = MULTI_COUNTRY_LABELS.get(frozenset(g["countries"]))
-            if not label:
-                label = (sorted(g["countries"])[0] if len(g["countries"]) == 1
-                         else " / ".join(sorted(g["countries"])))
-            action, text = "create", new_post_text(label, all_mentions)
+            is_multi = len(g["countries"]) > 1
+            label = (MULTI_COUNTRY_LABELS.get(frozenset(g["countries"]))
+                     or " / ".join(sorted(g["countries"]))) if is_multi else None
+            action = ACTION_CREATE
+            text = new_post_text(label, all_mentions, is_multi)
         elif not mentioned:
             # found_any is True but no self-authored mention landed: every
             # directory-shaped match belongs to someone else.
-            action, text = "human-authored — not touched", None
+            action, text = ACTION_HUMAN_AUTHORED, None
         elif not missing_ids:
-            action, text = "up to date", None
+            action, text = ACTION_UP_TO_DATE, None
         else:
-            action, text = "add-on", addendum_text(missing_mentions)
+            action, text = ACTION_ADD_ON, addendum_text(missing_mentions)
 
         rows.append({"channel": name, "channel_id": chan["id"],
                      "mentions": all_mentions, "missing": missing_mentions,
@@ -211,21 +264,26 @@ def collect():
 
 
 def report(rows, skipped):
-    todo = [r for r in rows if r["action"] in ("create", "add-on")]
+    todo = [r for r in rows if r["action"] in (ACTION_CREATE, ACTION_ADD_ON)]
     print("Country-channel directory posts — %d live channel(s)\n" % len(rows))
     for r in sorted(rows, key=lambda x: x["channel"]):
-        detail = " (%d missing)" % len(r["missing"]) if r["action"] == "add-on" else ""
+        detail = " (%d missing)" % len(r["missing"]) if r["action"] == ACTION_ADD_ON else ""
         print("  #%-20s %s%s" % (r["channel"], r["action"], detail))
+        # The approval gate below only means anything if the text it's
+        # gating is visible here — print exactly what --write would send.
+        if r["action"] in (ACTION_CREATE, ACTION_ADD_ON):
+            for line in r["post_text"].splitlines():
+                print("      %s" % line)
     if skipped:
         print("\nSkipped (%d):" % len(skipped))
         for name, why in sorted(skipped):
             print("  #%-20s %s" % (name, why))
     print("\nTo create: %d, to add-on: %d, already correct: %d, "
           "human-authored (not touched): %d"
-          % (sum(1 for r in rows if r["action"] == "create"),
-             sum(1 for r in rows if r["action"] == "add-on"),
-             sum(1 for r in rows if r["action"] == "up to date"),
-             sum(1 for r in rows if r["action"] == "human-authored — not touched")))
+          % (sum(1 for r in rows if r["action"] == ACTION_CREATE),
+             sum(1 for r in rows if r["action"] == ACTION_ADD_ON),
+             sum(1 for r in rows if r["action"] == ACTION_UP_TO_DATE),
+             sum(1 for r in rows if r["action"] == ACTION_HUMAN_AUTHORED)))
     return todo
 
 
@@ -270,7 +328,7 @@ def main():
                  "to %d channel(s), visible to everyone in them." % len(todo))
 
     token = write_token()
-    assert "chat.postMessage" in WRITE_METHODS
+    assert "chat.postMessage" in WRITE_METHODS and "conversations.join" in WRITE_METHODS
 
     done, failed = apply(todo, token)
     print("\nPosted %d, %d failed." % (done, len(failed)))

--- a/skills/aaif-sync-chapters/scripts/post_country_directory.py
+++ b/skills/aaif-sync-chapters/scripts/post_country_directory.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Make sure every chapter has a channel mention in its country channel.
+
+A country channel that serves more than one room (or serves a room different
+from itself) carries a standing post pointing members at their own city's
+channel. As chapters are added to a country — a new sheet row, a Country
+Channel that used to be blank — the post falls out of date unless something
+adds the new mentions.
+
+Answers two questions, and the first is useful on its own:
+
+1. **What would change?** For every live Country Channel, which chapter
+   channels its existing directory-style post does not yet mention, or
+   whether it has never had one at all. Read-only, and the report is the
+   default.
+2. **Add what's missing.** Behind `--write --i-have-approval`, and nothing
+   else.
+
+## Additive only — never edits or replaces an existing post
+
+The workspace already carries at least three different hand-written phrasings
+of this post (a plain "This country has N chapters" template, a "The Nordics
+have N chapters" variant, and a "we've opened a dedicated city channel for
+the X chapter" announcement for a room that just grew its first second city).
+Picking one canonical wording and overwriting the other two would replace
+text a human chose on purpose with no functional gain — the mentions inside
+it are what matters, not the sentence around them.
+
+So this script never calls `chat.update`. It only:
+
+- **Posts a brand-new message** in a country channel that has never had any
+  directory-style post at all (found: none). This uses the standard wording.
+- **Posts a short add-on message** in a channel whose existing post (any of
+  the phrasings above, self-authored) is missing one or more chapters that
+  now exist. The original post is left exactly as it was.
+
+A directory-style post authored by someone else (not this token) is reported
+and never touched — same reasoning as `invite_organizers.py` leaving people
+the intake doesn't list alone.
+
+## Which channels are skipped, and why
+
+A Country Channel that IS the chapter's own public channel (Singapore,
+Luxembourg) or that has no separate city channel to point to at all
+(Wellington's Slack Channel is `none`) has nothing to direct anyone to — the
+country room already is the whole answer. These are never posted to.
+
+## Why this is gated harder than a sheet write
+
+A channel post is a notification to everyone in it, same reasoning as
+`invite_organizers.py`. `--write` alone is not enough; `--i-have-approval`
+must be passed too, and the report must have been read.
+
+Usage:
+    python3 post_country_directory.py                  # what would change
+    python3 post_country_directory.py --write --i-have-approval
+"""
+
+import argparse
+import os
+import re
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "aaif-audit-slack", "scripts"))
+sys.path.insert(0, os.path.join(_HERE, "..", "..", "..", "lib"))
+
+from sync_chapters import NO_RESOURCE  # noqa: E402
+from sync_resources import read_grid  # noqa: E402
+from provision_channels import call_write, write_token, WRITE_METHODS  # noqa: E402
+
+from aaif_events import slack as slackmod  # noqa: E402
+
+#: A directory-style post is recognised by mentioning at least one channel
+#: (`<#C...>`) and using the word "chapter" — loose on purpose: the workspace
+#: already has three different phrasings (see the module docstring) and a
+#: tighter match would treat two of them as "never posted" and duplicate them.
+_MENTION_RE = re.compile(r"<#(C[A-Z0-9]+)")
+
+
+def _looks_like_directory_post(text):
+    return bool(text) and "chapter" in text.lower() and _MENTION_RE.search(text)
+
+
+#: Country Channels that ARE the one room they'd otherwise point at, or that
+#: have no separate city channel to point to. Nothing to say here that the
+#: channel itself doesn't already say.
+SINGLE_ROOM_CHANNELS = {"singapore", "luxembourg", "new-zealand"}
+
+#: Country -> the label to use in a brand-new post when several countries
+#: share one channel. A channel with exactly one Country value uses that
+#: value verbatim.
+MULTI_COUNTRY_LABELS = {
+    frozenset({"Denmark", "Finland", "Norway", "Sweden"}): "the Nordic countries",
+}
+
+
+def new_post_text(label, mentions):
+    return ("%s This country has %d chapter%s — join your city's channel: %s\n"
+            "Upcoming events for every chapter live at "
+            "https://aaif.io/events?tab=community. No chapter near you yet? "
+            "Ask here — we love helping new ones start."
+            % (":wave: Looking for your local AAIF community?", len(mentions),
+               "" if len(mentions) == 1 else "s", ", ".join(mentions)))
+
+
+def addendum_text(mentions):
+    return (":wave: New chapter channel%s for this country — join yours: %s"
+            % ("s" if len(mentions) > 1 else "", ", ".join(mentions)))
+
+
+def collect():
+    """Return (rows, skipped) — what each live country channel needs.
+
+    rows = [{channel, channel_id, mentions (ALL desired), missing (not yet
+             mentioned anywhere), action, post_text}], action in
+    ("create", "add-on", "up to date", "human-authored — not touched").
+    `skipped` = [(channel, why)] for Country Channels never posted to at all.
+    """
+    token = os.environ.get("AAIF_SLACK_WRITE_TOKEN", "").strip()
+    if not token:
+        print("note: AAIF_SLACK_WRITE_TOKEN is not set — falling back to the "
+              "Slack CLI credential, which on this estate is expired. If auth "
+              "fails, export AAIF_SLACK_WRITE_TOKEN.", file=sys.stderr)
+    api = slackmod.Slack(token=token or None)
+    self_id = api.ok("auth.test").get("user_id")
+
+    _, _, chapters = read_grid()
+    chans = {c["name"]: c for c in slackmod.channels(api) if not c["is_archived"]}
+
+    groups = {}
+    for ch in chapters:
+        name = ch["current"]["Country Channel"]
+        if not name or name == NO_RESOURCE:
+            continue
+        groups.setdefault(name, {"cities": [], "countries": set()})
+        groups[name]["cities"].append((ch["city"], ch["current"]["Slack Channel"]))
+        if ch["country"]:
+            groups[name]["countries"].add(ch["country"])
+
+    rows, skipped = [], []
+    for name, g in sorted(groups.items()):
+        chan = chans.get(name)
+        if not chan:
+            skipped.append((name, "not visible on Slack"))
+            continue
+        if name in SINGLE_ROOM_CHANNELS:
+            skipped.append((name, "single-room variant — nothing separate to "
+                                  "point members at"))
+            continue
+
+        # Ordered by city name, de-duplicated by channel id (San Francisco AND
+        # Silicon Valley both point at #bay-area — one mention, not two).
+        wanted_ids = {}
+        for city, slack_col in sorted(g["cities"]):
+            if not slack_col or slack_col == NO_RESOURCE or slack_col == name:
+                continue                  # no distinct city room to link
+            c = chans.get(slack_col)
+            if c and c["id"] not in wanted_ids:
+                wanted_ids[c["id"]] = city
+        if not wanted_ids:
+            skipped.append((name, "no distinct, live city channel to link"))
+            continue
+
+        # Scan every self-authored, directory-shaped post (not just the
+        # first) and union their mentions — the same channel is not
+        # re-announced just because an earlier post already named it. Once
+        # that union already covers every wanted city, no older message can
+        # change the outcome ("up to date"), so stop paging through history —
+        # the common case on every run after the first, and the one that
+        # would otherwise re-scan a busy channel's full history for nothing.
+        mentioned, found_any = set(), False
+        for m in api.paged("conversations.history", "messages", channel=chan["id"],
+                           limit=200):
+            text = m.get("text") or ""
+            if not _looks_like_directory_post(text):
+                continue
+            found_any = True
+            if m.get("user") == self_id:
+                mentioned |= set(_MENTION_RE.findall(text))
+                if set(wanted_ids) <= mentioned:
+                    break
+
+        # wanted_ids preserves city-name order (built from sorted(g["cities"])
+        # above) — iterate it directly, not sorted(), or the message would
+        # list channels by raw id instead of alphabetically by city.
+        missing_ids = [cid for cid in wanted_ids if cid not in mentioned]
+        all_mentions = ["<#%s>" % cid for cid in wanted_ids]
+        missing_mentions = ["<#%s>" % cid for cid in missing_ids]
+
+        if not found_any:
+            label = MULTI_COUNTRY_LABELS.get(frozenset(g["countries"]))
+            if not label:
+                label = (sorted(g["countries"])[0] if len(g["countries"]) == 1
+                         else " / ".join(sorted(g["countries"])))
+            action, text = "create", new_post_text(label, all_mentions)
+        elif not mentioned:
+            # found_any is True but no self-authored mention landed: every
+            # directory-shaped match belongs to someone else.
+            action, text = "human-authored — not touched", None
+        elif not missing_ids:
+            action, text = "up to date", None
+        else:
+            action, text = "add-on", addendum_text(missing_mentions)
+
+        rows.append({"channel": name, "channel_id": chan["id"],
+                     "mentions": all_mentions, "missing": missing_mentions,
+                     "action": action, "post_text": text})
+    return rows, skipped
+
+
+def report(rows, skipped):
+    todo = [r for r in rows if r["action"] in ("create", "add-on")]
+    print("Country-channel directory posts — %d live channel(s)\n" % len(rows))
+    for r in sorted(rows, key=lambda x: x["channel"]):
+        detail = " (%d missing)" % len(r["missing"]) if r["action"] == "add-on" else ""
+        print("  #%-20s %s%s" % (r["channel"], r["action"], detail))
+    if skipped:
+        print("\nSkipped (%d):" % len(skipped))
+        for name, why in sorted(skipped):
+            print("  #%-20s %s" % (name, why))
+    print("\nTo create: %d, to add-on: %d, already correct: %d, "
+          "human-authored (not touched): %d"
+          % (sum(1 for r in rows if r["action"] == "create"),
+             sum(1 for r in rows if r["action"] == "add-on"),
+             sum(1 for r in rows if r["action"] == "up to date"),
+             sum(1 for r in rows if r["action"] == "human-authored — not touched")))
+    return todo
+
+
+def apply(todo, token):
+    """Join (if needed), then post, one call per channel."""
+    done, failed = 0, []
+    for r in sorted(todo, key=lambda x: x["channel"]):
+        j = call_write(token, "conversations.join", channel=r["channel_id"])
+        if not j.get("ok") and j.get("error") not in (
+                "already_in_channel", "method_not_supported_for_channel_type"):
+            failed.append("%s: join failed: %s" % (r["channel"], j.get("error")))
+            continue
+        res = call_write(token, "chat.postMessage", channel=r["channel_id"],
+                         text=r["post_text"])
+        if res.get("ok"):
+            done += 1
+            print("  #%-20s %s" % (r["channel"], r["action"]))
+        else:
+            failed.append("%s: %s" % (r["channel"], res.get("error", "unknown")))
+    return done, failed
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--write", action="store_true")
+    ap.add_argument("--i-have-approval", action="store_true",
+                    help="required alongside --write; a channel post is a "
+                         "notification to everyone in it and cannot be unsent")
+    a = ap.parse_args()
+
+    rows, skipped = collect()
+    todo = report(rows, skipped)
+
+    if not a.write:
+        print("\nReport only. Nothing was posted.")
+        return 0
+    if not todo:
+        print("\nNothing to do.")
+        return 0
+    if not a.i_have_approval:
+        sys.exit("REFUSING: --write needs --i-have-approval too. This posts "
+                 "to %d channel(s), visible to everyone in them." % len(todo))
+
+    token = write_token()
+    assert "chat.postMessage" in WRITE_METHODS
+
+    done, failed = apply(todo, token)
+    print("\nPosted %d, %d failed." % (done, len(failed)))
+    for f in failed:
+        print("  %s" % f)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -108,8 +108,10 @@ API = "https://slack.com/api/"
 #:   room helps no one), never to speak anywhere else.
 #:
 #: `conversations.join` is here because a user token cannot post in a public
-#: channel it has not joined; it is only ever called on a room about to be
-#: archived, so the membership is momentary by construction.
+#: channel it has not joined. Two call sites, both join immediately before
+#: posting: the deprecated-room sweep below (archived right after, so the
+#: membership is momentary) and post_country_directory.py (posts a standing
+#: directory message and stays joined — the room is staying live, not closing).
 WRITE_METHODS = frozenset({"conversations.create", "conversations.rename",
                            "conversations.invite", "conversations.kick",
                            "conversations.archive", "conversations.join",

--- a/skills/aaif-sync-chapters/scripts/sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/sync_resources.py
@@ -237,7 +237,32 @@ COUNTRY_CHANNELS = {
     "Finland": "nordics",
     "Norway": "nordics",
     "Sweden": "nordics",
+    # #korea (Seoul's room) predates this convention; fold("South Korea") would
+    # look for #southkorea and find nothing, reporting a channel-less country
+    # that has had a home the whole time.
+    "South Korea": "korea",
+    # Likewise #brasil — the community's own (Portuguese) spelling, not
+    # fold("Brazil")'s #brazil.
+    "Brazil": "brasil",
+    # fold() would produce the unwieldy #democratic-republic-of-the-congo.
+    # Kenya/Uganda/Nigeria/South Africa/Egypt each already have their own
+    # per-country room (not the pan-African #africa), so Kinshasa follows the
+    # same per-country pattern — user-decided 2026-08-31 — under a name short
+    # enough to type and unambiguous against the Republic of Congo
+    # (Congo-Brazzaville).
+    "Democratic Republic of the Congo": "dr-congo",
 }
+
+
+def country_channel_name(country, ao):
+    """The channel name a country's row should match: override, else fold().
+
+    One call site for the rule COUNTRY_CHANNELS exists to express — an
+    override wins over the plain ASCII fold — so propose_channels() (matching
+    an existing channel) and plan_channels() (naming one still to be created)
+    can't drift out of sync on it the way COUNTRY_CHANNELS itself once did.
+    """
+    return COUNTRY_CHANNELS.get(country) or ao.fold(country)
 
 #: Values that channel_map.json's unconfirmed `public` table filed in the wrong
 #: COLUMN — not the wrong name, the wrong kind of thing.
@@ -452,8 +477,12 @@ def propose_channels(chapters, chans, cfg):
         # #norway, #turkey. It deliberately cannot find #africa, #nordics-public
         # or #spanish-speaking: those serve several countries and no rule derives
         # them from a country name, so they stay whatever a human put there.
+        # COUNTRY_CHANNELS wins when the room's real name diverges from the
+        # ASCII fold of the country (#deutschland, #nordics, #korea, #brasil) —
+        # without it a blank cell for one of these countries falls straight to
+        # "missing_countries" even though the room has existed for years.
         if not ch["current"]["Country Channel"] and ch["country"]:
-            key = ao.fold(ch["country"])
+            key = country_channel_name(ch["country"], ao)
             c = live.get(key)
             if c and not c["is_private"]:
                 proposals.append({"row": ch["row"], "city": ch["city"],
@@ -512,7 +541,7 @@ def plan_channels(chapters, chans, ao):
                             "column": "Organizer Channel", "value": name,
                             "why": "exists" if name in live else "TO CREATE"})
         if not ch["current"]["Country Channel"] and ch["country"]:
-            name = COUNTRY_CHANNELS.get(ch["country"]) or ao.fold(ch["country"])
+            name = country_channel_name(ch["country"], ao)
             if name:
                 planned.append({"row": ch["row"], "city": ch["city"],
                                 "column": "Country Channel", "value": name,

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -469,6 +469,76 @@ check("collect() runs to completion against a 3-tuple read_intake()",
 check("the one roster member already present is not double-counted as missing",
       (_rows[0]["missing"], [n for n, _ in _rows[0]["present"]]), ([], ["Ada"]))
 
+
+# --- fetch()/collect(fetched=...): a second column reuses the first fetch,
+# it does not hit the sheet or Slack's channel list a second time. This is
+# what makes `--scope both` one round trip, not two.
+_FETCH_CALLS = []
+chapters = [{"city": "Boston",
+            "current": {"Organizer Channel": "boston-organizers",
+                       "Country Channel": "united-states"}}]
+chans = [{"name": "boston-organizers", "id": "C1", "is_private": True,
+         "is_archived": False},
+        {"name": "united-states", "id": "C2", "is_private": False,
+         "is_archived": False}]
+
+
+def _counting_read_grid(c):
+    _FETCH_CALLS.append("read_grid")
+    return None, None, chapters
+
+
+def _counting_channels(api):
+    _FETCH_CALLS.append("channels")
+    return chans
+
+
+with _mock.patch.object(inv, "read_grid", _counting_read_grid), \
+     _mock.patch.object(inv.slackmod, "Slack", _FakeInviteApi), \
+     _mock.patch.object(inv.slackmod, "channels", _counting_channels), \
+     _mock.patch.object(inv.slackmod, "members", lambda api, cid: ["U1"]), \
+     _mock.patch.object(inv.slackmod, "lookup_emails",
+                        lambda api, emails: {"a@x.com": {"id": "U1"}}), \
+     _mock.patch.object(inv.ao, "read_intake", lambda: (_INTAKE, 0, {})):
+    _fetched = inv.fetch()
+    inv.collect(column="Organizer Channel", fetched=_fetched)
+    inv.collect(column="Country Channel", fetched=_fetched)
+
+check("fetch() hits the sheet and Slack exactly once for two collect() calls",
+      _FETCH_CALLS, ["read_grid", "channels"])
+
+
+# --- collect(column=...): a shared Country Channel merges chapters into ONE row
+_COUNTRY_INTAKE = [{"email": "a@x.com", "name": "Ada", "city": "Madrid"},
+                   {"email": "b@x.com", "name": "Bao", "city": "Barcelona"}]
+
+
+def _run_collect_country():
+    chapters = [
+        {"city": "Madrid", "current": {"Country Channel": "espana"}},
+        {"city": "Barcelona", "current": {"Country Channel": "espana"}},
+    ]
+    chans = [{"name": "espana", "id": "C1", "is_private": False,
+             "is_archived": False}]
+    with _mock.patch.object(inv, "read_grid", lambda c: (None, None, chapters)), \
+         _mock.patch.object(inv.slackmod, "Slack", _FakeInviteApi), \
+         _mock.patch.object(inv.slackmod, "channels", lambda api: chans), \
+         _mock.patch.object(inv.slackmod, "members", lambda api, cid: []), \
+         _mock.patch.object(inv.slackmod, "lookup_emails",
+                            lambda api, emails: {"a@x.com": {"id": "U1"},
+                                                 "b@x.com": {"id": "U2"}}), \
+         _mock.patch.object(inv.ao, "read_intake", lambda: (_COUNTRY_INTAKE, 0, {})):
+        return inv.collect(column="Country Channel")
+
+
+_crows, _cunresolved, _cno_channel = _run_collect_country()
+check("two chapters sharing one Country Channel produce ONE row, not two",
+      len(_crows), 1)
+check("the row's city label lists both contributing chapters",
+      _crows[0]["city"], "Barcelona, Madrid")
+check("the roster is the union across both chapters, both missing",
+      sorted(n for n, _ in _crows[0]["missing"]), ["Ada", "Bao"])
+
 if FAILS:
     print("\nFAIL (%d)" % len(FAILS))
     for f in FAILS:

--- a/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
+++ b/skills/aaif-sync-chapters/scripts/test_invite_organizers.py
@@ -539,6 +539,71 @@ check("the row's city label lists both contributing chapters",
 check("the roster is the union across both chapters, both missing",
       sorted(n for n, _ in _crows[0]["missing"]), ["Ada", "Bao"])
 
+
+# --- the same person under TWO different emails (one per contributing
+# chapter) resolves to one account and must not be double-counted -------------
+_SAME_PERSON_INTAKE = [
+    {"email": "ada@old.example", "name": "Ada", "city": "Madrid"},
+    {"email": "ada@new.example", "name": "Ada", "city": "Barcelona"},
+]
+
+
+def _run_collect_same_person():
+    chapters = [
+        {"city": "Madrid", "current": {"Country Channel": "espana"}},
+        {"city": "Barcelona", "current": {"Country Channel": "espana"}},
+    ]
+    chans = [{"name": "espana", "id": "C1", "is_private": False,
+             "is_archived": False}]
+    with _mock.patch.object(inv, "read_grid", lambda c: (None, None, chapters)), \
+         _mock.patch.object(inv.slackmod, "Slack", _FakeInviteApi), \
+         _mock.patch.object(inv.slackmod, "channels", lambda api: chans), \
+         _mock.patch.object(inv.slackmod, "members", lambda api, cid: []), \
+         _mock.patch.object(inv.slackmod, "lookup_emails",
+                            lambda api, emails: {"ada@old.example": {"id": "U1"},
+                                                 "ada@new.example": {"id": "U1"}}), \
+         _mock.patch.object(inv.ao, "read_intake",
+                            lambda: (_SAME_PERSON_INTAKE, 0, {})):
+        return inv.collect(column="Country Channel")
+
+
+_srows, _, _ = _run_collect_same_person()
+check("one account under two emails is counted once, not twice",
+      _srows[0]["missing"], [("Ada", "U1")])
+
+
+# --- run_scope("both", ...): totals and rows accumulate across BOTH columns,
+# not just the last one — the exact copy-paste class this factoring guards
+# against (`total =` silently replacing `total +=`) -----------------------------
+_BOTH_INTAKE = [{"email": "a@x.com", "name": "Ada", "city": "Boston"},
+               {"email": "b@x.com", "name": "Bo", "city": "Boston"}]
+
+
+def _run_run_scope_both():
+    chapters = [{"city": "Boston",
+                "current": {"Organizer Channel": "boston-organizers",
+                           "Country Channel": "united-states"}}]
+    chans = [{"name": "boston-organizers", "id": "C1", "is_private": True,
+             "is_archived": False},
+            {"name": "united-states", "id": "C2", "is_private": False,
+             "is_archived": False}]
+    with _mock.patch.object(inv, "read_grid", lambda c: (None, None, chapters)), \
+         _mock.patch.object(inv.slackmod, "Slack", _FakeInviteApi), \
+         _mock.patch.object(inv.slackmod, "channels", lambda api: chans), \
+         _mock.patch.object(inv.slackmod, "members", lambda api, cid: []), \
+         _mock.patch.object(inv.slackmod, "lookup_emails",
+                            lambda api, emails: {"a@x.com": {"id": "U1"},
+                                                 "b@x.com": {"id": "U2"}}), \
+         _mock.patch.object(inv.ao, "read_intake", lambda: (_BOTH_INTAKE, 0, {})):
+        return inv.run_scope("both")
+
+
+_both_rows, _both_total = _run_run_scope_both()
+check("both columns' rows are concatenated, not overwritten",
+      len(_both_rows), 2)
+check("both columns' missing counts are summed, not overwritten",
+      _both_total, 4)
+
 if FAILS:
     print("\nFAIL (%d)" % len(FAILS))
     for f in FAILS:

--- a/skills/aaif-sync-chapters/scripts/test_post_country_directory.py
+++ b/skills/aaif-sync-chapters/scripts/test_post_country_directory.py
@@ -35,6 +35,9 @@ class _FakeApi:
     def __init__(self, history):
         self._history = history
 
+    def require_scopes(self, *a):
+        pass
+
     def ok(self, method, **kw):
         assert method == "auth.test"
         return {"user_id": SELF_ID}
@@ -130,15 +133,25 @@ check("a human's post is reported, not touched",
 check("no post_text is generated for it", rows[0]["post_text"], None)
 
 
-# --- single-room variants are skipped, not posted to ---------------------------
+# --- a single-room variant (Country Channel IS the chapter's own channel) is
+# skipped via the generic "no distinct channel" check, not a hardcoded list ---
 chapters = [{"city": "Singapore", "country": "Singapore",
             "current": {"Country Channel": "singapore", "Slack Channel": "singapore"}}]
 chans = [_chan("singapore", "CSG")]
 rows, skipped = _run(chapters, chans, {})
 check("a single-room channel produces no row", rows, [])
 check("it is reported as skipped, with a reason",
-      skipped, [("singapore", "single-room variant — nothing separate to "
-                              "point members at")])
+      skipped, [("singapore", "no distinct, live city channel to link")])
+
+# --- ...and it stops being skipped the moment the country gets its own city
+# room — this is exactly the drift a hardcoded skip list would have missed ----
+chapters = [{"city": "Singapore", "country": "Singapore",
+            "current": {"Country Channel": "singapore", "Slack Channel": "raffles"}}]
+chans = [_chan("singapore", "CSG"), _chan("raffles", "CRF")]
+rows, skipped = _run(chapters, chans, {})
+check("a real city channel is no longer treated as single-room",
+      (rows[0]["action"], rows[0]["mentions"]), ("create", ["<#CRF>"]))
+check("and nothing is skipped", skipped, [])
 
 
 # --- two cities sharing one channel are mentioned ONCE, not twice -------------
@@ -151,6 +164,126 @@ chapters = [
 chans = [_chan("united-states", "CUS"), _chan("bay-area", "CBA")]
 rows, _ = _run(chapters, chans, {})
 check("a shared channel is mentioned once", rows[0]["mentions"], ["<#CBA>"])
+
+
+# --- a brand-new post for a channel shared by several countries opens with
+# the multi-country label, not the single-country "This country has..." ------
+# All four Nordic countries: MULTI_COUNTRY_LABELS matches the exact set, not
+# a subset — a channel serving only two of the four falls through to the
+# generic "X / Y" join instead, which is exercised right after this.
+chapters = [
+    {"city": "Copenhagen", "country": "Denmark",
+     "current": {"Country Channel": "nordics", "Slack Channel": "copenhagen"}},
+    {"city": "Oslo", "country": "Norway",
+     "current": {"Country Channel": "nordics", "Slack Channel": "oslo"}},
+    {"city": "Helsinki", "country": "Finland",
+     "current": {"Country Channel": "nordics", "Slack Channel": "helsinki"}},
+    {"city": "Stockholm", "country": "Sweden",
+     "current": {"Country Channel": "nordics", "Slack Channel": "stockholm"}},
+]
+chans = [_chan("nordics", "CNO"), _chan("copenhagen", "CCO"), _chan("oslo", "COS"),
+        _chan("helsinki", "CHE"), _chan("stockholm", "CST")]
+rows, _ = _run(chapters, chans, {})
+check("a multi-country channel's post opens with the region label",
+      rows[0]["post_text"].startswith(
+          ":wave: Looking for your local AAIF community? "
+          "the Nordic countries have 4 chapters"),
+      True)
+
+# A channel shared by countries with no MULTI_COUNTRY_LABELS entry falls back
+# to joining the sorted country names.
+chapters = [
+    {"city": "Copenhagen", "country": "Denmark",
+     "current": {"Country Channel": "benelux", "Slack Channel": "copenhagen"}},
+    {"city": "Brussels", "country": "Belgium",
+     "current": {"Country Channel": "benelux", "Slack Channel": "brussels"}},
+]
+chans = [_chan("benelux", "CBX"), _chan("copenhagen", "CCO"), _chan("brussels", "CBR")]
+rows, _ = _run(chapters, chans, {})
+check("an unmapped multi-country group falls back to a plain country join",
+      rows[0]["post_text"].startswith(
+          ":wave: Looking for your local AAIF community? "
+          "Belgium / Denmark have 2 chapters"),
+      True)
+
+chapters = [{"city": "Nairobi", "country": "Kenya",
+            "current": {"Country Channel": "kenya", "Slack Channel": "nairobi"}}]
+chans = [_chan("kenya", "CKE"), _chan("nairobi", "CNR")]
+rows, _ = _run(chapters, chans, {})
+check("a single-country channel's post does not name the country",
+      rows[0]["post_text"].startswith(
+          ":wave: Looking for your local AAIF community? This country has 1 chapter"),
+      True)
+
+
+# --- hitting the scan cap with nothing found -> skipped, never "create" ------
+# A directory post that exists but sits past HISTORY_SCAN_CAP messages back
+# must never read as "none exists" — that would post a duplicate greeting.
+_capped_history = {"CIN": [{"user": "UOTHER", "text": "unrelated message"}]
+                   * pcd.HISTORY_SCAN_CAP}
+chapters = [{"city": "Berlin", "country": "Germany",
+            "current": {"Country Channel": "germany", "Slack Channel": "berlin"}}]
+chans = [_chan("germany", "CIN"), _chan("berlin", "CDE")]
+rows, skipped = _run(chapters, chans, _capped_history)
+check("a capped scan with nothing found produces no row", rows, [])
+check("it is reported as skipped, not silently treated as create",
+      any(name == "germany" for name, _ in skipped), True)
+
+
+# --- report() prints the exact text that --write would send, for the two
+# actions that actually post something -----------------------------------------
+import io as _io  # noqa: E402
+import contextlib as _ctx  # noqa: E402
+
+_create_row = {"channel": "kenya", "missing": [], "action": pcd.ACTION_CREATE,
+              "post_text": "the create text"}
+_addon_row = {"channel": "india", "missing": ["<#C1>"], "action": pcd.ACTION_ADD_ON,
+             "post_text": "the add-on text"}
+_uptodate_row = {"channel": "japan", "missing": [], "action": pcd.ACTION_UP_TO_DATE,
+                "post_text": None}
+_buf = _io.StringIO()
+with _ctx.redirect_stdout(_buf):
+    pcd.report([_create_row, _addon_row, _uptodate_row], [])
+_out = _buf.getvalue()
+check("the create row's post text is printed", "the create text" in _out, True)
+check("the add-on row's post text is printed", "the add-on text" in _out, True)
+check("an up-to-date row prints no post text (there is none)",
+      "None" in _out, False)
+
+
+# --- apply(): a real join failure stops before posting; a benign race doesn't -
+class _Recorder:
+    def __init__(self, results):
+        self.calls, self._results = [], results
+
+    def __call__(self, token, method, **params):
+        self.calls.append((method, params))
+        return self._results.get(method, {"ok": True})
+
+
+_todo = [{"channel": "kenya", "channel_id": "CKE", "action": pcd.ACTION_CREATE,
+         "post_text": "hello"}]
+
+_rec = _Recorder({"conversations.join": {"ok": False, "error": "not_authed"}})
+_orig = pcd.call_write
+pcd.call_write = _rec
+try:
+    done, failed = pcd.apply(_todo, "token")
+finally:
+    pcd.call_write = _orig
+check("a real join failure is reported and nothing is posted",
+      (done, failed, [c[0] for c in _rec.calls]),
+      (0, ["kenya: join failed: not_authed"], ["conversations.join"]))
+
+_rec = _Recorder({"conversations.join": {"ok": False, "error": "already_in_channel"}})
+pcd.call_write = _rec
+try:
+    done, failed = pcd.apply(_todo, "token")
+finally:
+    pcd.call_write = _orig
+check("a benign already-in-channel race still posts",
+      (done, failed, [c[0] for c in _rec.calls]),
+      (1, [], ["conversations.join", "chat.postMessage"]))
 
 
 if FAILS:

--- a/skills/aaif-sync-chapters/scripts/test_post_country_directory.py
+++ b/skills/aaif-sync-chapters/scripts/test_post_country_directory.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Self-tests for the country-directory-post logic. No network, no Slack, no gws.
+
+What is covered is what would be dangerous or misleading if wrong: that an
+existing post (any of the workspace's several real phrasings) is recognised
+and never edited or duplicated, that a human-authored post is left alone, and
+that the single-room and no-distinct-channel skips actually skip.
+"""
+
+import os
+import sys
+from unittest import mock as _mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "..", "aaif-audit-slack", "scripts"))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "..", "..", "lib"))
+
+import post_country_directory as pcd  # noqa: E402
+
+FAILS = []
+
+
+def check(label, got, want):
+    if got != want:
+        FAILS.append("%s\n     got:  %r\n     want: %r" % (label, got, want))
+    print("%s %s" % ("ok  " if got == want else "FAIL", label))
+
+
+SELF_ID = "USELF"
+
+
+class _FakeApi:
+    def __init__(self, history):
+        self._history = history
+
+    def ok(self, method, **kw):
+        assert method == "auth.test"
+        return {"user_id": SELF_ID}
+
+    def paged(self, method, key, **kw):
+        assert method == "conversations.history" and key == "messages"
+        return self._history.get(kw["channel"], [])
+
+
+def _run(chapters, chans, history):
+    with _mock.patch.object(pcd, "read_grid", lambda: (None, None, chapters)), \
+         _mock.patch.object(pcd.slackmod, "Slack", lambda token=None: _FakeApi(history)), \
+         _mock.patch.object(pcd.slackmod, "channels", lambda api: chans):
+        return pcd.collect()
+
+
+def _chan(name, cid):
+    return {"name": name, "id": cid, "is_private": False, "is_archived": False}
+
+
+# --- a channel with no directory post at all -> create, with every mention ----
+chapters = [{"city": "Nairobi", "country": "Kenya",
+            "current": {"Country Channel": "kenya", "Slack Channel": "nairobi"}}]
+chans = [_chan("kenya", "CKE"), _chan("nairobi", "CNR")]
+rows, skipped = _run(chapters, chans, {})
+check("no existing post -> create", (rows[0]["action"], rows[0]["mentions"]),
+      ("create", ["<#CNR>"]))
+check("nothing skipped", skipped, [])
+
+
+# --- a self-authored post already covers everyone -> up to date ---------------
+history = {"CIN": [{"user": SELF_ID, "text":
+                    ":wave: Looking for your local AAIF community? This country "
+                    "has 1 chapter — join your city's channel: <#CDE>"}]}
+chapters = [{"city": "Berlin", "country": "Germany",
+            "current": {"Country Channel": "germany", "Slack Channel": "berlin"}}]
+chans = [_chan("germany", "CIN"), _chan("berlin", "CDE")]
+rows, _ = _run(chapters, chans, history)
+check("fully-covered self post -> up to date", rows[0]["action"], "up to date")
+
+
+# --- once the union covers every wanted city, the history scan STOPS --------
+# `paged()` yields lazily here; a poisoned second page raises if pulled at
+# all, so this fails loudly if the early-break regresses into a full scan.
+def _poison_after(first):
+    yield first
+    raise AssertionError("scanned past a fully-covering self-authored post")
+
+
+class _LazyFakeApi(_FakeApi):
+    def paged(self, method, key, **kw):
+        assert method == "conversations.history" and key == "messages"
+        first = self._history[kw["channel"]][0]
+        return _poison_after(first)
+
+
+with _mock.patch.object(pcd, "read_grid", lambda: (None, None, chapters)), \
+     _mock.patch.object(pcd.slackmod, "Slack", lambda token=None: _LazyFakeApi(history)), \
+     _mock.patch.object(pcd.slackmod, "channels", lambda api: chans):
+    rows, _ = pcd.collect()
+check("a fully-covering post stops the scan before a later page is pulled",
+      rows[0]["action"], "up to date")
+
+
+# --- a self-authored post is missing a NEW chapter -> add-on, never an edit ---
+history = {"CIN": [{"user": SELF_ID, "text":
+                    ":wave: Looking for your local AAIF community? This country "
+                    "has 1 chapter — join your city's channel: <#CDE>"}]}
+chapters = [
+    {"city": "Berlin", "country": "Germany",
+     "current": {"Country Channel": "germany", "Slack Channel": "berlin"}},
+    {"city": "Stuttgart", "country": "Germany",
+     "current": {"Country Channel": "germany", "Slack Channel": "stuttgart"}},
+]
+chans = [_chan("germany", "CIN"), _chan("berlin", "CDE"), _chan("stuttgart", "CST")]
+rows, _ = _run(chapters, chans, history)
+check("a new chapter -> add-on, not a rewrite", rows[0]["action"], "add-on")
+check("the add-on names only the NEW mention", rows[0]["missing"], ["<#CST>"])
+check("post_text is a short addendum, not the original template",
+      rows[0]["post_text"].startswith(":wave: New chapter channel"), True)
+
+
+# --- a human-authored post is left alone no matter what ------------------------
+history = {"CIN": [{"user": "UHUMAN", "text":
+                    ":wave: Looking for your local AAIF community? This "
+                    "country has 1 chapter — join <#CDE>"}]}
+chapters = [{"city": "Berlin", "country": "Germany",
+            "current": {"Country Channel": "germany", "Slack Channel": "berlin"}}]
+chans = [_chan("germany", "CIN"), _chan("berlin", "CDE")]
+rows, _ = _run(chapters, chans, history)
+check("a human's post is reported, not touched",
+      rows[0]["action"], "human-authored — not touched")
+check("no post_text is generated for it", rows[0]["post_text"], None)
+
+
+# --- single-room variants are skipped, not posted to ---------------------------
+chapters = [{"city": "Singapore", "country": "Singapore",
+            "current": {"Country Channel": "singapore", "Slack Channel": "singapore"}}]
+chans = [_chan("singapore", "CSG")]
+rows, skipped = _run(chapters, chans, {})
+check("a single-room channel produces no row", rows, [])
+check("it is reported as skipped, with a reason",
+      skipped, [("singapore", "single-room variant — nothing separate to "
+                              "point members at")])
+
+
+# --- two cities sharing one channel are mentioned ONCE, not twice -------------
+chapters = [
+    {"city": "San Francisco", "country": "United States",
+     "current": {"Country Channel": "united-states", "Slack Channel": "bay-area"}},
+    {"city": "Silicon Valley", "country": "United States",
+     "current": {"Country Channel": "united-states", "Slack Channel": "bay-area"}},
+]
+chans = [_chan("united-states", "CUS"), _chan("bay-area", "CBA")]
+rows, _ = _run(chapters, chans, {})
+check("a shared channel is mentioned once", rows[0]["mentions"], ["<#CBA>"])
+
+
+if FAILS:
+    print("\nFAIL (%d)" % len(FAILS))
+    for f in FAILS:
+        print("  - %s" % f)
+    sys.exit(1)
+print("\npost_country_directory: all checks passed")

--- a/skills/aaif-sync-chapters/scripts/test_sync_resources.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_resources.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 "..", "..", "..", "lib"))
 
+import audit_organizers as ao  # noqa: E402
 import sync_chapters  # noqa: E402
 import sync_resources as sr  # noqa: E402
 
@@ -143,6 +144,23 @@ _p, _, _missing = sr.propose_channels([ch("Lagos", country="Nigeria", slack="lag
                                       [chan("lagos"), chan("africa")], CFG)
 check("#africa is not guessed from Nigeria", _p, [])
 check("and the country is reported as a gap", sorted(_missing), ["Nigeria"])
+
+# A blank Country Channel cell must consult COUNTRY_CHANNELS too, not only
+# fold(country) — otherwise a country whose room's real name diverges from its
+# ASCII fold (#deutschland, #korea, #brasil, ...) reports a gap that has had a
+# room the whole time.
+_p, _, _missing = sr.propose_channels(
+    [ch("Stuttgart", country="Germany", slack="stuttgart")],
+    [chan("stuttgart"), chan("deutschland")], CFG)
+check("COUNTRY_CHANNELS wins over fold(country) for a blank cell",
+      [(p["column"], p["value"]) for p in _p], [("Country Channel", "deutschland")])
+check("so it is not reported as a gap", _missing, {})
+
+# --- country_channel_name(): the ONE call site propose_channels() and
+# plan_channels() both go through, so they can't drift on the rule again -----
+check("an override wins", sr.country_channel_name("Germany", ao), "deutschland")
+check("no override falls back to fold()",
+      sr.country_channel_name("India", ao), "india")
 
 # --- folder cells -------------------------------------------------------------
 check("a folder URL round-trips to its id",


### PR DESCRIPTION
## Summary
Adds an opt-in `--scope country`/`both` to `invite_organizers.py` for public Country Channels (dedup'd across chapters that share one), a new `post_country_directory.py` that keeps each country channel's chapter-directory post complete without ever rewriting a human's wording, and fixes two related bugs found while building this: `summarize_audits.py`'s invite-gap count was inflated by people with no Slack account at all, and `sync_resources.py` never consulted the `COUNTRY_CHANNELS` override for a blank cell's first fill. A self-review pass (six agents plus a security check) found and fixed nine correctness/robustness issues in the new code — see Changeset 4.

## Changesets

### 1. `fix(audit-slack): separate no-account organizers from real invite gaps`
**Files:** `skills/aaif-audit-slack/scripts/summarize_audits.py` (+27 -4)
`org_findings()` folded "no Slack account under their intake email" and "has an account but wasn't invited" into one `gaps` bucket, inflating the reported invite backlog from 2 to 42 in a live run. Split into `gaps` (invitable) and `no_account` (an intake data-quality issue, not a channel-routing one), each its own ranked action item.

### 2. `fix(sync-chapters): consult COUNTRY_CHANNELS for blank Country Channel cells`
**Files:** `skills/aaif-sync-chapters/scripts/sync_resources.py` (+31 -2), `skills/aaif-sync-chapters/scripts/test_sync_resources.py` (+18)
`propose_channels()` only matched a blank `Country Channel` cell against `fold(country)`, so a country whose real room diverges from that fold (`#deutschland`, `#nordics`, `#korea`, `#brasil`) always reported as missing a channel even after the room existed. Extracted `country_channel_name()` as the one call site both `propose_channels()` and `plan_channels()` now share, and added South Korea/Brazil/DR Congo entries for the rooms created this session.

### 3. `feat(sync-chapters): add country-channel organizer invites and directory posts`
**Files:** `skills/aaif-sync-chapters/scripts/invite_organizers.py` (+126 -21), `skills/aaif-sync-chapters/scripts/post_country_directory.py` (new), `skills/aaif-sync-chapters/scripts/test_invite_organizers.py` (+70), `skills/aaif-sync-chapters/scripts/test_post_country_directory.py` (new), `skills/aaif-sync-chapters/SKILL.md` (+40 -2)
- `invite_organizers.py --scope {organizer,country,both}`: default unchanged (organizer channel only); `country` targets the public Country Channel, a deliberately narrower version of the 2026-08-25 public-city-channel override, with roster deduplicated by resolved account across every chapter sharing one channel. `collect()` is split into `fetch()` + a per-column pass so `--scope both` does one Slack/Sheets round trip, not two.
- `post_country_directory.py` (new): keeps each country channel's chapter-directory post complete as chapters are added. Additive only — it never calls `chat.update`, since the workspace already carries several different human phrasings of this post and overwriting them would replace text someone chose on purpose. A channel with no post gets a new one; an existing self-authored post missing a chapter gets a short add-on naming only what's new; a post authored by someone else is reported and left alone.

### 4. `fix: address self-review findings`
**Files:** same five scripts plus `skills/aaif-sync-chapters/scripts/provision_channels.py` and the new `skills/aaif-audit-slack/scripts/test_summarize_audits.py`
Six review agents (code quality, silent failures, test coverage, comments, type design) plus a security pass ran against the full diff. Nine Important and four Suggestion findings, all fixed:
- `post_country_directory.py` now checks Slack scopes before scanning history, caps how much history it scans before giving up rather than guessing "create" (which risked a duplicate public post), and its `report()` prints the exact text a create/add-on will send — the approval gate was previously blind to what it was approving.
- `new_post_text()`'s `label` argument was computed but never used, so a channel shared by several countries would have silently gotten the wrong wording the first time one was created from scratch — fixed.
- `summarize_audits.py`'s new `no_account` bucket was gated on a chapter already having an organizers channel, silently dropping exactly the newest chapters; decoupled, and it now has its own test file (previously zero coverage).
- `invite_organizers.py` now dedups a shared country-channel roster by the resolved Slack account, not the raw intake email, so one person under two addresses on file isn't double-counted.
- A stale comment in `provision_channels.py`, the bare `action` string in `post_country_directory.py`, and the untested `--scope both` accumulation were all fixed with hoisted constants, a factored `run_scope()` helper, and new tests.

Full findings and fixes are in the PR's review comments.

## Test plan
- [x] `PYTHONPATH=lib python -m pytest lib/aaif_events/tests -q` — 386 passed, 1 skipped
- [x] All 16 skill test scripts under `aaif-sync-chapters`/`aaif-audit-slack` pass, including 3 new files
- [x] `pre-commit run --all-files`, `check_no_secret_args.py`, `check_workflows.py`, `extract_design_tokens.py --check` — all pass
- [x] Live dry-runs against the real workspace, before and after the self-review fixes: `invite_organizers.py --scope country` (75→81 invited, 0 failures), `post_country_directory.py` (10 posts/add-ons, then repeated clean idempotent re-runs — 34/34 "up to date" with the corrected skip reasons)
- [x] The `--scope country` policy override (public Country Channel membership) was confirmed with the estate owner before this PR was opened

_Generated using hero-skills._
