### PR TITLE
feat(badges): add aaif-sync-badges skill for chapter organizer badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ talk to Slack or Luma.
 | `aaif-event-status` | Report overdue / due-soon event tasks by owner, plus read-only Luma registration stats | Google Drive, Luma |
 | `aaif-sync-chapters` | Push intake decisions to the Chapters List, About docs, chapter CRMs, per-chapter Drive access and the resource map (report/propose by default) | Google Sheets/Drive/Docs, Slack |
 | `aaif-audit-slack` | Audit the community Slack workspace — chapter/organizer channel coverage and member/channel health — as a self-contained HTML report | Slack, Google Sheets |
+| `aaif-community-pulse` | Draft the periodic "AAIF Community Organizer Update" Slack post from recent chapter events, community news, and the Luma calendar | Slack, Google Drive, Luma |
+| `aaif-sync-badges` | Generate and sync chapter organizer badges (SVG + PNG) into the chapter-badges Drive folder | Google Drive |
 
 > **Heads up — these ship with AAIF's own IDs.** The ops skills reference AAIF's
 > Google resources (the Chapters Drive, the Intake Ops spreadsheet ID, Luma slug

--- a/skills/aaif-sync-badges/SKILL.md
+++ b/skills/aaif-sync-badges/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: aaif-sync-badges
+description: Sync AAIF chapter organizer badges (SVG + PNG) into the chapter-badges Google Drive folder — generate missing badges for chapters that don't have them yet, and optionally regenerate all of them after a design change. Use when asked to add/sync/update/regenerate chapter organizer badges.
+argument-hint: '[--chapter <City Name>] [--regenerate] [--write]'
+---
+
+# Sync AAIF Chapter Badges
+
+> **Tooling rule — `gws` + Python only.** Every read, edit, and write of a Drive
+> file goes through the `gws` CLI, driven from Python. **Prefer native Google
+> formats**: edit `application/vnd.google-apps.*` files with the Docs/Sheets/
+> Slides API. Drop to byte-level OOXML surgery on the `.docx`/`.pptx`/`.xlsx`
+> zip parts (embedded fonts and untouched parts survive) only when the file
+> genuinely is a stored Office file. **Never use LibreOffice / `soffice`** — not to edit, not to convert,
+> and not to render a "just checking it locally" preview: it substitutes local
+> system fonts for the brand fonts and drops OOXML it doesn't understand, so its
+> output and its renders both misrepresent the real file. Same for `unoconv` and
+> any desktop office suite. To *see* a file, render it through the API instead —
+> a slide via `aaif_events.slides_export.render_slide_png`, a doc via
+> `gws drive files copy` to a Google Doc → `gws drive files export` to PDF →
+> trash the copy. Never round-trip a native Doc through `.docx` — it strips
+> native features like Tabs.
+
+Keeps the **chapter-badges** Drive folder (id `1ViKjLZh-4KrMBVihOGQyAL2SVsXcI3B9`)
+in sync with the **Chapters** Drive folder (id `1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx`,
+same one `aaif-create-chapter` clones from). Each chapter gets a subfolder named
+by its **slug** (`make_badges.slugify` — e.g. "Mexico City" → `mexico_city`,
+"Delhi NCR" → `delhi_ncr`), holding 4 files:
+
+```
+organizer_badge_<slug>_colour.svg
+organizer_badge_<slug>_white.svg
+organizer_badge_<slug>_colour_1000.png
+organizer_badge_<slug>_white_1000.png
+```
+
+Badges are generated locally by `scripts/make_badges.py` (a ring-and-arc AAIF
+organizer badge, city name on the top arc, "AGENTIC AI FOUNDATION" on the
+bottom arc, "ORGANIZER" pill) and rendered to PNG via `cairosvg`.
+
+Prereqs: the `gws` CLI must be installed and authenticated (see the user's
+`gws-cli-access` memory), and `cairosvg` must be importable
+(`python3 -m pip install cairosvg`, or run inside a venv that has it — the
+engine imports it lazily, only when actually generating a PNG, so a plan-only
+run needs neither Drive write access nor `cairosvg`).
+
+## Usage (engine: `scripts/sync_badges.py`)
+
+```bash
+# Plan (default) — nothing is created/uploaded, just reported:
+python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py
+
+# Apply — create missing chapter subfolders and upload missing files:
+python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --write
+
+# Regenerate every file (after a design change to make_badges.py) and
+# overwrite what's already there:
+python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --write --regenerate
+
+# One chapter only (Drive chapter-folder name, case-insensitive substring):
+python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --chapter "Mexico City" --write
+```
+
+## What it does and doesn't touch
+
+- **Source of truth for the chapter list** is the live "Chapters" Drive
+  folder, not a hardcoded list — a chapter created by `aaif-create-chapter`
+  shows up here on the next run with no code change. `TemplateCity` (the
+  clone source, not a real chapter) is excluded.
+- **Additive only.** A chapter subfolder or file already present is left
+  alone unless `--regenerate` is passed — badges are never deleted, and a
+  file that already exists is *updated in place* (same Drive file id), never
+  duplicated.
+- **Badge folders with no matching chapter** (a chapter renamed or retired in
+  Drive after its badge folder was created) are reported as orphans and never
+  touched — deleting or renaming them is a manual call.
+- **Non-folder items** directly under the chapter-badges parent (stray files
+  like a `.DS_Store`) are reported and ignored.
+- A collision — two chapter folder names slugifying to the same value — aborts
+  the whole run rather than silently dropping one of them; rename one of the
+  chapters in Drive first.
+
+## Procedure
+
+1. **Plan first** (the default) to see what's missing:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py
+   ```
+   Review the `+ create folder` / `upload` / `overwrite` lines, and any
+   reported orphans, before writing anything.
+2. **Apply** with `--write` once the plan looks right.
+3. New badges land as `image/svg+xml` and `image/png` files inside the
+   chapter's slug subfolder; re-running afterward reports "Up to date".
+
+## Notes
+
+- The generator (`make_badges.py`) is a verbatim copy of the AAIF badge
+  script — kept self-contained here rather than imported from `lib`, per this
+  repo's usual skill-script convention, so this skill still runs standalone.
+- Badges are built into a private `tempfile.mkdtemp()` directory that is
+  deleted at the end of the run — nothing lands in the repo working tree, so
+  there's no `.gitignore` entry to add.
+- To change the badge design (colours, layout, text), edit
+  `scripts/make_badges.py` directly, then run `--write --regenerate` to push
+  the new design to every chapter.

--- a/skills/aaif-sync-badges/SKILL.md
+++ b/skills/aaif-sync-badges/SKILL.md
@@ -94,9 +94,9 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --chapter "Mexico City" --wri
 
 ## Notes
 
-- The generator (`make_badges.py`) is a verbatim copy of the AAIF badge
-  script — kept self-contained here rather than imported from `lib`, per this
-  repo's usual skill-script convention, so this skill still runs standalone.
+- The generator (`make_badges.py`) is AAIF's badge-generation logic, kept
+  self-contained here rather than imported from `lib`, per this repo's usual
+  skill-script convention, so this skill still runs standalone.
 - Badges are built into a private `tempfile.mkdtemp()` directory that is
   deleted at the end of the run — nothing lands in the repo working tree, so
   there's no `.gitignore` entry to add.

--- a/skills/aaif-sync-badges/scripts/make_badges.py
+++ b/skills/aaif-sync-badges/scripts/make_badges.py
@@ -14,9 +14,10 @@ Produces, per chapter, in OUTDIR/<slug>/ :
     organizer_badge_<slug>_white_1000.png
 """
 import os, re, sys, unicodedata
+from xml.sax.saxutils import escape as _xml_escape
 
 # --- Brand tokens -----------------------------------------------------------
-ORANGE = "#E9852B"   # primary accent: ring, city text, ORGANIZER pill
+ORANGE = "#E9852B"   # primary accent: ring, city text, endpoint dots, ORGANIZER pill
 INK    = "#14141C"   # badge background + text knocked out of the pill
 LILAC  = "#A99BCB"   # secondary: inner rings, foundation arc, COMMUNITY EVENTS
 CREAM  = "#F7F5EF"   # AAIF wordmark
@@ -24,10 +25,14 @@ FONTS  = "Liberation Sans, DejaVu Sans, sans-serif"
 
 BOTTOM_ARC_ORIG = "M 860.0,500 A 360.0,360.0 0 0,1 140.0,500"
 BOTTOM_ARC_UPRIGHT = "M 140.0,500 A 360.0,360.0 0 0,0 860.0,500"
-UPRIGHT_BOTTOM = False   # True => bottom text reads left-to-right (see SKILL notes)
+# True => bottom text reads left-to-right instead of upside-down along the arc
+# (set via --upright-bottom; useful when a city name is long enough to wrap
+# past the arc's bottom, where the default orientation reads inverted).
+UPRIGHT_BOTTOM = False
 
 def _svg(city, ring_fill, c_ring, c_city, c_arc, c_dot, c_word, c_sub, pill, c_pill_text):
     bottom = BOTTOM_ARC_UPRIGHT if UPRIGHT_BOTTOM else BOTTOM_ARC_ORIG
+    city = _xml_escape(city)
     return f'''<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="1000" viewBox="0 0 1000 1000"><circle cx="500" cy="500" r="470.0" fill="{ring_fill}" stroke="{c_ring}" stroke-width="24.0"/>
 <circle cx="500" cy="500" r="432.0" fill="none" stroke="{c_arc}" stroke-width="4.0"/>
 <circle cx="500" cy="500" r="300.0" fill="none" stroke="{c_arc}" stroke-width="2.0" opacity="0.5"/>
@@ -68,7 +73,7 @@ def build(name, outroot, slug=None):
             f.write(svg)
         made.append(sp)
         pp = os.path.join(d, f"organizer_badge_{slug}_{variant}_1000.png")
-        import cairosvg
+        import cairosvg  # lazy: plan-only callers of this module never need it installed
         cairosvg.svg2png(url=sp, write_to=pp, output_width=1000, output_height=1000)
         made.append(pp)
     return slug, made
@@ -85,6 +90,8 @@ if __name__ == "__main__":
         if rest[i] == "--upright-bottom":
             globals()["UPRIGHT_BOTTOM"] = True; i += 1
         elif rest[i] == "--slug":
+            if i + 1 >= len(rest):
+                print("--slug requires a value"); sys.exit(1)
             override = rest[i+1]; i += 2
         else:
             names.append(rest[i]); i += 1

--- a/skills/aaif-sync-badges/scripts/make_badges.py
+++ b/skills/aaif-sync-badges/scripts/make_badges.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+AAIF chapter organizer badge generator.
+
+Usage:
+    python make_badges.py OUTDIR "Mexico City" "Sao Paulo" "Dublin"
+    python make_badges.py OUTDIR --slug delhi_ncr "Delhi NCR"
+    python make_badges.py OUTDIR --upright-bottom "Dublin"
+
+Produces, per chapter, in OUTDIR/<slug>/ :
+    organizer_badge_<slug>_colour.svg
+    organizer_badge_<slug>_white.svg
+    organizer_badge_<slug>_colour_1000.png
+    organizer_badge_<slug>_white_1000.png
+"""
+import os, re, sys, unicodedata
+
+# --- Brand tokens -----------------------------------------------------------
+ORANGE = "#E9852B"   # primary accent: ring, city text, ORGANIZER pill
+INK    = "#14141C"   # badge background + text knocked out of the pill
+LILAC  = "#A99BCB"   # secondary: inner rings, foundation arc, COMMUNITY EVENTS
+CREAM  = "#F7F5EF"   # AAIF wordmark
+FONTS  = "Liberation Sans, DejaVu Sans, sans-serif"
+
+BOTTOM_ARC_ORIG = "M 860.0,500 A 360.0,360.0 0 0,1 140.0,500"
+BOTTOM_ARC_UPRIGHT = "M 140.0,500 A 360.0,360.0 0 0,0 860.0,500"
+UPRIGHT_BOTTOM = False   # True => bottom text reads left-to-right (see SKILL notes)
+
+def _svg(city, ring_fill, c_ring, c_city, c_arc, c_dot, c_word, c_sub, pill, c_pill_text):
+    bottom = BOTTOM_ARC_UPRIGHT if UPRIGHT_BOTTOM else BOTTOM_ARC_ORIG
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="1000" viewBox="0 0 1000 1000"><circle cx="500" cy="500" r="470.0" fill="{ring_fill}" stroke="{c_ring}" stroke-width="24.0"/>
+<circle cx="500" cy="500" r="432.0" fill="none" stroke="{c_arc}" stroke-width="4.0"/>
+<circle cx="500" cy="500" r="300.0" fill="none" stroke="{c_arc}" stroke-width="2.0" opacity="0.5"/>
+<path id="tp500500" d="M 140.0,500 A 360.0,360.0 0 0,1 860.0,500" fill="none"/>
+<path id="bp500500" d="{bottom}" fill="none"/>
+<text font-family="{FONTS}" font-weight="bold" font-size="48.0" letter-spacing="5.0" fill="{c_city}"><textPath href="#tp500500" startOffset="50%" text-anchor="middle">{city}</textPath></text>
+<text font-family="{FONTS}" font-weight="bold" font-size="37.0" letter-spacing="4.0" fill="{c_arc}"><textPath href="#bp500500" startOffset="50%" text-anchor="middle">AGENTIC AI FOUNDATION</textPath></text>
+<circle cx="140.0" cy="500" r="11.0" fill="{c_dot}"/>
+<circle cx="860.0" cy="500" r="11.0" fill="{c_dot}"/>
+<text x="500" y="470.0" font-family="{FONTS}" font-weight="bold" font-size="150.0" text-anchor="middle" fill="{c_word}">AAIF</text>
+<text x="500" y="540.0" font-family="{FONTS}" font-weight="bold" font-size="36.0" letter-spacing="6.0" text-anchor="middle" fill="{c_sub}">COMMUNITY EVENTS</text>
+<rect x="296.0" y="572.0" width="408.0" height="88.0" rx="44.0" {pill}/>
+<text x="500" y="632.0" font-family="{FONTS}" font-weight="bold" font-size="46.0" letter-spacing="6.0" text-anchor="middle" fill="{c_pill_text}">ORGANIZER</text></svg>'''
+
+def colour_svg(city):
+    return _svg(city, INK, ORANGE, ORANGE, LILAC, ORANGE, CREAM, LILAC,
+                f'fill="{ORANGE}"', INK)
+
+def white_svg(city):
+    W = "#FFFFFF"
+    return _svg(city, "none", W, W, W, W, W, W,
+                f'fill="none" stroke="{W}" stroke-width="5.0"', W)
+
+def slugify(name):
+    s = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", s).strip("_").lower()
+    return s
+
+def build(name, outroot, slug=None):
+    slug = slug or slugify(name)
+    city = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode().upper()
+    d = os.path.join(outroot, slug)
+    os.makedirs(d, exist_ok=True)
+    made = []
+    for variant, svg in (("colour", colour_svg(city)), ("white", white_svg(city))):
+        sp = os.path.join(d, f"organizer_badge_{slug}_{variant}.svg")
+        with open(sp, "w") as f:
+            f.write(svg)
+        made.append(sp)
+        pp = os.path.join(d, f"organizer_badge_{slug}_{variant}_1000.png")
+        import cairosvg
+        cairosvg.svg2png(url=sp, write_to=pp, output_width=1000, output_height=1000)
+        made.append(pp)
+    return slug, made
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__); sys.exit(1)
+    outroot, rest = args[0], args[1:]
+    override = None
+    names = []
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--upright-bottom":
+            globals()["UPRIGHT_BOTTOM"] = True; i += 1
+        elif rest[i] == "--slug":
+            override = rest[i+1]; i += 2
+        else:
+            names.append(rest[i]); i += 1
+    for n in names:
+        slug, made = build(n, outroot, override)
+        override = None
+        print(f"{n} -> {slug}/  ({len(made)} files)")

--- a/skills/aaif-sync-badges/scripts/sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/sync_badges.py
@@ -46,6 +46,14 @@ _TRANSIENT = ("timed out", "Connection reset", "503", "502", "429")
 
 
 def _gws(cmd, cwd=None, retries=5):
+    """Run a gws command, retrying transient-looking failures.
+
+    retries=1 (no retry) is REQUIRED for any non-idempotent write (a Drive
+    `files.create`, folder or file): if the create actually succeeded
+    server-side but the response looked like a timeout, retrying it creates a
+    second folder/file with the same name, and nothing on the destination side
+    detects that duplicate. Reads and `files.update` (by file id) are safe to
+    retry at the default."""
     for i in range(retries):
         r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=_scrubbed_env())
         if r.returncode == 0:
@@ -57,13 +65,13 @@ def _gws(cmd, cwd=None, retries=5):
         raise RuntimeError("gws failed (%s): %s" % (r.returncode, msg.strip()[:400]))
 
 
-def gws_json(*args, params=None, body=None):
+def gws_json(*args, params=None, body=None, retries=5):
     cmd = ["gws", *args]
     if params is not None:
         cmd += ["--params", json.dumps(params)]
     if body is not None:
         cmd += ["--json", json.dumps(body)]
-    out = _gws(cmd)
+    out = _gws(cmd, retries=retries)
     s = "\n".join(l for l in out.split("\n") if "keyring backend" not in l).strip()
     if not s:
         raise RuntimeError("gws produced no JSON output for: %s" % " ".join(args))
@@ -91,7 +99,7 @@ def list_children(folder_id):
 
 
 def create_folder(name, parent):
-    return gws_json("drive", "files", "create",
+    return gws_json("drive", "files", "create", retries=1,  # non-idempotent write, see _gws
                      params={"supportsAllDrives": True},
                      body={"name": name, "mimeType": FOLDER, "parents": [parent]})["id"]
 
@@ -107,7 +115,7 @@ def upload_new(name, parent, local_path):
           "--params", json.dumps({"supportsAllDrives": True}),
           "--json", json.dumps({"name": name, "parents": [parent]}),
           "--upload", os.path.basename(local_path),
-          "--upload-content-type", mime], cwd=d)
+          "--upload-content-type", mime], cwd=d, retries=1)  # non-idempotent write, see _gws
 
 
 def upload_update(file_id, local_path):
@@ -147,21 +155,25 @@ def needed_filenames(slug):
             f"organizer_badge_{slug}_colour_1000.png", f"organizer_badge_{slug}_white_1000.png"]
 
 
-def plan(chapters, badge_folders, regenerate):
-    """Returns (folders_to_create: {slug: name}, files_to_upload: {slug: (folder_id_or_None, [filenames])})."""
+def plan(chapters, badge_folders, children_by_slug, regenerate):
+    """Returns (folders_to_create: {slug: name}, files_to_upload: {slug: (folder_id_or_None, [filenames])}).
+
+    `children_by_slug` must already hold an entry for every slug in `chapters`
+    that also has a matching `badge_folders` entry -- membership in it (not an
+    optional key on `badge_folders`) is what means "already fetched"."""
     folders_to_create = {}
     files_to_upload = {}
     for slug, name in sorted(chapters.items()):
-        entry = badge_folders.get(slug)
+        folder = badge_folders.get(slug)
         need = needed_filenames(slug)
-        if entry is None:
+        if folder is None:
             folders_to_create[slug] = name
             files_to_upload[slug] = (None, need)
             continue
-        existing_names = {c["name"] for c in entry["children"]}
+        existing_names = {c["name"] for c in children_by_slug[slug]}
         missing = need if regenerate else [n for n in need if n not in existing_names]
         if missing:
-            files_to_upload[slug] = (entry["id"], missing)
+            files_to_upload[slug] = (folder["id"], missing)
     return folders_to_create, files_to_upload
 
 
@@ -196,18 +208,18 @@ def main():
     # Fetch each folder's contents only for slugs actually in scope (the
     # --chapter filter, or every chapter on a full run) -- an orphan folder,
     # or any folder outside a --chapter filter, needs its NAME (already known
-    # from the listing above) but never its children.
-    for slug in chapters:
-        entry = badge_folders.get(slug)
-        if entry is not None:
-            entry["children"] = list_children(entry["id"])
+    # from the listing above) but never its children. Presence as a KEY in
+    # children_by_slug (not an optional field on badge_folders) is what means
+    # "already fetched" -- see plan()'s docstring.
+    children_by_slug = {slug: list_children(badge_folders[slug]["id"])
+                         for slug in chapters if slug in badge_folders}
 
     # Orphans are judged against the FULL canonical set, never the --chapter
     # filter -- otherwise every other real chapter's folder would misreport as
     # having "no matching chapter" just because it wasn't the one asked for.
     orphans = sorted(n for n in badge_folders if n not in all_chapters)
 
-    folders_to_create, files_to_upload = plan(chapters, badge_folders, a.regenerate)
+    folders_to_create, files_to_upload = plan(chapters, badge_folders, children_by_slug, a.regenerate)
 
     print(f"Chapters (canonical): {len(chapters)}")
     print(f"Badge folders present: {len(badge_folders)}")
@@ -224,8 +236,11 @@ def main():
     for slug, name in sorted(folders_to_create.items()):
         print(f"+ create folder  {slug}/   ({name})")
     for slug, (folder_id, files) in sorted(files_to_upload.items()):
-        verb = "upload" if folder_id is None else ("overwrite" if a.regenerate else "upload")
+        # Per-file, not per-chapter: under --regenerate a partially-complete
+        # folder still has files that were never there to "overwrite".
+        existing_names = {c["name"] for c in children_by_slug.get(slug, [])}
         for fn in files:
+            verb = "overwrite" if fn in existing_names else "upload"
             print(f"  {verb:<9} {slug}/{fn}")
 
     if not a.write:
@@ -244,7 +259,7 @@ def main():
                 print(f"created folder {slug}/ -> {folder_id}")
                 existing_by_name = {}
             else:
-                existing_by_name = {c["name"]: c["id"] for c in badge_folders[slug]["children"]}
+                existing_by_name = {c["name"]: c["id"] for c in children_by_slug[slug]}
             make_badges.build(name, tmp, slug)
             for fn in files:
                 local_path = os.path.join(tmp, slug, fn)
@@ -258,7 +273,10 @@ def main():
                 total += 1
         print(f"\nDone. {total} file(s) written.")
     finally:
-        shutil.rmtree(tmp, ignore_errors=True)
+        try:
+            shutil.rmtree(tmp)
+        except OSError as e:
+            print(f"warning: could not remove temp dir {tmp}: {e}")
 
 
 if __name__ == "__main__":

--- a/skills/aaif-sync-badges/scripts/sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/sync_badges.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Sync AAIF organizer badges (SVG + PNG) to the chapter-badges Drive folder.
+
+Reads the canonical chapter list from the "Chapters" Drive folder, generates
+each chapter's 4 badge files (colour/white SVG + their 1000px PNG renders)
+with make_badges.py, and uploads whatever the chapter-badges folder is
+missing. Existing files are left untouched unless --regenerate is passed.
+
+Usage:
+    # Plan (default) -- nothing is created/uploaded, just reported:
+    python sync_badges.py
+
+    # Apply -- create missing chapter subfolders and upload missing files:
+    python sync_badges.py --write
+
+    # Regenerate every file (design refresh) and overwrite what's already there:
+    python sync_badges.py --write --regenerate
+
+    # One chapter only (matches the Drive chapter folder name, case-insensitive):
+    python sync_badges.py --chapter "Mexico City" --write
+"""
+import argparse, json, os, shutil, subprocess, sys, tempfile, time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import make_badges  # noqa: E402
+
+CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
+BADGES_PARENT = "1ViKjLZh-4KrMBVihOGQyAL2SVsXcI3B9"      # the chapter-badges Drive folder
+FOLDER = "application/vnd.google-apps.folder"
+# Not a real chapter -- the clone source create_chapter.py rebrands from.
+NOT_A_CHAPTER = {"templatecity"}
+
+MIME_BY_EXT = {".svg": "image/svg+xml", ".png": "image/png"}
+
+
+def _scrubbed_env():
+    """os.environ minus the Slack/Luma secrets. gws never needs them, and a child
+    process inherits everything by default. Local (not lib) so this script stays
+    standalone."""
+    return {k: v for k, v in os.environ.items()
+            if not (k.startswith("AAIF_SLACK_") and k.endswith("_TOKEN"))
+            and k != "LUMA_API_KEY"}
+
+
+_TRANSIENT = ("timed out", "Connection reset", "503", "502", "429")
+
+
+def _gws(cmd, cwd=None, retries=5):
+    for i in range(retries):
+        r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=_scrubbed_env())
+        if r.returncode == 0:
+            return r.stdout
+        msg = (r.stderr or "") + (r.stdout or "")
+        if i < retries - 1 and any(k in msg for k in _TRANSIENT):
+            time.sleep(2 * (i + 1))
+            continue
+        raise RuntimeError("gws failed (%s): %s" % (r.returncode, msg.strip()[:400]))
+
+
+def gws_json(*args, params=None, body=None):
+    cmd = ["gws", *args]
+    if params is not None:
+        cmd += ["--params", json.dumps(params)]
+    if body is not None:
+        cmd += ["--json", json.dumps(body)]
+    out = _gws(cmd)
+    s = "\n".join(l for l in out.split("\n") if "keyring backend" not in l).strip()
+    if not s:
+        raise RuntimeError("gws produced no JSON output for: %s" % " ".join(args))
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        raise RuntimeError("gws returned non-JSON output for %s: %s" % (" ".join(args), s[:200]))
+
+
+def list_children(folder_id):
+    """Every child of `folder_id`, following pagination to the end."""
+    out, token = [], None
+    while True:
+        params = {
+            "q": "'%s' in parents and trashed=false" % folder_id,
+            "fields": "nextPageToken, files(id,name,mimeType,size)", "pageSize": 1000,
+            "supportsAllDrives": True, "includeItemsFromAllDrives": True}
+        if token:
+            params["pageToken"] = token
+        res = gws_json("drive", "files", "list", params=params)
+        out.extend(res.get("files", []))
+        token = res.get("nextPageToken")
+        if not token:
+            return out
+
+
+def create_folder(name, parent):
+    return gws_json("drive", "files", "create",
+                     params={"supportsAllDrives": True},
+                     body={"name": name, "mimeType": FOLDER, "parents": [parent]})["id"]
+
+
+def _mime_and_dir(local_path):
+    # gws rejects --upload paths outside its cwd, so callers run it in the file's dir.
+    return MIME_BY_EXT[os.path.splitext(local_path)[1]], os.path.dirname(local_path) or "."
+
+
+def upload_new(name, parent, local_path):
+    mime, d = _mime_and_dir(local_path)
+    _gws(["gws", "drive", "files", "create",
+          "--params", json.dumps({"supportsAllDrives": True}),
+          "--json", json.dumps({"name": name, "parents": [parent]}),
+          "--upload", os.path.basename(local_path),
+          "--upload-content-type", mime], cwd=d)
+
+
+def upload_update(file_id, local_path):
+    mime, d = _mime_and_dir(local_path)
+    _gws(["gws", "drive", "files", "update",
+          "--params", json.dumps({"fileId": file_id, "supportsAllDrives": True}),
+          "--upload", os.path.basename(local_path),
+          "--upload-content-type", mime], cwd=d)
+
+
+# --- planning ----------------------------------------------------------------
+
+def canonical_chapters():
+    """{slug: display name} for every real chapter folder, keyed by
+    make_badges.slugify -- the same slug convention the badges folder already
+    uses (e.g. "Delhi NCR" -> "delhi_ncr", "Mexico City" -> "mexico_city")."""
+    chapters = {}
+    collisions = {}
+    for f in list_children(CHAPTERS_PARENT):
+        if f["mimeType"] != FOLDER:
+            continue
+        if f["name"].strip().lower() in NOT_A_CHAPTER:
+            continue
+        slug = make_badges.slugify(f["name"])
+        if slug in chapters and chapters[slug] != f["name"]:
+            collisions.setdefault(slug, {chapters[slug]}).add(f["name"])
+        chapters[slug] = f["name"]
+    if collisions:
+        raise SystemExit("ABORT: chapter names collide on the same badge slug: %s"
+                          % ", ".join("%s -> %s" % (s, sorted(names))
+                                       for s, names in collisions.items()))
+    return chapters
+
+
+def needed_filenames(slug):
+    return [f"organizer_badge_{slug}_colour.svg", f"organizer_badge_{slug}_white.svg",
+            f"organizer_badge_{slug}_colour_1000.png", f"organizer_badge_{slug}_white_1000.png"]
+
+
+def plan(chapters, badge_folders, regenerate):
+    """Returns (folders_to_create: {slug: name}, files_to_upload: {slug: (folder_id_or_None, [filenames])})."""
+    folders_to_create = {}
+    files_to_upload = {}
+    for slug, name in sorted(chapters.items()):
+        entry = badge_folders.get(slug)
+        need = needed_filenames(slug)
+        if entry is None:
+            folders_to_create[slug] = name
+            files_to_upload[slug] = (None, need)
+            continue
+        existing_names = {c["name"] for c in entry["children"]}
+        missing = need if regenerate else [n for n in need if n not in existing_names]
+        if missing:
+            files_to_upload[slug] = (entry["id"], missing)
+    return folders_to_create, files_to_upload
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--write", action="store_true",
+                     help="LIVE WRITE: create folders/upload files. Without it this only plans.")
+    ap.add_argument("--regenerate", action="store_true",
+                     help="Re-generate and overwrite every existing badge file too "
+                          "(use after a design change to make_badges.py). Requires --write "
+                          "to actually overwrite; harmless to pass without it (just widens the plan).")
+    ap.add_argument("--chapter", help="Only sync one chapter (Drive folder name, case-insensitive substring match)")
+    a = ap.parse_args()
+
+    all_chapters = canonical_chapters()
+    chapters = all_chapters
+    if a.chapter:
+        needle = a.chapter.strip().lower()
+        chapters = {s: n for s, n in all_chapters.items() if needle in n.lower()}
+        if not chapters:
+            sys.exit(f"ABORT: no chapter folder matches {a.chapter!r}")
+
+    raw_badge_children = list_children(BADGES_PARENT)
+    badge_folders = {}
+    stray_files = []
+    for f in raw_badge_children:
+        if f["mimeType"] != FOLDER:
+            stray_files.append(f["name"])
+            continue
+        badge_folders[f["name"]] = {"id": f["id"]}
+    # Fetch each folder's contents only for slugs actually in scope (the
+    # --chapter filter, or every chapter on a full run) -- an orphan folder,
+    # or any folder outside a --chapter filter, needs its NAME (already known
+    # from the listing above) but never its children.
+    for slug in chapters:
+        entry = badge_folders.get(slug)
+        if entry is not None:
+            entry["children"] = list_children(entry["id"])
+
+    # Orphans are judged against the FULL canonical set, never the --chapter
+    # filter -- otherwise every other real chapter's folder would misreport as
+    # having "no matching chapter" just because it wasn't the one asked for.
+    orphans = sorted(n for n in badge_folders if n not in all_chapters)
+
+    folders_to_create, files_to_upload = plan(chapters, badge_folders, a.regenerate)
+
+    print(f"Chapters (canonical): {len(chapters)}")
+    print(f"Badge folders present: {len(badge_folders)}")
+    if stray_files:
+        print(f"Stray non-folder items in badges parent (ignored): {stray_files}")
+    if orphans:
+        print(f"Badge folders with no matching chapter (left alone): {orphans}")
+    print()
+
+    if not folders_to_create and not files_to_upload:
+        print("Up to date -- nothing to create or upload.")
+        return
+
+    for slug, name in sorted(folders_to_create.items()):
+        print(f"+ create folder  {slug}/   ({name})")
+    for slug, (folder_id, files) in sorted(files_to_upload.items()):
+        verb = "upload" if folder_id is None else ("overwrite" if a.regenerate else "upload")
+        for fn in files:
+            print(f"  {verb:<9} {slug}/{fn}")
+
+    if not a.write:
+        print("\nPlan only -- re-run with --write to create/upload.")
+        return
+
+    tmp = tempfile.mkdtemp(prefix="aaif-badges-")
+    try:
+        total = 0
+        for slug, (folder_id, files) in sorted(files_to_upload.items()):
+            name = chapters[slug]
+            if slug in folders_to_create:
+                # Folder name is the SLUG, matching every existing badge folder
+                # (e.g. "mexico_city", not the chapter's display name).
+                folder_id = create_folder(slug, BADGES_PARENT)
+                print(f"created folder {slug}/ -> {folder_id}")
+                existing_by_name = {}
+            else:
+                existing_by_name = {c["name"]: c["id"] for c in badge_folders[slug]["children"]}
+            make_badges.build(name, tmp, slug)
+            for fn in files:
+                local_path = os.path.join(tmp, slug, fn)
+                existing_id = existing_by_name.get(fn)
+                if existing_id:
+                    upload_update(existing_id, local_path)
+                    print(f"  updated  {slug}/{fn}")
+                else:
+                    upload_new(fn, folder_id, local_path)
+                    print(f"  uploaded {slug}/{fn}")
+                total += 1
+        print(f"\nDone. {total} file(s) written.")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-badges/scripts/test_make_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_make_badges.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+import make_badges  # noqa: E402
+
+
+class TestSlugify(unittest.TestCase):
+    def test_matches_existing_badge_folder_names(self):
+        # These are the slugs already live under the chapter-badges Drive folder;
+        # a drift here would mismatch every existing folder.
+        cases = {
+            "Mexico City": "mexico_city",
+            "Delhi NCR": "delhi_ncr",
+            "Silicon Valley": "silicon_valley",
+            "Washington DC": "washington_dc",
+            "Buenos Aires": "buenos_aires",
+            "Montréal": "montreal",
+            "Cape Town": "cape_town",
+        }
+        for name, expected in cases.items():
+            self.assertEqual(make_badges.slugify(name), expected)
+
+
+class TestBuild(unittest.TestCase):
+    def test_writes_four_files_per_chapter(self):
+        with tempfile.TemporaryDirectory() as d:
+            slug, made = make_badges.build("Dublin", d)
+            self.assertEqual(slug, "dublin")
+            self.assertEqual(len(made), 4)
+            for p in made:
+                self.assertTrue(os.path.isfile(p))
+                self.assertGreater(os.path.getsize(p), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-sync-badges/scripts/test_make_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_make_badges.py
@@ -1,16 +1,25 @@
+import importlib.util
 import os
 import sys
 import tempfile
 import unittest
+import xml.dom.minidom
 
 sys.path.insert(0, os.path.dirname(__file__))
 import make_badges  # noqa: E402
 
+# CI installs only pytest/pyyaml (see .github/workflows/validate.yml) --
+# cairosvg is a manual, documented-in-SKILL.md dependency for the PNG render
+# step, so anything that calls build() must skip gracefully where it's absent
+# rather than fail the whole suite.
+HAS_CAIROSVG = importlib.util.find_spec("cairosvg") is not None
+
 
 class TestSlugify(unittest.TestCase):
-    def test_matches_existing_badge_folder_names(self):
-        # These are the slugs already live under the chapter-badges Drive folder;
-        # a drift here would mismatch every existing folder.
+    def test_matches_representative_edge_cases(self):
+        # Accents, spaces, and abbreviations -- a regression here would
+        # mismatch a chapter against whatever badge folder already carries
+        # its slug in Drive.
         cases = {
             "Mexico City": "mexico_city",
             "Delhi NCR": "delhi_ncr",
@@ -24,6 +33,33 @@ class TestSlugify(unittest.TestCase):
             self.assertEqual(make_badges.slugify(name), expected)
 
 
+class TestSvgEscaping(unittest.TestCase):
+    """A chapter's Drive folder display name is untrusted (any of its
+    organizers can rename it) and lands in the SVG unescaped otherwise --
+    regression coverage for the XML-injection fix."""
+
+    def test_ampersand_and_angle_brackets_are_escaped(self):
+        svg = make_badges.colour_svg('R&D <VILLE>')
+        xml.dom.minidom.parseString(svg)  # raises if not well-formed
+        self.assertIn("R&amp;D &lt;VILLE&gt;", svg)
+        self.assertNotIn("<VILLE>", svg)
+
+    def test_plain_name_parses_and_renders_unescaped(self):
+        svg = make_badges.colour_svg("DUBLIN")
+        xml.dom.minidom.parseString(svg)
+        self.assertIn(">DUBLIN<", svg)
+
+
+class TestColourAndWhiteVariants(unittest.TestCase):
+    def test_variants_use_different_palettes(self):
+        colour = make_badges.colour_svg("DUBLIN")
+        white = make_badges.white_svg("DUBLIN")
+        self.assertIn(make_badges.ORANGE, colour)
+        self.assertNotIn(make_badges.ORANGE, white)
+        self.assertIn("#FFFFFF", white)
+
+
+@unittest.skipUnless(HAS_CAIROSVG, "cairosvg not installed")
 class TestBuild(unittest.TestCase):
     def test_writes_four_files_per_chapter(self):
         with tempfile.TemporaryDirectory() as d:

--- a/skills/aaif-sync-badges/scripts/test_sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_sync_badges.py
@@ -48,17 +48,18 @@ class TestCanonicalChapters(unittest.TestCase):
 class TestPlan(unittest.TestCase):
     def test_new_chapter_needs_folder_and_all_files(self):
         chapters = {"dublin": "Dublin"}
-        folders, files = sync_badges.plan(chapters, badge_folders={}, regenerate=False)
+        folders, files = sync_badges.plan(chapters, badge_folders={}, children_by_slug={}, regenerate=False)
         self.assertEqual(folders, {"dublin": "Dublin"})
         self.assertEqual(files["dublin"], (None, sync_badges.needed_filenames("dublin")))
 
     def test_existing_folder_only_uploads_missing_files(self):
         chapters = {"dublin": "Dublin"}
-        badge_folders = {"dublin": {"id": "fid", "children": [
+        badge_folders = {"dublin": {"id": "fid"}}
+        children_by_slug = {"dublin": [
             {"name": "organizer_badge_dublin_colour.svg"},
             {"name": "organizer_badge_dublin_white.svg"},
-        ]}}
-        folders, files = sync_badges.plan(chapters, badge_folders, regenerate=False)
+        ]}
+        folders, files = sync_badges.plan(chapters, badge_folders, children_by_slug, regenerate=False)
         self.assertEqual(folders, {})
         self.assertEqual(files["dublin"], ("fid", [
             "organizer_badge_dublin_colour_1000.png",
@@ -67,20 +68,132 @@ class TestPlan(unittest.TestCase):
 
     def test_complete_chapter_is_left_alone(self):
         chapters = {"dublin": "Dublin"}
-        badge_folders = {"dublin": {"id": "fid",
-                                     "children": [{"name": n} for n in
-                                                  sync_badges.needed_filenames("dublin")]}}
-        folders, files = sync_badges.plan(chapters, badge_folders, regenerate=False)
+        badge_folders = {"dublin": {"id": "fid"}}
+        children_by_slug = {"dublin": [{"name": n} for n in sync_badges.needed_filenames("dublin")]}
+        folders, files = sync_badges.plan(chapters, badge_folders, children_by_slug, regenerate=False)
         self.assertEqual(folders, {})
         self.assertEqual(files, {})
 
     def test_regenerate_reuploads_every_file_even_if_complete(self):
         chapters = {"dublin": "Dublin"}
-        badge_folders = {"dublin": {"id": "fid",
-                                     "children": [{"name": n} for n in
-                                                  sync_badges.needed_filenames("dublin")]}}
-        folders, files = sync_badges.plan(chapters, badge_folders, regenerate=True)
+        badge_folders = {"dublin": {"id": "fid"}}
+        children_by_slug = {"dublin": [{"name": n} for n in sync_badges.needed_filenames("dublin")]}
+        folders, files = sync_badges.plan(chapters, badge_folders, children_by_slug, regenerate=True)
         self.assertEqual(files["dublin"], ("fid", sync_badges.needed_filenames("dublin")))
+
+
+class TestListChildrenPagination(unittest.TestCase):
+    def test_follows_next_page_token_to_the_end(self):
+        pages = [
+            {"nextPageToken": "p2", "files": [{"id": "1", "name": "a", "mimeType": sync_badges.FOLDER}]},
+            {"files": [{"id": "2", "name": "b", "mimeType": sync_badges.FOLDER}]},
+        ]
+        calls = []
+
+        def fake_gws_json(*_args, params=None, **_kwargs):
+            calls.append(params.get("pageToken"))
+            return pages.pop(0)
+
+        with mock.patch.object(sync_badges, "gws_json", fake_gws_json):
+            out = sync_badges.list_children("folder123")
+        self.assertEqual([f["id"] for f in out], ["1", "2"])
+        self.assertEqual(calls, [None, "p2"])  # second call carries the token from page 1
+
+
+class TestGwsRetry(unittest.TestCase):
+    def test_retries_transient_failure_then_succeeds(self):
+        results = [
+            mock.Mock(returncode=1, stdout="", stderr="503 Service Unavailable"),
+            mock.Mock(returncode=0, stdout="ok", stderr=""),
+        ]
+        with mock.patch.object(sync_badges.subprocess, "run", side_effect=results), \
+             mock.patch.object(sync_badges.time, "sleep"):
+            out = sync_badges._gws(["gws", "noop"])
+        self.assertEqual(out, "ok")
+
+    def test_non_transient_failure_raises_immediately(self):
+        result = mock.Mock(returncode=1, stdout="", stderr="permission denied")
+        with mock.patch.object(sync_badges.subprocess, "run", return_value=result) as run:
+            with self.assertRaises(RuntimeError):
+                sync_badges._gws(["gws", "noop"])
+        self.assertEqual(run.call_count, 1)  # no retry on a non-transient error
+
+    def test_retries_1_means_no_retry_even_on_transient_error(self):
+        # Non-idempotent writes (create_folder, upload_new) pass retries=1 so a
+        # timed-out `files.create` is never blindly retried into a duplicate.
+        result = mock.Mock(returncode=1, stdout="", stderr="timed out")
+        with mock.patch.object(sync_badges.subprocess, "run", return_value=result) as run:
+            with self.assertRaises(RuntimeError):
+                sync_badges._gws(["gws", "noop"], retries=1)
+        self.assertEqual(run.call_count, 1)
+
+
+class TestWritePathDispatch(unittest.TestCase):
+    """main()'s create-vs-update dispatch, fully mocked -- no live Drive."""
+
+    def _run_main(self, argv, all_chapters, badge_children):
+        with mock.patch.object(sys, "argv", ["sync_badges.py"] + argv), \
+             mock.patch.object(sync_badges, "canonical_chapters", return_value=all_chapters), \
+             mock.patch.object(sync_badges, "list_children",
+                                side_effect=lambda fid: badge_children.get(fid, [])), \
+             mock.patch.object(sync_badges, "create_folder") as create_folder, \
+             mock.patch.object(sync_badges, "upload_new") as upload_new, \
+             mock.patch.object(sync_badges, "upload_update") as upload_update, \
+             mock.patch.object(sync_badges.make_badges, "build") as build:
+            create_folder.return_value = "new-folder-id"
+            sync_badges.main()
+        return create_folder, upload_new, upload_update, build
+
+    def test_new_chapter_creates_folder_and_uploads_every_file(self):
+        all_chapters = {"dublin": "Dublin"}
+        badge_children = {sync_badges.BADGES_PARENT: []}  # no existing badge folders
+        create_folder, upload_new, upload_update, build = self._run_main(
+            ["--write", "--chapter", "Dublin"], all_chapters, badge_children)
+
+        create_folder.assert_called_once_with("dublin", sync_badges.BADGES_PARENT)
+        build.assert_called_once_with("Dublin", mock.ANY, "dublin")
+        self.assertEqual(upload_new.call_count, 4)
+        upload_update.assert_not_called()
+
+    def test_existing_folder_only_uploads_the_files_actually_missing(self):
+        all_chapters = {"dublin": "Dublin"}
+        badge_children = {
+            sync_badges.BADGES_PARENT: [{"id": "folder-id", "name": "dublin", "mimeType": sync_badges.FOLDER}],
+            "folder-id": [{"id": "existing-svg", "name": "organizer_badge_dublin_colour.svg"}],
+        }
+        create_folder, upload_new, upload_update, build = self._run_main(
+            ["--write", "--chapter", "Dublin"], all_chapters, badge_children)
+
+        # The already-present file is left untouched (neither uploaded nor
+        # updated) -- only the 3 genuinely missing files are created.
+        create_folder.assert_not_called()
+        upload_update.assert_not_called()
+        self.assertEqual(upload_new.call_count, 3)
+
+    def test_regenerate_updates_the_existing_file_in_place(self):
+        all_chapters = {"dublin": "Dublin"}
+        badge_children = {
+            sync_badges.BADGES_PARENT: [{"id": "folder-id", "name": "dublin", "mimeType": sync_badges.FOLDER}],
+            "folder-id": [{"id": "existing-svg", "name": "organizer_badge_dublin_colour.svg"}],
+        }
+        create_folder, upload_new, upload_update, build = self._run_main(
+            ["--write", "--regenerate", "--chapter", "Dublin"], all_chapters, badge_children)
+
+        create_folder.assert_not_called()
+        upload_update.assert_called_once()
+        self.assertEqual(upload_update.call_args.args[0], "existing-svg")
+        self.assertEqual(upload_new.call_count, 3)  # the other 3 needed files
+
+    def test_plan_only_never_touches_drive(self):
+        all_chapters = {"dublin": "Dublin"}
+        badge_children = {sync_badges.BADGES_PARENT: []}
+        create_folder, upload_new, upload_update, build = self._run_main(
+            ["--chapter", "Dublin"], all_chapters, badge_children)  # no --write
+
+        create_folder.assert_not_called()
+        upload_new.assert_not_called()
+        upload_update.assert_not_called()
+        build.assert_not_called()
 
 
 class TestScrubbedEnv(unittest.TestCase):

--- a/skills/aaif-sync-badges/scripts/test_sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_sync_badges.py
@@ -1,0 +1,99 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+import sync_badges  # noqa: E402
+
+
+class TestNeededFilenames(unittest.TestCase):
+    def test_four_files_per_slug(self):
+        got = sync_badges.needed_filenames("mexico_city")
+        self.assertEqual(got, [
+            "organizer_badge_mexico_city_colour.svg",
+            "organizer_badge_mexico_city_white.svg",
+            "organizer_badge_mexico_city_colour_1000.png",
+            "organizer_badge_mexico_city_white_1000.png",
+        ])
+
+
+class TestCanonicalChapters(unittest.TestCase):
+    def _fake_children(self, folder_id):
+        self.assertEqual(folder_id, sync_badges.CHAPTERS_PARENT)
+        return [
+            {"name": "Mexico City", "mimeType": sync_badges.FOLDER},
+            {"name": "Delhi NCR", "mimeType": sync_badges.FOLDER},
+            {"name": "TemplateCity", "mimeType": sync_badges.FOLDER},
+            {"name": "Event Tracker.docx", "mimeType": "application/vnd.google-apps.document"},
+        ]
+
+    def test_excludes_templatecity_and_non_folders(self):
+        with mock.patch.object(sync_badges, "list_children", self._fake_children):
+            chapters = sync_badges.canonical_chapters()
+        self.assertEqual(chapters, {"mexico_city": "Mexico City", "delhi_ncr": "Delhi NCR"})
+
+    def test_collision_aborts_rather_than_silently_dropping_a_chapter(self):
+        def children(_folder_id):
+            return [
+                {"name": "Mexico City", "mimeType": sync_badges.FOLDER},
+                {"name": "Mexico  City", "mimeType": sync_badges.FOLDER},  # slugifies the same
+            ]
+        with mock.patch.object(sync_badges, "list_children", children):
+            with self.assertRaises(SystemExit) as e:
+                sync_badges.canonical_chapters()
+        self.assertIn("collide", str(e.exception))
+
+
+class TestPlan(unittest.TestCase):
+    def test_new_chapter_needs_folder_and_all_files(self):
+        chapters = {"dublin": "Dublin"}
+        folders, files = sync_badges.plan(chapters, badge_folders={}, regenerate=False)
+        self.assertEqual(folders, {"dublin": "Dublin"})
+        self.assertEqual(files["dublin"], (None, sync_badges.needed_filenames("dublin")))
+
+    def test_existing_folder_only_uploads_missing_files(self):
+        chapters = {"dublin": "Dublin"}
+        badge_folders = {"dublin": {"id": "fid", "children": [
+            {"name": "organizer_badge_dublin_colour.svg"},
+            {"name": "organizer_badge_dublin_white.svg"},
+        ]}}
+        folders, files = sync_badges.plan(chapters, badge_folders, regenerate=False)
+        self.assertEqual(folders, {})
+        self.assertEqual(files["dublin"], ("fid", [
+            "organizer_badge_dublin_colour_1000.png",
+            "organizer_badge_dublin_white_1000.png",
+        ]))
+
+    def test_complete_chapter_is_left_alone(self):
+        chapters = {"dublin": "Dublin"}
+        badge_folders = {"dublin": {"id": "fid",
+                                     "children": [{"name": n} for n in
+                                                  sync_badges.needed_filenames("dublin")]}}
+        folders, files = sync_badges.plan(chapters, badge_folders, regenerate=False)
+        self.assertEqual(folders, {})
+        self.assertEqual(files, {})
+
+    def test_regenerate_reuploads_every_file_even_if_complete(self):
+        chapters = {"dublin": "Dublin"}
+        badge_folders = {"dublin": {"id": "fid",
+                                     "children": [{"name": n} for n in
+                                                  sync_badges.needed_filenames("dublin")]}}
+        folders, files = sync_badges.plan(chapters, badge_folders, regenerate=True)
+        self.assertEqual(files["dublin"], ("fid", sync_badges.needed_filenames("dublin")))
+
+
+class TestScrubbedEnv(unittest.TestCase):
+    def test_drops_slack_and_luma_secrets_only(self):
+        with mock.patch.dict(os.environ, {"AAIF_SLACK_WRITE_TOKEN": "x",
+                                          "AAIF_SLACK_READ_TOKEN": "y",
+                                          "LUMA_API_KEY": "z", "HOME_KEEP": "1"}):
+            env = sync_badges._scrubbed_env()
+        self.assertNotIn("AAIF_SLACK_WRITE_TOKEN", env)
+        self.assertNotIn("AAIF_SLACK_READ_TOKEN", env)
+        self.assertNotIn("LUMA_API_KEY", env)
+        self.assertEqual(env["HOME_KEEP"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a new `aaif-sync-badges` skill that generates and syncs AAIF chapter organizer badges (colour/white SVG + 1000px PNG renders) into the chapter-badges Google Drive folder. It reads the canonical chapter list from the live "Chapters" Drive folder, diffs it against what's already in the badges folder, and creates only what's missing — additive by default, with a `--regenerate` flag to push a design refresh to every chapter and a `--chapter` flag to scope to one city.

## Changesets

### 1. `feat(badges): add aaif-sync-badges skill for chapter organizer badges`
**Files:** `skills/aaif-sync-badges/SKILL.md`, `skills/aaif-sync-badges/scripts/make_badges.py`, `skills/aaif-sync-badges/scripts/sync_badges.py`, `skills/aaif-sync-badges/scripts/test_make_badges.py`, `skills/aaif-sync-badges/scripts/test_sync_badges.py` (+602)

- `make_badges.py` — the badge generator (ring/arc SVG design, rendered to PNG via `cairosvg`), self-contained per this repo's skill-script convention.
- `sync_badges.py` — the sync engine: `gws`-CLI plumbing to list the Chapters and chapter-badges Drive folders, diff canonical chapters against existing badge folders/files, and create/upload only what's missing. Plan-only by default; `--write` applies, `--regenerate` forces a full re-push, `--chapter` scopes to one city.
- Unit tests cover slug parity with existing Drive folder names, the diff/plan logic (new chapter, partially-complete chapter, complete chapter, regenerate), and the collision guard.

Live-tested against the real chapter-badges Drive folder: filled in badges for the 29 chapters that didn't have them yet (112 files uploaded across 28 new folders, plus a smoke-tested Tatooine folder), then verified idempotency (`Up to date`) on re-run.

### 2. `fix: address self-review findings`
**Files:** same five, plus `README.md` (+216 -40)

- Fixed a CI-breaking test (`cairosvg` isn't installed in CI) with a skip guard.
- Closed a duplicate-write risk: Drive `files.create` is non-idempotent, so a false-timeout retry could silently duplicate a chapter's folder/file — creates now use `retries=1`.
- XML-escaped the chapter display name before it reaches the generated SVG (a chapter organizer renaming their own folder could otherwise inject markup).
- Fixed an `IndexError` on `--slug` with no value, a fragile implicit-key data shape (`badge_folders`/`children_by_slug` split), and a cosmetic plan-output labeling bug.
- Added `aaif-sync-badges` (and the previously-missing `aaif-community-pulse`) to the README skill table.
- Added test coverage for the write-path dispatch, `list_children` pagination, and `_gws` retry/backoff.
- The reviewer also flagged that the badge's hardcoded palette/font and `cairosvg` renderer sit in tension with the repo's design-system conventions — confirmed with the user to leave as-is, since this is the design as supplied and 89 badges are already live with it.

## Test Plan
- [x] `python3 skills/aaif-sync-badges/scripts/test_sync_badges.py` — 16 passed
- [x] `python3 skills/aaif-sync-badges/scripts/test_make_badges.py` — 5 passed with `cairosvg` installed, 4 passed + 1 skipped without it (mimics CI)
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Live plan-mode dry run against the real Drive folders (89 canonical chapters, 89 badge folders — up to date)
- [x] Live `--write` smoke test (single chapter, then full sync of the 29 missing chapters) followed by idempotent re-run
- [x] Self-review via `hero-skills:review-pr` — 6 parallel review agents (code quality, silent failures, test coverage, comments, type design, security); all Critical/Important/Suggestion findings fixed except one confirmed-intentional product decision

_Generated using hero-skills._