### PR TITLE
feat(badges): move badges into per-chapter Badges/ folders, add design-system agent badge

### DIFF
--- a/skills/aaif-sync-badges/SKILL.md
+++ b/skills/aaif-sync-badges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aaif-sync-badges
-description: Sync AAIF chapter organizer badges (SVG + PNG) into the chapter-badges Google Drive folder — generate missing badges for chapters that don't have them yet, and optionally regenerate all of them after a design change. Use when asked to add/sync/update/regenerate chapter organizer badges.
+description: Sync AAIF chapter organizer badges (SVG + PNG) into each chapter's own Drive folder — generate missing badges for chapters that don't have them yet, and optionally regenerate all of them after a design change. Use when asked to add/sync/update/regenerate chapter organizer badges.
 argument-hint: '[--chapter <City Name>] [--regenerate] [--write]'
 ---
 
@@ -21,28 +21,50 @@ argument-hint: '[--chapter <City Name>] [--regenerate] [--write]'
 > trash the copy. Never round-trip a native Doc through `.docx` — it strips
 > native features like Tabs.
 
-Keeps the **chapter-badges** Drive folder (id `1ViKjLZh-4KrMBVihOGQyAL2SVsXcI3B9`)
-in sync with the **Chapters** Drive folder (id `1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx`,
-same one `aaif-create-chapter` clones from). Each chapter gets a subfolder named
-by its **slug** (`make_badges.slugify` — e.g. "Mexico City" → `mexico_city`,
-"Delhi NCR" → `delhi_ncr`), holding 4 files:
+Keeps every chapter's own **`Badges/`** Drive subfolder (created directly inside
+the chapter's folder under the **Chapters** Drive folder, id
+`1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx` — same one `aaif-create-chapter` clones from
+— alongside its existing `Icons/`, `Event Templates (…)/`, etc.) in sync. Each
+chapter's `Badges/` folder holds **two badge styles**, 6 files total:
 
 ```
-organizer_badge_<slug>_colour.svg
-organizer_badge_<slug>_white.svg
-organizer_badge_<slug>_colour_1000.png
-organizer_badge_<slug>_white_1000.png
+organizer_badge_<slug>_colour.svg          \
+organizer_badge_<slug>_white.svg            |  style 1 — scripts/make_badges.py
+organizer_badge_<slug>_colour_1000.png      |  (self-contained, hand-tuned palette)
+organizer_badge_<slug>_white_1000.png      /
+
+organizer_badge_<slug>_agent.svg            \  style 2 — scripts/make_agent_badge.py
+organizer_badge_<slug>_agent_1000.png      /   (real AAIF design-system tokens
+                                                 + the chapter's own agent mascot)
 ```
 
-Badges are generated locally by `scripts/make_badges.py` (a ring-and-arc AAIF
-organizer badge, city name on the top arc, "AGENTIC AI FOUNDATION" on the
-bottom arc, "ORGANIZER" pill) and rendered to PNG via `cairosvg`.
+`<slug>` is `make_badges.slugify(city name)` — e.g. "Mexico City" → `mexico_city`,
+"Delhi NCR" → `delhi_ncr`.
 
-Prereqs: the `gws` CLI must be installed and authenticated (see the user's
-`gws-cli-access` memory), and `cairosvg` must be importable
-(`python3 -m pip install cairosvg`, or run inside a venv that has it — the
-engine imports it lazily, only when actually generating a PNG, so a plan-only
-run needs neither Drive write access nor `cairosvg`).
+## The two badge styles
+
+- **`make_badges.py`** — a ring-and-arc badge in its own hand-picked orange/ink/
+  lilac palette and a system font stack (`Liberation Sans, DejaVu Sans`), rendered
+  to PNG via `cairosvg`. Self-contained (no `lib` import), per this repo's usual
+  skill-script convention. This was the original design and is deliberately kept
+  as-is — it does not pull from the AAIF design system.
+- **`make_agent_badge.py`** — draws from the real design system instead: Instrument
+  Sans embedded exactly as `report_style.font_css()` does for every HTML report,
+  ink/paper/hairline tokens, and the chapter's own **agent mascot**
+  (`agent_art.chapter_scene()` / `agent_art.agent()` — the same deterministic
+  per-chapter colour already used for that chapter's `Icons/` folder and decks, so
+  the badge and the chapter's other AAIF-generated art always agree). Rendered via
+  **headless Chrome** — DESIGN.md's one allowed SVG→PNG renderer — not `cairosvg`.
+  This intentionally takes the `lib/aaif_events` coupling AGENTS.md otherwise asks
+  skill scripts to avoid, for the same reason `restyle_design_system.py` does: the
+  whole point of this variant is to be provably on-system.
+
+Prereqs: the `gws` CLI installed and authenticated (see the user's
+`gws-cli-access` memory); `cairosvg` importable for style 1
+(`python3 -m pip install cairosvg`); a Chrome/Chromium install for style 2. Both
+are imported lazily (only when actually rendering a PNG), so a plan-only run
+needs neither Drive write access nor either renderer, and a chapter only missing
+one style's files never invokes the other style's renderer.
 
 ## Usage (engine: `scripts/sync_badges.py`)
 
@@ -53,8 +75,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py
 # Apply — create missing chapter subfolders and upload missing files:
 python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --write
 
-# Regenerate every file (after a design change to make_badges.py) and
-# overwrite what's already there:
+# Regenerate every file (after a design change) and overwrite what's already there:
 python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --write --regenerate
 
 # One chapter only (Drive chapter-folder name, case-insensitive substring):
@@ -67,18 +88,46 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --chapter "Mexico City" --wri
   folder, not a hardcoded list — a chapter created by `aaif-create-chapter`
   shows up here on the next run with no code change. `TemplateCity` (the
   clone source, not a real chapter) is excluded.
-- **Additive only.** A chapter subfolder or file already present is left
-  alone unless `--regenerate` is passed — badges are never deleted, and a
+- **Additive only.** A chapter's `Badges/` subfolder or file already present is
+  left alone unless `--regenerate` is passed — badges are never deleted, and a
   file that already exists is *updated in place* (same Drive file id), never
   duplicated.
-- **Badge folders with no matching chapter** (a chapter renamed or retired in
-  Drive after its badge folder was created) are reported as orphans and never
-  touched — deleting or renaming them is a manual call.
-- **Non-folder items** directly under the chapter-badges parent (stray files
-  like a `.DS_Store`) are reported and ignored.
 - A collision — two chapter folder names slugifying to the same value — aborts
   the whole run rather than silently dropping one of them; rename one of the
   chapters in Drive first.
+
+## Migrating from the old shared chapter-badges folder
+
+Badges used to live in one shared parent folder (`<parent>/<slug>/…`) instead
+of inside each chapter. `scripts/migrate_legacy_badges.py` moves files out of
+that old layout into the per-chapter `Badges/` folder this skill now targets —
+a Drive **reparent** (`addParents`/`removeParents`), not a re-upload, so file
+ids and revision history survive. Plan-only by default:
+
+```bash
+# Plan — nothing is moved:
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_legacy_badges.py
+
+# Apply the moves:
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_legacy_badges.py --write
+
+# Also trash (Drive trash, recoverable) a legacy folder left empty by the move:
+python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_legacy_badges.py --write --trash-empty
+```
+
+`--trash-empty` is resilient per folder: one folder's trash failing (e.g. a
+permissions mismatch on that specific folder) is reported and skipped, never
+lets an exception stop the rest from being cleaned up. On the first real run
+against the 89-chapter estate, 28 of 88 emptied legacy folders were trashed;
+the other 60 hit `insufficientFilePermissions` and were left in place —
+harmless (empty, all their files already safely moved) and can be deleted by
+hand in Drive by an owner, or re-run later if permissions change.
+
+A file already present at the destination (by name) is left alone and
+reported, never overwritten by the migration — run `sync_badges.py
+--regenerate` afterward if the content should also be refreshed. A legacy
+folder matching no canonical chapter (a renamed/retired chapter, or a stray
+item) is reported and never touched.
 
 ## Procedure
 
@@ -86,20 +135,21 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py --chapter "Mexico City" --wri
    ```bash
    python3 ${CLAUDE_SKILL_DIR}/scripts/sync_badges.py
    ```
-   Review the `+ create folder` / `upload` / `overwrite` lines, and any
-   reported orphans, before writing anything.
+   Review the `+ create folder` / `upload` / `overwrite` lines before writing
+   anything.
 2. **Apply** with `--write` once the plan looks right.
 3. New badges land as `image/svg+xml` and `image/png` files inside the
-   chapter's slug subfolder; re-running afterward reports "Up to date".
+   chapter's own `Badges/` subfolder; re-running afterward reports "Up to date".
 
 ## Notes
 
-- The generator (`make_badges.py`) is AAIF's badge-generation logic, kept
-  self-contained here rather than imported from `lib`, per this repo's usual
-  skill-script convention, so this skill still runs standalone.
 - Badges are built into a private `tempfile.mkdtemp()` directory that is
   deleted at the end of the run — nothing lands in the repo working tree, so
   there's no `.gitignore` entry to add.
-- To change the badge design (colours, layout, text), edit
-  `scripts/make_badges.py` directly, then run `--write --regenerate` to push
-  the new design to every chapter.
+- To change either badge design, edit the corresponding script
+  (`make_badges.py` or `make_agent_badge.py`) directly, then run `--write
+  --regenerate` to push the new design to every chapter.
+- Both chapter-name display strings that reach a generated SVG are
+  XML-escaped before use: the Drive folder name is organizer-editable
+  (any of a chapter's accepted organizers can rename their own chapter
+  folder), so this is untrusted input, not just untrusted-shaped text.

--- a/skills/aaif-sync-badges/SKILL.md
+++ b/skills/aaif-sync-badges/SKILL.md
@@ -116,12 +116,16 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/migrate_legacy_badges.py --write --trash-emp
 ```
 
 `--trash-empty` is resilient per folder: one folder's trash failing (e.g. a
-permissions mismatch on that specific folder) is reported and skipped, never
-lets an exception stop the rest from being cleaned up. On the first real run
-against the 89-chapter estate, 28 of 88 emptied legacy folders were trashed;
-the other 60 hit `insufficientFilePermissions` and were left in place —
-harmless (empty, all their files already safely moved) and can be deleted by
-hand in Drive by an owner, or re-run later if permissions change.
+Drive permissions mismatch on that specific folder — differing ownership or
+sharing from its siblings) is reported and skipped, never lets an exception
+stop the rest from being cleaned up. A folder that can't be trashed this way
+is harmless either way — it's already empty, and every file it held has
+already been safely moved — and can be deleted by hand in Drive by an owner,
+or re-run later if permissions change. If many folders in a row fail with the
+*same* error, the script stops instead of continuing to fail identically
+through every remaining folder — that pattern means something systemic (a
+stale `gws` credential, a broken API call), not a per-folder quirk, and is
+worth fixing before re-running rather than working around.
 
 A file already present at the destination (by name) is left alone and
 reported, never overwritten by the migration — run `sync_badges.py

--- a/skills/aaif-sync-badges/scripts/make_agent_badge.py
+++ b/skills/aaif-sync-badges/scripts/make_agent_badge.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""AAIF chapter organizer badge — design-system variant.
+
+Unlike make_badges.py (a self-contained, hand-tuned palette), this generator
+draws from the actual AAIF design system: `report_style.font_css()` embeds
+the real Instrument Sans, and each chapter's mascot comes from
+`agent_art.chapter_scene()` / `agent_art.agent()` -- the same deterministic
+per-chapter colour already used for chapter Icons/ folders and decks, so a
+chapter's badge and its other AAIF-generated art always agree.
+
+This intentionally takes the `lib/aaif_events` coupling that AGENTS.md
+otherwise asks skill scripts to avoid (see its "Architecture" section): the
+whole point of this variant is to be provably on-system, which means calling
+the system's own renderer and mascot generator rather than re-implementing
+either. `skills/aaif-create-chapter/scripts/restyle_design_system.py` takes
+the same trade-off for the same reason.
+
+Rendered via headless Chrome (the repo's one allowed SVG->PNG renderer -- see
+DESIGN.md), so a Chrome/Chromium install is required; make_badges.py's
+`cairosvg` route has no such requirement.
+
+Usage:
+    python make_agent_badge.py OUTDIR "Mexico City" "Dublin"
+    python make_agent_badge.py OUTDIR --slug delhi_ncr "Delhi NCR"
+
+Produces, per chapter, in OUTDIR/<slug>/ :
+    organizer_badge_<slug>_agent.svg
+    organizer_badge_<slug>_agent_1000.png
+"""
+import os, re, sys, unicodedata
+from xml.sax.saxutils import escape as _xml_escape
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))))), "lib"))
+from aaif_events import agent_art, report_style  # noqa: E402
+
+INK = "#0A0A0A"
+INK_3 = "#4A4A4A"
+PAPER = "#FFFFFF"
+LINE_2 = "#CFCFC9"
+
+
+def slugify(name):
+    s = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", s).strip("_").lower()
+    return s
+
+
+def _svg(city, chapter_name):
+    """One badge: chapter name on the top arc, the chapter's own agent mascot
+    (deterministic colour/action/mirroring from agent_art.chapter_scene), the
+    AAIF wordmark, and an ORGANIZER pill -- all in real design-system tokens."""
+    spec, secondary, action, ridge, mirrored = agent_art.chapter_scene(chapter_name)
+    asz = 300
+    ax, ay = 500 - asz / 2, 330
+    art = agent_art.agent(ax, ay, asz, spec=spec)
+    if mirrored:
+        art = f'<g transform="translate(1000,0) scale(-1,1)">{art}</g>'
+    accent = agent_art.hue(secondary)
+    city = _xml_escape(city)
+
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="1000" viewBox="0 0 1000 1000">
+<style>{report_style.font_css()}</style>
+<circle cx="500" cy="500" r="480" fill="{PAPER}"/>
+<circle cx="500" cy="500" r="460" fill="none" stroke="{LINE_2}" stroke-width="2"/>
+<path id="tp" d="M 160,500 A 340,340 0 0 1 840,500" fill="none"/>
+<text font-family="Instrument Sans" font-weight="600" font-size="46" letter-spacing="6"
+      fill="{INK}"><textPath href="#tp" startOffset="50%" text-anchor="middle">{city}</textPath></text>
+{art}
+<circle cx="500" cy="675" r="4" fill="{accent}"/>
+<text x="500" y="720" font-family="Instrument Sans" font-weight="500" font-size="26"
+      letter-spacing="5" text-anchor="middle" fill="{INK_3}">AGENTIC AI FOUNDATION</text>
+<rect x="368" y="752" width="264" height="60" rx="30" fill="{INK}"/>
+<text x="500" y="791" font-family="Instrument Sans" font-weight="600" font-size="26"
+      letter-spacing="4" text-anchor="middle" fill="{PAPER}">ORGANIZER</text>
+</svg>'''
+
+
+def build(name, outroot, slug=None):
+    slug = slug or slugify(name)
+    city = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode().upper()
+    d = os.path.join(outroot, slug)
+    os.makedirs(d, exist_ok=True)
+    svg = _svg(city, name)
+    sp = os.path.join(d, f"organizer_badge_{slug}_agent.svg")
+    with open(sp, "w") as f:
+        f.write(svg)
+    pp = os.path.join(d, f"organizer_badge_{slug}_agent_1000.png")
+    agent_art.render_png(svg, pp, (1000, 1000), ground=PAPER)
+    return slug, [sp, pp]
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__); sys.exit(1)
+    outroot, rest = args[0], args[1:]
+    override = None
+    names = []
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--slug":
+            if i + 1 >= len(rest):
+                print("--slug requires a value"); sys.exit(1)
+            override = rest[i + 1]; i += 2
+        else:
+            names.append(rest[i]); i += 1
+    for n in names:
+        slug, made = build(n, outroot, override)
+        override = None
+        print(f"{n} -> {slug}/  ({len(made)} files)")

--- a/skills/aaif-sync-badges/scripts/make_agent_badge.py
+++ b/skills/aaif-sync-badges/scripts/make_agent_badge.py
@@ -27,23 +27,29 @@ Produces, per chapter, in OUTDIR/<slug>/ :
     organizer_badge_<slug>_agent.svg
     organizer_badge_<slug>_agent_1000.png
 """
-import os, re, sys, unicodedata
+import os, sys, unicodedata
 from xml.sax.saxutils import escape as _xml_escape
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import make_badges  # noqa: E402 -- reuse its slugify; this module already
+                     # gave up standalone-zip portability below, so a second
+                     # copy of the same one-liner would only drift, not help.
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.dirname(os.path.abspath(__file__))))), "lib"))
 from aaif_events import agent_art, report_style  # noqa: E402
+from aaif_events.ooxml_style import token  # noqa: E402
 
-INK = "#0A0A0A"
-INK_3 = "#4A4A4A"
-PAPER = "#FFFFFF"
-LINE_2 = "#CFCFC9"
+# Read straight from the design system rather than copying hex values here --
+# a hardcoded copy is exactly the drift this variant exists to avoid (see
+# module docstring). ink()/paper() are agent_art's own equivalent read.
+INK = agent_art.ink()
+INK_3 = "#" + token("ink-3")
+PAPER = agent_art.paper()
+LINE_2 = "#" + token("line-2")
+FONTS = "Instrument Sans, ui-sans-serif, sans-serif"
 
-
-def slugify(name):
-    s = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
-    s = re.sub(r"[^a-zA-Z0-9]+", "_", s).strip("_").lower()
-    return s
+slugify = make_badges.slugify
 
 
 def _svg(city, chapter_name):
@@ -64,14 +70,14 @@ def _svg(city, chapter_name):
 <circle cx="500" cy="500" r="480" fill="{PAPER}"/>
 <circle cx="500" cy="500" r="460" fill="none" stroke="{LINE_2}" stroke-width="2"/>
 <path id="tp" d="M 160,500 A 340,340 0 0 1 840,500" fill="none"/>
-<text font-family="Instrument Sans" font-weight="600" font-size="46" letter-spacing="6"
+<text font-family="{FONTS}" font-weight="600" font-size="46" letter-spacing="6"
       fill="{INK}"><textPath href="#tp" startOffset="50%" text-anchor="middle">{city}</textPath></text>
 {art}
 <circle cx="500" cy="675" r="4" fill="{accent}"/>
-<text x="500" y="720" font-family="Instrument Sans" font-weight="500" font-size="26"
+<text x="500" y="720" font-family="{FONTS}" font-weight="500" font-size="26"
       letter-spacing="5" text-anchor="middle" fill="{INK_3}">AGENTIC AI FOUNDATION</text>
 <rect x="368" y="752" width="264" height="60" rx="30" fill="{INK}"/>
-<text x="500" y="791" font-family="Instrument Sans" font-weight="600" font-size="26"
+<text x="500" y="791" font-family="{FONTS}" font-weight="600" font-size="26"
       letter-spacing="4" text-anchor="middle" fill="{PAPER}">ORGANIZER</text>
 </svg>'''
 

--- a/skills/aaif-sync-badges/scripts/migrate_legacy_badges.py
+++ b/skills/aaif-sync-badges/scripts/migrate_legacy_badges.py
@@ -34,9 +34,23 @@ LEGACY_BADGES_PARENT = "1ViKjLZh-4KrMBVihOGQyAL2SVsXcI3B9"  # the old chapter-ba
 
 
 def move_file(file_id, new_parent, old_parent):
-    sb.gws_json("drive", "files", "update",
-                params={"fileId": file_id, "addParents": new_parent,
-                        "removeParents": old_parent, "supportsAllDrives": True})
+    """Reparent one file, and verify Drive actually applied BOTH halves.
+
+    Drive does not guarantee addParents/removeParents apply atomically together
+    -- a caller can have permission to add the new parent but not to detach the
+    old one. A response that gws returned as a normal 200 could still leave the
+    file in both folders; without checking `parents` that half-applied state
+    would print as a clean "moved" and later be missed by the --trash-empty
+    safety check for the wrong reason (folder "still has files" with no
+    explanation why)."""
+    resp = sb.gws_json("drive", "files", "update",
+                        params={"fileId": file_id, "addParents": new_parent,
+                                "removeParents": old_parent, "supportsAllDrives": True,
+                                "fields": "id,parents"})
+    parents = resp.get("parents") or []
+    if new_parent not in parents or old_parent in parents:
+        raise RuntimeError(f"reparent for file {file_id} did not fully apply "
+                            f"(expected only {new_parent!r}, got parents={parents})")
 
 
 def trash_folder(folder_id):
@@ -51,7 +65,9 @@ def plan_legacy_folders(chapters):
     - all_legacy_folders: {slug: folder_id} -- every legacy folder matching a chapter,
       including ones already emptied by a prior run (needed so --trash-empty has
       something to act on even when there is nothing left to migrate)
-    - orphans: [(name, [file names])] for slugs with no matching chapter
+    - orphans: [(name, [file names])] for slugs with no matching chapter AND
+      at least one file -- an empty folder matching no chapter has nothing to
+      report or act on, so it is silently skipped rather than listed here
     """
     legacy_with_files = {}
     all_legacy_folders = {}
@@ -114,35 +130,72 @@ def main():
     moved = 0
     for chapter_name, slug, legacy_folder_id, f, dest_id in moves:
         if slug not in dest_cache:
+            if dest_id is None:
+                # Re-check right before creating rather than trusting the plan
+                # snapshot unconditionally: on a long batch, a concurrent run
+                # (another migration invocation, or sync_badges.py --write
+                # racing to create this chapter's first badge folder) could
+                # have created Badges/ since the plan was made. create_folder
+                # is non-idempotent (see sync_badges._gws's retries=1 note),
+                # so creating a second one here would go undetected.
+                dest_id = sb.find_badges_subfolder(chapters[slug]["folder_id"])
             dest_cache[slug] = dest_id or sb.create_folder(sb.BADGES_SUBFOLDER, chapters[slug]["folder_id"])
             if dest_id is None:
                 print(f"created folder {chapter_name}/{sb.BADGES_SUBFOLDER}/ -> {dest_cache[slug]}")
-        move_file(f["id"], dest_cache[slug], legacy_folder_id)
+        try:
+            move_file(f["id"], dest_cache[slug], legacy_folder_id)
+        except RuntimeError as e:
+            # Re-run is safe (idempotent: already-moved files are re-detected
+            # as "already present" and skipped), so surface exactly which
+            # move to investigate rather than a bare stack trace out of gws.
+            raise RuntimeError(
+                f"failed moving {f['name']!r} for chapter {chapter_name!r} "
+                f"(slug={slug!r}) after {moved} successful move(s) this run: {e}") from e
         print(f"  moved    {chapter_name}/{sb.BADGES_SUBFOLDER}/{f['name']}")
         moved += 1
     if moves:
         print(f"\nMoved {moved} file(s).")
 
     if a.trash_empty:
-        trashed, failed = 0, []
+        # A run of failures sharing the SAME error message points at something
+        # systemic (a stale gws credential, a broken API call) rather than
+        # per-folder permission differences -- stop instead of silently
+        # burning through every remaining folder with a guaranteed failure.
+        CONSECUTIVE_FAILURE_LIMIT = 5
+        trashed, failed, consecutive_same = 0, [], []
         for slug, folder_id in sorted(all_legacy_folders.items()):
-            if sb.list_children(folder_id):
-                continue  # still has files -- not this run's business
+            remaining = sb.list_children(folder_id)
+            if remaining:
+                print(f"  left in place  {slug}/  (still has {len(remaining)} file(s): "
+                      f"{[c['name'] for c in remaining]})")
+                continue
             try:
                 trash_folder(folder_id)
             except RuntimeError as e:
-                # One folder's permissions (owned/shared differently than its
-                # siblings) must not stop the rest from being cleaned up --
-                # the files were already safely moved regardless of this step.
-                failed.append((slug, str(e)))
+                err = str(e).splitlines()[0]
+                failed.append((slug, err))
+                if consecutive_same and consecutive_same[-1] == err:
+                    consecutive_same.append(err)
+                else:
+                    consecutive_same = [err]
+                if len(consecutive_same) >= CONSECUTIVE_FAILURE_LIMIT:
+                    print(f"\nABORTING trash-empty: {len(consecutive_same)} consecutive "
+                          f"folders failed with the identical error -- this looks like a "
+                          f"systemic gws/credential problem, not a per-folder permission "
+                          f"quirk. Fix the underlying issue and re-run rather than "
+                          f"continuing through folders certain to fail the same way.")
+                    print(f"Repeated error: {err}")
+                    break
                 continue
+            consecutive_same = []
             print(f"trashed empty legacy folder: {slug}/")
             trashed += 1
         print(f"\nTrashed {trashed} now-empty legacy folder(s).")
         if failed:
-            print(f"Could not trash {len(failed)} folder(s) (left in place, harmless):")
+            print(f"Could not trash {len(failed)} folder(s) -- files already safely "
+                  f"moved regardless, so these are left in place, not lost:")
             for slug, err in failed:
-                print(f"  {slug}/: {err.splitlines()[0]}")
+                print(f"  {slug}/: {err}")
 
 
 if __name__ == "__main__":

--- a/skills/aaif-sync-badges/scripts/migrate_legacy_badges.py
+++ b/skills/aaif-sync-badges/scripts/migrate_legacy_badges.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""One-time migration: move badges out of the old shared chapter-badges
+folder and into each chapter's own `Badges/` subfolder (see sync_badges.py).
+
+For each `<slug>/` subfolder under the legacy parent, this MOVES (Drive
+reparent -- addParents/removeParents; no re-upload, no lost revision history)
+every file into the matching chapter's `Badges/` subfolder, creating that
+subfolder if it doesn't exist yet. A file already present at the destination
+(by name) is left alone and reported, never overwritten here -- re-run
+sync_badges.py --regenerate afterward if you also want content refreshed.
+
+Once a legacy slug folder is fully emptied by the move, it can optionally be
+trashed (Drive trash, not permanent delete) with --trash-empty.
+
+A legacy slug folder that matches no canonical chapter (renamed/retired chapter,
+or a stray item) is reported and never touched -- resolve those by hand.
+
+Usage:
+    # Plan (default) -- nothing is moved:
+    python migrate_legacy_badges.py
+
+    # Apply the moves:
+    python migrate_legacy_badges.py --write
+
+    # Also trash (Drive trash, recoverable) legacy folders left empty by the move:
+    python migrate_legacy_badges.py --write --trash-empty
+"""
+import argparse, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sync_badges as sb  # noqa: E402
+
+LEGACY_BADGES_PARENT = "1ViKjLZh-4KrMBVihOGQyAL2SVsXcI3B9"  # the old chapter-badges Drive folder
+
+
+def move_file(file_id, new_parent, old_parent):
+    sb.gws_json("drive", "files", "update",
+                params={"fileId": file_id, "addParents": new_parent,
+                        "removeParents": old_parent, "supportsAllDrives": True})
+
+
+def trash_folder(folder_id):
+    sb.gws_json("drive", "files", "update",
+                params={"fileId": folder_id, "supportsAllDrives": True},
+                body={"trashed": True})
+
+
+def plan_legacy_folders(chapters):
+    """Returns (legacy_with_files, all_legacy_folders, orphans):
+    - legacy_with_files: {slug: {"id", "files"}} -- only folders with something to move
+    - all_legacy_folders: {slug: folder_id} -- every legacy folder matching a chapter,
+      including ones already emptied by a prior run (needed so --trash-empty has
+      something to act on even when there is nothing left to migrate)
+    - orphans: [(name, [file names])] for slugs with no matching chapter
+    """
+    legacy_with_files = {}
+    all_legacy_folders = {}
+    orphans = []
+    for f in sb.list_children(LEGACY_BADGES_PARENT):
+        if f["mimeType"] != sb.FOLDER:
+            continue  # e.g. a stray .DS_Store -- not this script's business
+        files = sb.list_children(f["id"])
+        if f["name"] not in chapters:
+            if files:
+                orphans.append((f["name"], [c["name"] for c in files]))
+            continue
+        all_legacy_folders[f["name"]] = f["id"]
+        if files:
+            legacy_with_files[f["name"]] = {"id": f["id"], "files": files}
+    return legacy_with_files, all_legacy_folders, orphans
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--write", action="store_true", help="LIVE WRITE: move files. Without it this only plans.")
+    ap.add_argument("--trash-empty", action="store_true",
+                     help="Also trash (Drive trash, recoverable) a legacy folder left empty by the move")
+    a = ap.parse_args()
+    if a.trash_empty and not a.write:
+        sys.exit("ABORT: --trash-empty only applies together with --write.")
+
+    chapters = sb.canonical_chapters()
+    legacy, all_legacy_folders, orphans = plan_legacy_folders(chapters)
+
+    print(f"Legacy chapter folders with files to move: {len(legacy)}")
+    if orphans:
+        print(f"Legacy folders with no matching chapter (left alone): "
+              f"{[name for name, _ in orphans]}")
+    print()
+
+    moves = []  # (chapter_name, slug, legacy_folder_id, file, dest_folder_id_or_None)
+    if not legacy:
+        print("Nothing to migrate.")
+    else:
+        for slug, entry in sorted(legacy.items()):
+            chapter = chapters[slug]
+            dest_id = sb.find_badges_subfolder(chapter["folder_id"])
+            existing_names = {c["name"] for c in sb.list_children(dest_id)} if dest_id else set()
+            for f in entry["files"]:
+                if f["name"] in existing_names:
+                    print(f"  skip     {chapter['name']}/Badges/{f['name']}  (already present)")
+                    continue
+                moves.append((chapter["name"], slug, entry["id"], f, dest_id))
+                verb = "move" if dest_id else "move (creates Badges/)"
+                print(f"  {verb:<22} {chapter['name']}/{sb.BADGES_SUBFOLDER}/{f['name']}")
+
+    if not a.write:
+        if moves:
+            print("\nPlan only -- re-run with --write to move.")
+        return
+
+    dest_cache = {}  # slug -> resolved Badges folder id, created at most once per chapter
+    moved = 0
+    for chapter_name, slug, legacy_folder_id, f, dest_id in moves:
+        if slug not in dest_cache:
+            dest_cache[slug] = dest_id or sb.create_folder(sb.BADGES_SUBFOLDER, chapters[slug]["folder_id"])
+            if dest_id is None:
+                print(f"created folder {chapter_name}/{sb.BADGES_SUBFOLDER}/ -> {dest_cache[slug]}")
+        move_file(f["id"], dest_cache[slug], legacy_folder_id)
+        print(f"  moved    {chapter_name}/{sb.BADGES_SUBFOLDER}/{f['name']}")
+        moved += 1
+    if moves:
+        print(f"\nMoved {moved} file(s).")
+
+    if a.trash_empty:
+        trashed, failed = 0, []
+        for slug, folder_id in sorted(all_legacy_folders.items()):
+            if sb.list_children(folder_id):
+                continue  # still has files -- not this run's business
+            try:
+                trash_folder(folder_id)
+            except RuntimeError as e:
+                # One folder's permissions (owned/shared differently than its
+                # siblings) must not stop the rest from being cleaned up --
+                # the files were already safely moved regardless of this step.
+                failed.append((slug, str(e)))
+                continue
+            print(f"trashed empty legacy folder: {slug}/")
+            trashed += 1
+        print(f"\nTrashed {trashed} now-empty legacy folder(s).")
+        if failed:
+            print(f"Could not trash {len(failed)} folder(s) (left in place, harmless):")
+            for slug, err in failed:
+                print(f"  {slug}/: {err.splitlines()[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/aaif-sync-badges/scripts/sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/sync_badges.py
@@ -48,6 +48,13 @@ STYLES = (
     (make_badges, ("colour.svg", "white.svg", "colour_1000.png", "white_1000.png")),
     (make_agent_badge, ("agent.svg", "agent_1000.png")),
 )
+# styles_needed_for() matches filenames by suffix across ALL styles at once --
+# a future style whose suffixes overlap another's would make it silently
+# select the wrong module. Assert that stays impossible rather than relying on
+# every future editor to notice.
+assert len({s for _module, suffixes in STYLES for s in suffixes}) == \
+    sum(len(suffixes) for _module, suffixes in STYLES), \
+    "STYLES suffixes must be disjoint across styles -- see styles_needed_for()"
 
 
 def _scrubbed_env():
@@ -250,6 +257,8 @@ def main():
         print(f"+ create folder  {name}/{BADGES_SUBFOLDER}/")
     for slug, (folder_id, files) in sorted(files_to_upload.items()):
         name = chapters[slug]["name"]
+        # Per-file, not per-chapter: under --regenerate a partially-complete
+        # folder still has files that were never there to "overwrite".
         existing_names = {c["name"] for c in children_by_slug.get(slug, [])}
         for fn in files:
             verb = "overwrite" if fn in existing_names else "upload"

--- a/skills/aaif-sync-badges/scripts/sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/sync_badges.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Sync AAIF organizer badges (SVG + PNG) to the chapter-badges Drive folder.
+"""Sync AAIF organizer badges (SVG + PNG) into each chapter's own Drive folder.
 
 Reads the canonical chapter list from the "Chapters" Drive folder, generates
-each chapter's 4 badge files (colour/white SVG + their 1000px PNG renders)
-with make_badges.py, and uploads whatever the chapter-badges folder is
-missing. Existing files are left untouched unless --regenerate is passed.
+each chapter's badge files -- 4 from make_badges.py (colour/white ring badge)
+plus 2 from make_agent_badge.py (the chapter's own agent mascot, in the real
+AAIF design-system tokens) -- and uploads whatever that chapter's own
+`Badges/` subfolder is missing. Existing files are left untouched unless
+--regenerate is passed.
+
+Chapters that still have badges under the old shared chapter-badges parent
+folder (pre per-chapter layout) are not touched here -- see
+migrate_legacy_badges.py.
 
 Usage:
     # Plan (default) -- nothing is created/uploaded, just reported:
@@ -22,15 +28,26 @@ Usage:
 import argparse, json, os, shutil, subprocess, sys, tempfile, time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import make_badges  # noqa: E402
+import make_agent_badge, make_badges  # noqa: E402
 
 CHAPTERS_PARENT = "1IQ1K7aVOKUUkxAcfLuNjdETEnmavvtjx"   # the "Chapters" Drive folder
-BADGES_PARENT = "1ViKjLZh-4KrMBVihOGQyAL2SVsXcI3B9"      # the chapter-badges Drive folder
+BADGES_SUBFOLDER = "Badges"                              # per-chapter subfolder name
 FOLDER = "application/vnd.google-apps.folder"
 # Not a real chapter -- the clone source create_chapter.py rebrands from.
 NOT_A_CHAPTER = {"templatecity"}
 
 MIME_BY_EXT = {".svg": "image/svg+xml", ".png": "image/png"}
+
+# Each badge style: its generator MODULE (looked up as module.build(name,
+# outroot, slug) at call time, not bound to the function object here, so a
+# style's generator can still be mocked/swapped after import) and the
+# filename suffixes it produces (organizer_badge_<slug>_<suffix>). Keeping
+# them apart means a chapter only missing an agent-style file doesn't need
+# make_badges' cairosvg dependency invoked, and vice versa.
+STYLES = (
+    (make_badges, ("colour.svg", "white.svg", "colour_1000.png", "white_1000.png")),
+    (make_agent_badge, ("agent.svg", "agent_1000.png")),
+)
 
 
 def _scrubbed_env():
@@ -129,9 +146,10 @@ def upload_update(file_id, local_path):
 # --- planning ----------------------------------------------------------------
 
 def canonical_chapters():
-    """{slug: display name} for every real chapter folder, keyed by
-    make_badges.slugify -- the same slug convention the badges folder already
-    uses (e.g. "Delhi NCR" -> "delhi_ncr", "Mexico City" -> "mexico_city")."""
+    """{slug: {"name": display name, "folder_id": Drive folder id}} for every
+    real chapter folder, keyed by make_badges.slugify -- the same slug
+    convention every generated filename uses (e.g. "Delhi NCR" -> "delhi_ncr",
+    "Mexico City" -> "mexico_city")."""
     chapters = {}
     collisions = {}
     for f in list_children(CHAPTERS_PARENT):
@@ -140,9 +158,9 @@ def canonical_chapters():
         if f["name"].strip().lower() in NOT_A_CHAPTER:
             continue
         slug = make_badges.slugify(f["name"])
-        if slug in chapters and chapters[slug] != f["name"]:
-            collisions.setdefault(slug, {chapters[slug]}).add(f["name"])
-        chapters[slug] = f["name"]
+        if slug in chapters and chapters[slug]["name"] != f["name"]:
+            collisions.setdefault(slug, {chapters[slug]["name"]}).add(f["name"])
+        chapters[slug] = {"name": f["name"], "folder_id": f["id"]}
     if collisions:
         raise SystemExit("ABORT: chapter names collide on the same badge slug: %s"
                           % ", ".join("%s -> %s" % (s, sorted(names))
@@ -150,30 +168,43 @@ def canonical_chapters():
     return chapters
 
 
+def find_badges_subfolder(chapter_folder_id):
+    """The chapter's own `Badges/` subfolder id, or None if it doesn't exist yet."""
+    for f in list_children(chapter_folder_id):
+        if f["mimeType"] == FOLDER and f["name"] == BADGES_SUBFOLDER:
+            return f["id"]
+    return None
+
+
 def needed_filenames(slug):
-    return [f"organizer_badge_{slug}_colour.svg", f"organizer_badge_{slug}_white.svg",
-            f"organizer_badge_{slug}_colour_1000.png", f"organizer_badge_{slug}_white_1000.png"]
+    return [f"organizer_badge_{slug}_{suffix}" for _builder, suffixes in STYLES for suffix in suffixes]
 
 
-def plan(chapters, badge_folders, children_by_slug, regenerate):
+def styles_needed_for(files):
+    """Which STYLES entries must run to produce every filename in `files`."""
+    return [(module, suffixes) for module, suffixes in STYLES
+            if any(fn.endswith(suffix) for fn in files for suffix in suffixes)]
+
+
+def plan(chapters, badges_folders, children_by_slug, regenerate):
     """Returns (folders_to_create: {slug: name}, files_to_upload: {slug: (folder_id_or_None, [filenames])}).
 
     `children_by_slug` must already hold an entry for every slug in `chapters`
-    that also has a matching `badge_folders` entry -- membership in it (not an
-    optional key on `badge_folders`) is what means "already fetched"."""
+    that also has a matching `badges_folders` entry -- membership in it (not an
+    optional key on `badges_folders`) is what means "already fetched"."""
     folders_to_create = {}
     files_to_upload = {}
-    for slug, name in sorted(chapters.items()):
-        folder = badge_folders.get(slug)
+    for slug, name in sorted((s, c["name"]) for s, c in chapters.items()):
+        folder_id = badges_folders.get(slug)
         need = needed_filenames(slug)
-        if folder is None:
+        if folder_id is None:
             folders_to_create[slug] = name
             files_to_upload[slug] = (None, need)
             continue
         existing_names = {c["name"] for c in children_by_slug[slug]}
         missing = need if regenerate else [n for n in need if n not in existing_names]
         if missing:
-            files_to_upload[slug] = (folder["id"], missing)
+            files_to_upload[slug] = (folder_id, missing)
     return folders_to_create, files_to_upload
 
 
@@ -184,8 +215,8 @@ def main():
                      help="LIVE WRITE: create folders/upload files. Without it this only plans.")
     ap.add_argument("--regenerate", action="store_true",
                      help="Re-generate and overwrite every existing badge file too "
-                          "(use after a design change to make_badges.py). Requires --write "
-                          "to actually overwrite; harmless to pass without it (just widens the plan).")
+                          "(use after a design change). Requires --write to actually "
+                          "overwrite; harmless to pass without it (just widens the plan).")
     ap.add_argument("--chapter", help="Only sync one chapter (Drive folder name, case-insensitive substring match)")
     a = ap.parse_args()
 
@@ -193,40 +224,22 @@ def main():
     chapters = all_chapters
     if a.chapter:
         needle = a.chapter.strip().lower()
-        chapters = {s: n for s, n in all_chapters.items() if needle in n.lower()}
+        chapters = {s: c for s, c in all_chapters.items() if needle in c["name"].lower()}
         if not chapters:
             sys.exit(f"ABORT: no chapter folder matches {a.chapter!r}")
 
-    raw_badge_children = list_children(BADGES_PARENT)
-    badge_folders = {}
-    stray_files = []
-    for f in raw_badge_children:
-        if f["mimeType"] != FOLDER:
-            stray_files.append(f["name"])
-            continue
-        badge_folders[f["name"]] = {"id": f["id"]}
-    # Fetch each folder's contents only for slugs actually in scope (the
-    # --chapter filter, or every chapter on a full run) -- an orphan folder,
-    # or any folder outside a --chapter filter, needs its NAME (already known
-    # from the listing above) but never its children. Presence as a KEY in
-    # children_by_slug (not an optional field on badge_folders) is what means
-    # "already fetched" -- see plan()'s docstring.
-    children_by_slug = {slug: list_children(badge_folders[slug]["id"])
-                         for slug in chapters if slug in badge_folders}
+    badges_folders = {}       # slug -> Badges subfolder id (only where it exists)
+    children_by_slug = {}     # slug -> that subfolder's children (only where fetched)
+    for slug, chapter in chapters.items():
+        folder_id = find_badges_subfolder(chapter["folder_id"])
+        if folder_id is not None:
+            badges_folders[slug] = folder_id
+            children_by_slug[slug] = list_children(folder_id)
 
-    # Orphans are judged against the FULL canonical set, never the --chapter
-    # filter -- otherwise every other real chapter's folder would misreport as
-    # having "no matching chapter" just because it wasn't the one asked for.
-    orphans = sorted(n for n in badge_folders if n not in all_chapters)
-
-    folders_to_create, files_to_upload = plan(chapters, badge_folders, children_by_slug, a.regenerate)
+    folders_to_create, files_to_upload = plan(chapters, badges_folders, children_by_slug, a.regenerate)
 
     print(f"Chapters (canonical): {len(chapters)}")
-    print(f"Badge folders present: {len(badge_folders)}")
-    if stray_files:
-        print(f"Stray non-folder items in badges parent (ignored): {stray_files}")
-    if orphans:
-        print(f"Badge folders with no matching chapter (left alone): {orphans}")
+    print(f"Chapters with a {BADGES_SUBFOLDER}/ subfolder already: {len(badges_folders)}")
     print()
 
     if not folders_to_create and not files_to_upload:
@@ -234,14 +247,13 @@ def main():
         return
 
     for slug, name in sorted(folders_to_create.items()):
-        print(f"+ create folder  {slug}/   ({name})")
+        print(f"+ create folder  {name}/{BADGES_SUBFOLDER}/")
     for slug, (folder_id, files) in sorted(files_to_upload.items()):
-        # Per-file, not per-chapter: under --regenerate a partially-complete
-        # folder still has files that were never there to "overwrite".
+        name = chapters[slug]["name"]
         existing_names = {c["name"] for c in children_by_slug.get(slug, [])}
         for fn in files:
             verb = "overwrite" if fn in existing_names else "upload"
-            print(f"  {verb:<9} {slug}/{fn}")
+            print(f"  {verb:<9} {name}/{BADGES_SUBFOLDER}/{fn}")
 
     if not a.write:
         print("\nPlan only -- re-run with --write to create/upload.")
@@ -251,25 +263,24 @@ def main():
     try:
         total = 0
         for slug, (folder_id, files) in sorted(files_to_upload.items()):
-            name = chapters[slug]
+            name = chapters[slug]["name"]
             if slug in folders_to_create:
-                # Folder name is the SLUG, matching every existing badge folder
-                # (e.g. "mexico_city", not the chapter's display name).
-                folder_id = create_folder(slug, BADGES_PARENT)
-                print(f"created folder {slug}/ -> {folder_id}")
+                folder_id = create_folder(BADGES_SUBFOLDER, chapters[slug]["folder_id"])
+                print(f"created folder {name}/{BADGES_SUBFOLDER}/ -> {folder_id}")
                 existing_by_name = {}
             else:
                 existing_by_name = {c["name"]: c["id"] for c in children_by_slug[slug]}
-            make_badges.build(name, tmp, slug)
+            for module, _suffixes in styles_needed_for(files):
+                module.build(name, tmp, slug)
             for fn in files:
                 local_path = os.path.join(tmp, slug, fn)
                 existing_id = existing_by_name.get(fn)
                 if existing_id:
                     upload_update(existing_id, local_path)
-                    print(f"  updated  {slug}/{fn}")
+                    print(f"  updated  {name}/{BADGES_SUBFOLDER}/{fn}")
                 else:
                     upload_new(fn, folder_id, local_path)
-                    print(f"  uploaded {slug}/{fn}")
+                    print(f"  uploaded {name}/{BADGES_SUBFOLDER}/{fn}")
                 total += 1
         print(f"\nDone. {total} file(s) written.")
     finally:

--- a/skills/aaif-sync-badges/scripts/test_make_agent_badge.py
+++ b/skills/aaif-sync-badges/scripts/test_make_agent_badge.py
@@ -10,9 +10,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
 import make_agent_badge  # noqa: E402
 from aaif_events.report_style import find_chrome  # noqa: E402
 
-# CI installs neither Chrome nor cairosvg (see .github/workflows/validate.yml)
-# -- this generator's PNG step needs headless Chrome (DESIGN.md's one allowed
-# renderer), so tests that call build() must skip gracefully where it's absent.
+# CI's pytest job installs no browser or cairosvg -- this generator's PNG step
+# needs headless Chrome (DESIGN.md's one allowed renderer), so tests that call
+# build() must skip gracefully where it's absent.
 HAS_CHROME = bool(find_chrome())
 
 
@@ -42,8 +42,13 @@ class TestSvgContent(unittest.TestCase):
     def test_escapes_untrusted_chapter_names(self):
         # The chapter display name comes from a live Drive folder any of its
         # organizers can rename -- mirrors make_badges.py's escaping fix.
-        svg = make_agent_badge._svg("R&amp;D", "R&D")
-        xml.dom.minidom.parseString(svg)
+        # Raw, UNescaped input: "R&amp;D" alone would be vacuous here, since
+        # a literal "&amp;" already reads as valid XML whether or not the
+        # escaping code runs at all.
+        svg = make_agent_badge._svg('R&D <VILLE>', 'R&D <VILLE>')
+        xml.dom.minidom.parseString(svg)  # raises if not well-formed
+        self.assertIn("R&amp;D &lt;VILLE&gt;", svg)
+        self.assertNotIn("R&D <VILLE>", svg)
 
 
 @unittest.skipUnless(HAS_CHROME, "headless Chrome not installed")

--- a/skills/aaif-sync-badges/scripts/test_make_agent_badge.py
+++ b/skills/aaif-sync-badges/scripts/test_make_agent_badge.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import tempfile
+import unittest
+import xml.dom.minidom
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))))), "lib"))
+import make_agent_badge  # noqa: E402
+from aaif_events.report_style import find_chrome  # noqa: E402
+
+# CI installs neither Chrome nor cairosvg (see .github/workflows/validate.yml)
+# -- this generator's PNG step needs headless Chrome (DESIGN.md's one allowed
+# renderer), so tests that call build() must skip gracefully where it's absent.
+HAS_CHROME = bool(find_chrome())
+
+
+class TestSlugify(unittest.TestCase):
+    def test_matches_make_badges_slugify(self):
+        # Both generators are invoked with the SAME slug by sync_badges.py, but
+        # each also has its own standalone CLI -- they must stay in agreement.
+        sys.path.insert(0, os.path.dirname(__file__))
+        import make_badges
+        for name in ("Mexico City", "Delhi NCR", "Washington DC", "Montréal"):
+            self.assertEqual(make_agent_badge.slugify(name), make_badges.slugify(name))
+
+
+class TestSvgContent(unittest.TestCase):
+    def test_well_formed_and_shows_city_name(self):
+        svg = make_agent_badge._svg("DUBLIN", "Dublin")
+        xml.dom.minidom.parseString(svg)  # raises if not well-formed
+        self.assertIn(">DUBLIN<", svg)
+
+    def test_deterministic_per_chapter_colour(self):
+        # Same chapter name -> same mascot colour every run (agent_art.chapter_scene
+        # hashes the name), so re-running the sync doesn't flap between colours.
+        svg1 = make_agent_badge._svg("DUBLIN", "Dublin")
+        svg2 = make_agent_badge._svg("DUBLIN", "Dublin")
+        self.assertEqual(svg1, svg2)
+
+    def test_escapes_untrusted_chapter_names(self):
+        # The chapter display name comes from a live Drive folder any of its
+        # organizers can rename -- mirrors make_badges.py's escaping fix.
+        svg = make_agent_badge._svg("R&amp;D", "R&D")
+        xml.dom.minidom.parseString(svg)
+
+
+@unittest.skipUnless(HAS_CHROME, "headless Chrome not installed")
+class TestBuild(unittest.TestCase):
+    def test_writes_two_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            slug, made = make_agent_badge.build("Dublin", d)
+            self.assertEqual(slug, "dublin")
+            self.assertEqual(len(made), 2)
+            for p in made:
+                self.assertTrue(os.path.isfile(p))
+                self.assertGreater(os.path.getsize(p), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-sync-badges/scripts/test_migrate_legacy_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_migrate_legacy_badges.py
@@ -1,0 +1,208 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+import migrate_legacy_badges as mlb  # noqa: E402
+import sync_badges as sb  # noqa: E402
+
+
+class TestPlanLegacyFolders(unittest.TestCase):
+    def test_matches_slug_folder_to_its_chapter(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+
+        def children(folder_id):
+            if folder_id == mlb.LEGACY_BADGES_PARENT:
+                return [{"id": "legacy-dublin-fid", "name": "dublin", "mimeType": sb.FOLDER},
+                        {"name": ".DS_Store", "mimeType": "application/octet-stream"}]
+            if folder_id == "legacy-dublin-fid":
+                return [{"id": "f1", "name": "organizer_badge_dublin_colour.svg"}]
+            raise AssertionError(f"unexpected list_children({folder_id!r})")
+
+        with mock.patch.object(sb, "list_children", side_effect=children):
+            legacy, all_legacy, orphans = mlb.plan_legacy_folders(chapters)
+        self.assertEqual(set(legacy), {"dublin"})
+        self.assertEqual(legacy["dublin"]["id"], "legacy-dublin-fid")
+        self.assertEqual(all_legacy, {"dublin": "legacy-dublin-fid"})
+        self.assertEqual(orphans, [])
+
+    def test_folder_matching_no_chapter_is_an_orphan_not_touched(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+
+        def children(folder_id):
+            if folder_id == mlb.LEGACY_BADGES_PARENT:
+                return [{"id": "stray-fid", "name": "Neverland", "mimeType": sb.FOLDER}]
+            if folder_id == "stray-fid":
+                return [{"id": "f1", "name": "organizer_badge_neverland_colour.svg"}]
+            raise AssertionError(f"unexpected list_children({folder_id!r})")
+
+        with mock.patch.object(sb, "list_children", side_effect=children):
+            legacy, all_legacy, orphans = mlb.plan_legacy_folders(chapters)
+        self.assertEqual(legacy, {})
+        self.assertEqual(all_legacy, {})  # Neverland matches no chapter -- not tracked at all
+        self.assertEqual(orphans, [("Neverland", ["organizer_badge_neverland_colour.svg"])])
+
+    def test_empty_legacy_folder_has_nothing_to_move_but_is_still_tracked_for_trashing(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+
+        def children(folder_id):
+            if folder_id == mlb.LEGACY_BADGES_PARENT:
+                return [{"id": "legacy-dublin-fid", "name": "dublin", "mimeType": sb.FOLDER}]
+            return []  # already fully migrated -- nothing left to move
+
+        with mock.patch.object(sb, "list_children", side_effect=children):
+            legacy, all_legacy, orphans = mlb.plan_legacy_folders(chapters)
+        self.assertEqual(legacy, {})
+        # Still tracked (not an orphan, has no files) so --trash-empty can act on it
+        # even on a run where there was nothing left to migrate.
+        self.assertEqual(all_legacy, {"dublin": "legacy-dublin-fid"})
+        self.assertEqual(orphans, [])
+
+
+class TestMainDispatch(unittest.TestCase):
+    """main()'s move/skip/create decisions, fully mocked -- no live Drive."""
+
+    def _run_main(self, argv, chapters, legacy_children, dest_children):
+        def list_children(folder_id):
+            if folder_id in legacy_children:
+                return legacy_children[folder_id]
+            if folder_id in dest_children:
+                return dest_children[folder_id]
+            return []
+
+        with mock.patch.object(sys, "argv", ["migrate_legacy_badges.py"] + argv), \
+             mock.patch.object(sb, "canonical_chapters", return_value=chapters), \
+             mock.patch.object(sb, "list_children", side_effect=list_children), \
+             mock.patch.object(sb, "find_badges_subfolder",
+                                side_effect=lambda cid: "existing-badges-fid" if cid == "has-badges-fid" else None), \
+             mock.patch.object(sb, "create_folder") as create_folder, \
+             mock.patch.object(mlb, "move_file") as move_file, \
+             mock.patch.object(mlb, "trash_folder") as trash_folder:
+            create_folder.return_value = "new-badges-fid"
+            mlb.main()
+        return create_folder, move_file, trash_folder
+
+    def test_moves_files_and_creates_badges_folder_when_missing(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "no-badges-fid"}}
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [{"id": "legacy-fid", "name": "dublin", "mimeType": sb.FOLDER}],
+            "legacy-fid": [{"id": "f1", "name": "organizer_badge_dublin_colour.svg"}],
+        }
+        create_folder, move_file, trash_folder = self._run_main(
+            ["--write"], chapters, legacy_children, dest_children={})
+
+        create_folder.assert_called_once_with(sb.BADGES_SUBFOLDER, "no-badges-fid")
+        move_file.assert_called_once_with("f1", "new-badges-fid", "legacy-fid")
+        trash_folder.assert_not_called()  # --trash-empty not passed
+
+    def test_file_already_present_at_destination_is_skipped(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "has-badges-fid"}}
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [{"id": "legacy-fid", "name": "dublin", "mimeType": sb.FOLDER}],
+            "legacy-fid": [{"id": "f1", "name": "organizer_badge_dublin_colour.svg"}],
+        }
+        dest_children = {"existing-badges-fid": [{"id": "f1-dup", "name": "organizer_badge_dublin_colour.svg"}]}
+        create_folder, move_file, trash_folder = self._run_main(
+            ["--write"], chapters, legacy_children, dest_children)
+
+        create_folder.assert_not_called()
+        move_file.assert_not_called()
+
+    def test_trash_empty_only_trashes_folders_left_empty_by_the_move(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "has-badges-fid"}}
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [{"id": "legacy-fid", "name": "dublin", "mimeType": sb.FOLDER}],
+            "legacy-fid": [{"id": "f1", "name": "organizer_badge_dublin_colour.svg"}],
+        }
+
+        def list_children(folder_id):
+            if folder_id in legacy_children:
+                return legacy_children[folder_id]
+            return []
+
+        def move_file_side_effect(_file_id, _new_parent, old_parent):
+            legacy_children[old_parent] = []  # a real move empties the source folder
+
+        with mock.patch.object(sys, "argv", ["migrate_legacy_badges.py", "--write", "--trash-empty"]), \
+             mock.patch.object(sb, "canonical_chapters", return_value=chapters), \
+             mock.patch.object(sb, "list_children", side_effect=list_children), \
+             mock.patch.object(sb, "find_badges_subfolder", return_value="existing-badges-fid"), \
+             mock.patch.object(sb, "create_folder"), \
+             mock.patch.object(mlb, "move_file", side_effect=move_file_side_effect) as move_file, \
+             mock.patch.object(mlb, "trash_folder") as trash_folder:
+            mlb.main()
+
+        move_file.assert_called_once()
+        trash_folder.assert_called_once_with("legacy-fid")
+
+    def test_trash_empty_still_runs_when_nothing_left_to_migrate(self):
+        # Regression: a legacy folder already emptied by a PRIOR run has no
+        # entry in `legacy` (nothing to move), but --trash-empty must still
+        # reach and trash it -- it must not bail out at "Nothing to migrate."
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "has-badges-fid"}}
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [{"id": "legacy-fid", "name": "dublin", "mimeType": sb.FOLDER}],
+            "legacy-fid": [],  # already empty -- nothing to move this run
+        }
+        create_folder, move_file, trash_folder = self._run_main(
+            ["--write", "--trash-empty"], chapters, legacy_children, dest_children={})
+
+        move_file.assert_not_called()
+        trash_folder.assert_called_once_with("legacy-fid")
+
+    def test_one_folders_trash_failure_does_not_block_the_others(self):
+        chapters = {
+            "dublin": {"name": "Dublin", "folder_id": "has-badges-fid"},
+            "oslo": {"name": "Oslo", "folder_id": "has-badges-fid"},
+        }
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [
+                {"id": "legacy-dublin-fid", "name": "dublin", "mimeType": sb.FOLDER},
+                {"id": "legacy-oslo-fid", "name": "oslo", "mimeType": sb.FOLDER},
+            ],
+            "legacy-dublin-fid": [],
+            "legacy-oslo-fid": [],
+        }
+
+        def list_children(folder_id):
+            return legacy_children.get(folder_id, [])
+
+        def trash_side_effect(folder_id):
+            if folder_id == "legacy-dublin-fid":
+                raise RuntimeError("gws failed (1): permission denied")
+
+        with mock.patch.object(sys, "argv", ["migrate_legacy_badges.py", "--write", "--trash-empty"]), \
+             mock.patch.object(sb, "canonical_chapters", return_value=chapters), \
+             mock.patch.object(sb, "list_children", side_effect=list_children), \
+             mock.patch.object(sb, "find_badges_subfolder", return_value="existing-badges-fid"), \
+             mock.patch.object(sb, "create_folder"), \
+             mock.patch.object(mlb, "move_file"), \
+             mock.patch.object(mlb, "trash_folder", side_effect=trash_side_effect) as trash_folder:
+            mlb.main()  # must not raise -- the dublin failure is caught and reported
+
+        self.assertEqual(trash_folder.call_count, 2)
+        trash_folder.assert_any_call("legacy-oslo-fid")
+
+    def test_trash_empty_without_write_aborts(self):
+        with mock.patch.object(sys, "argv", ["migrate_legacy_badges.py", "--trash-empty"]):
+            with self.assertRaises(SystemExit) as e:
+                mlb.main()
+        self.assertIn("--write", str(e.exception))
+
+    def test_plan_only_never_touches_drive(self):
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "no-badges-fid"}}
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [{"id": "legacy-fid", "name": "dublin", "mimeType": sb.FOLDER}],
+            "legacy-fid": [{"id": "f1", "name": "organizer_badge_dublin_colour.svg"}],
+        }
+        create_folder, move_file, trash_folder = self._run_main(
+            [], chapters, legacy_children, dest_children={})  # no --write
+
+        create_folder.assert_not_called()
+        move_file.assert_not_called()
+        trash_folder.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/aaif-sync-badges/scripts/test_migrate_legacy_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_migrate_legacy_badges.py
@@ -8,6 +8,30 @@ import migrate_legacy_badges as mlb  # noqa: E402
 import sync_badges as sb  # noqa: E402
 
 
+class TestMoveFile(unittest.TestCase):
+    """Drive doesn't guarantee addParents/removeParents apply atomically
+    together -- move_file must verify the resulting `parents`, not trust a
+    200 response blindly."""
+
+    def test_succeeds_when_parents_fully_updated(self):
+        resp = {"id": "f1", "parents": ["new-parent"]}
+        with mock.patch.object(sb, "gws_json", return_value=resp):
+            mlb.move_file("f1", "new-parent", "old-parent")  # must not raise
+
+    def test_raises_when_old_parent_was_not_actually_removed(self):
+        resp = {"id": "f1", "parents": ["new-parent", "old-parent"]}
+        with mock.patch.object(sb, "gws_json", return_value=resp):
+            with self.assertRaises(RuntimeError) as e:
+                mlb.move_file("f1", "new-parent", "old-parent")
+        self.assertIn("did not fully apply", str(e.exception))
+
+    def test_raises_when_new_parent_was_not_actually_added(self):
+        resp = {"id": "f1", "parents": ["old-parent"]}
+        with mock.patch.object(sb, "gws_json", return_value=resp):
+            with self.assertRaises(RuntimeError):
+                mlb.move_file("f1", "new-parent", "old-parent")
+
+
 class TestPlanLegacyFolders(unittest.TestCase):
     def test_matches_slug_folder_to_its_chapter(self):
         chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
@@ -108,6 +132,30 @@ class TestMainDispatch(unittest.TestCase):
 
         create_folder.assert_not_called()
         move_file.assert_not_called()
+
+    def test_partial_overlap_moves_only_the_files_not_already_at_destination(self):
+        # The realistic case: a chapter partially synced under the new layout
+        # (sync_badges.py already put some files in Badges/) and partially
+        # still under the old shared folder.
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "has-badges-fid"}}
+        legacy_children = {
+            mlb.LEGACY_BADGES_PARENT: [{"id": "legacy-fid", "name": "dublin", "mimeType": sb.FOLDER}],
+            "legacy-fid": [
+                {"id": "f1", "name": "organizer_badge_dublin_colour.svg"},
+                {"id": "f2", "name": "organizer_badge_dublin_white.svg"},
+                {"id": "f3", "name": "organizer_badge_dublin_colour_1000.png"},
+            ],
+        }
+        dest_children = {"existing-badges-fid": [
+            {"id": "f1-dup", "name": "organizer_badge_dublin_colour.svg"},
+        ]}
+        create_folder, move_file, trash_folder = self._run_main(
+            ["--write"], chapters, legacy_children, dest_children)
+
+        create_folder.assert_not_called()
+        self.assertEqual(move_file.call_count, 2)
+        moved_ids = {c.args[0] for c in move_file.call_args_list}
+        self.assertEqual(moved_ids, {"f2", "f3"})
 
     def test_trash_empty_only_trashes_folders_left_empty_by_the_move(self):
         chapters = {"dublin": {"name": "Dublin", "folder_id": "has-badges-fid"}}

--- a/skills/aaif-sync-badges/scripts/test_sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_sync_badges.py
@@ -26,6 +26,11 @@ class TestStylesNeededFor(unittest.TestCase):
         got = sync_badges.styles_needed_for(["organizer_badge_dublin_agent.svg"])
         self.assertEqual(got, [agent_style])
 
+    def test_ring_style_alone_selects_only_make_badges(self):
+        make_badges_style, agent_style = sync_badges.STYLES
+        got = sync_badges.styles_needed_for(["organizer_badge_dublin_colour.svg"])
+        self.assertEqual(got, [make_badges_style])
+
     def test_both_builders_run_when_both_kinds_are_missing(self):
         got = sync_badges.styles_needed_for(
             ["organizer_badge_dublin_colour.svg", "organizer_badge_dublin_agent_1000.png"])
@@ -224,6 +229,21 @@ class TestWritePathDispatch(unittest.TestCase):
         badges_build.assert_not_called()
         agent_build.assert_called_once()
         self.assertEqual(upload_new.call_count, 2)
+
+    def test_only_ring_builder_runs_when_only_ring_files_are_missing(self):
+        all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+        children_by_folder_id = {
+            "chapter-fid": [{"id": "badges-fid", "name": "Badges", "mimeType": sync_badges.FOLDER}],
+            "badges-fid": [{"id": n, "name": n} for n in [
+                "organizer_badge_dublin_agent.svg", "organizer_badge_dublin_agent_1000.png",
+            ]],
+        }
+        create_folder, upload_new, upload_update, badges_build, agent_build = self._run_main(
+            ["--write", "--chapter", "Dublin"], all_chapters, children_by_folder_id)
+
+        badges_build.assert_called_once()
+        agent_build.assert_not_called()
+        self.assertEqual(upload_new.call_count, 4)
 
     def test_regenerate_updates_the_existing_file_in_place(self):
         all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}

--- a/skills/aaif-sync-badges/scripts/test_sync_badges.py
+++ b/skills/aaif-sync-badges/scripts/test_sync_badges.py
@@ -8,36 +8,53 @@ import sync_badges  # noqa: E402
 
 
 class TestNeededFilenames(unittest.TestCase):
-    def test_four_files_per_slug(self):
+    def test_six_files_per_slug_across_both_styles(self):
         got = sync_badges.needed_filenames("mexico_city")
         self.assertEqual(got, [
             "organizer_badge_mexico_city_colour.svg",
             "organizer_badge_mexico_city_white.svg",
             "organizer_badge_mexico_city_colour_1000.png",
             "organizer_badge_mexico_city_white_1000.png",
+            "organizer_badge_mexico_city_agent.svg",
+            "organizer_badge_mexico_city_agent_1000.png",
         ])
+
+
+class TestStylesNeededFor(unittest.TestCase):
+    def test_only_the_relevant_module_is_selected(self):
+        make_badges_style, agent_style = sync_badges.STYLES
+        got = sync_badges.styles_needed_for(["organizer_badge_dublin_agent.svg"])
+        self.assertEqual(got, [agent_style])
+
+    def test_both_builders_run_when_both_kinds_are_missing(self):
+        got = sync_badges.styles_needed_for(
+            ["organizer_badge_dublin_colour.svg", "organizer_badge_dublin_agent_1000.png"])
+        self.assertEqual(len(got), 2)
 
 
 class TestCanonicalChapters(unittest.TestCase):
     def _fake_children(self, folder_id):
         self.assertEqual(folder_id, sync_badges.CHAPTERS_PARENT)
         return [
-            {"name": "Mexico City", "mimeType": sync_badges.FOLDER},
-            {"name": "Delhi NCR", "mimeType": sync_badges.FOLDER},
-            {"name": "TemplateCity", "mimeType": sync_badges.FOLDER},
-            {"name": "Event Tracker.docx", "mimeType": "application/vnd.google-apps.document"},
+            {"id": "mc-id", "name": "Mexico City", "mimeType": sync_badges.FOLDER},
+            {"id": "dn-id", "name": "Delhi NCR", "mimeType": sync_badges.FOLDER},
+            {"id": "tc-id", "name": "TemplateCity", "mimeType": sync_badges.FOLDER},
+            {"id": "et-id", "name": "Event Tracker.docx", "mimeType": "application/vnd.google-apps.document"},
         ]
 
     def test_excludes_templatecity_and_non_folders(self):
         with mock.patch.object(sync_badges, "list_children", self._fake_children):
             chapters = sync_badges.canonical_chapters()
-        self.assertEqual(chapters, {"mexico_city": "Mexico City", "delhi_ncr": "Delhi NCR"})
+        self.assertEqual(chapters, {
+            "mexico_city": {"name": "Mexico City", "folder_id": "mc-id"},
+            "delhi_ncr": {"name": "Delhi NCR", "folder_id": "dn-id"},
+        })
 
     def test_collision_aborts_rather_than_silently_dropping_a_chapter(self):
         def children(_folder_id):
             return [
-                {"name": "Mexico City", "mimeType": sync_badges.FOLDER},
-                {"name": "Mexico  City", "mimeType": sync_badges.FOLDER},  # slugifies the same
+                {"id": "1", "name": "Mexico City", "mimeType": sync_badges.FOLDER},
+                {"id": "2", "name": "Mexico  City", "mimeType": sync_badges.FOLDER},  # slugifies the same
             ]
         with mock.patch.object(sync_badges, "list_children", children):
             with self.assertRaises(SystemExit) as e:
@@ -45,41 +62,59 @@ class TestCanonicalChapters(unittest.TestCase):
         self.assertIn("collide", str(e.exception))
 
 
+class TestFindBadgesSubfolder(unittest.TestCase):
+    def test_finds_the_folder_named_badges(self):
+        children = [
+            {"name": "CRM.xlsx", "mimeType": "application/vnd.google-apps.spreadsheet"},
+            {"id": "badges-id", "name": "Badges", "mimeType": sync_badges.FOLDER},
+            {"id": "icons-id", "name": "Icons", "mimeType": sync_badges.FOLDER},
+        ]
+        with mock.patch.object(sync_badges, "list_children", return_value=children):
+            self.assertEqual(sync_badges.find_badges_subfolder("chapter-id"), "badges-id")
+
+    def test_returns_none_when_absent(self):
+        children = [{"id": "icons-id", "name": "Icons", "mimeType": sync_badges.FOLDER}]
+        with mock.patch.object(sync_badges, "list_children", return_value=children):
+            self.assertIsNone(sync_badges.find_badges_subfolder("chapter-id"))
+
+
 class TestPlan(unittest.TestCase):
     def test_new_chapter_needs_folder_and_all_files(self):
-        chapters = {"dublin": "Dublin"}
-        folders, files = sync_badges.plan(chapters, badge_folders={}, children_by_slug={}, regenerate=False)
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "cid"}}
+        folders, files = sync_badges.plan(chapters, badges_folders={}, children_by_slug={}, regenerate=False)
         self.assertEqual(folders, {"dublin": "Dublin"})
         self.assertEqual(files["dublin"], (None, sync_badges.needed_filenames("dublin")))
 
     def test_existing_folder_only_uploads_missing_files(self):
-        chapters = {"dublin": "Dublin"}
-        badge_folders = {"dublin": {"id": "fid"}}
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "cid"}}
+        badges_folders = {"dublin": "badges-fid"}
         children_by_slug = {"dublin": [
             {"name": "organizer_badge_dublin_colour.svg"},
             {"name": "organizer_badge_dublin_white.svg"},
+            {"name": "organizer_badge_dublin_agent.svg"},
+            {"name": "organizer_badge_dublin_agent_1000.png"},
         ]}
-        folders, files = sync_badges.plan(chapters, badge_folders, children_by_slug, regenerate=False)
+        folders, files = sync_badges.plan(chapters, badges_folders, children_by_slug, regenerate=False)
         self.assertEqual(folders, {})
-        self.assertEqual(files["dublin"], ("fid", [
+        self.assertEqual(files["dublin"], ("badges-fid", [
             "organizer_badge_dublin_colour_1000.png",
             "organizer_badge_dublin_white_1000.png",
         ]))
 
     def test_complete_chapter_is_left_alone(self):
-        chapters = {"dublin": "Dublin"}
-        badge_folders = {"dublin": {"id": "fid"}}
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "cid"}}
+        badges_folders = {"dublin": "badges-fid"}
         children_by_slug = {"dublin": [{"name": n} for n in sync_badges.needed_filenames("dublin")]}
-        folders, files = sync_badges.plan(chapters, badge_folders, children_by_slug, regenerate=False)
+        folders, files = sync_badges.plan(chapters, badges_folders, children_by_slug, regenerate=False)
         self.assertEqual(folders, {})
         self.assertEqual(files, {})
 
     def test_regenerate_reuploads_every_file_even_if_complete(self):
-        chapters = {"dublin": "Dublin"}
-        badge_folders = {"dublin": {"id": "fid"}}
+        chapters = {"dublin": {"name": "Dublin", "folder_id": "cid"}}
+        badges_folders = {"dublin": "badges-fid"}
         children_by_slug = {"dublin": [{"name": n} for n in sync_badges.needed_filenames("dublin")]}
-        folders, files = sync_badges.plan(chapters, badge_folders, children_by_slug, regenerate=True)
-        self.assertEqual(files["dublin"], ("fid", sync_badges.needed_filenames("dublin")))
+        folders, files = sync_badges.plan(chapters, badges_folders, children_by_slug, regenerate=True)
+        self.assertEqual(files["dublin"], ("badges-fid", sync_badges.needed_filenames("dublin")))
 
 
 class TestListChildrenPagination(unittest.TestCase):
@@ -129,71 +164,92 @@ class TestGwsRetry(unittest.TestCase):
 
 
 class TestWritePathDispatch(unittest.TestCase):
-    """main()'s create-vs-update dispatch, fully mocked -- no live Drive."""
+    """main()'s create-vs-update dispatch, fully mocked -- no live Drive, no Chrome."""
 
-    def _run_main(self, argv, all_chapters, badge_children):
+    def _run_main(self, argv, all_chapters, children_by_folder_id):
         with mock.patch.object(sys, "argv", ["sync_badges.py"] + argv), \
              mock.patch.object(sync_badges, "canonical_chapters", return_value=all_chapters), \
              mock.patch.object(sync_badges, "list_children",
-                                side_effect=lambda fid: badge_children.get(fid, [])), \
+                                side_effect=lambda fid: children_by_folder_id.get(fid, [])), \
              mock.patch.object(sync_badges, "create_folder") as create_folder, \
              mock.patch.object(sync_badges, "upload_new") as upload_new, \
              mock.patch.object(sync_badges, "upload_update") as upload_update, \
-             mock.patch.object(sync_badges.make_badges, "build") as build:
+             mock.patch("make_badges.build") as badges_build, \
+             mock.patch("make_agent_badge.build") as agent_build:
             create_folder.return_value = "new-folder-id"
             sync_badges.main()
-        return create_folder, upload_new, upload_update, build
+        return create_folder, upload_new, upload_update, badges_build, agent_build
 
     def test_new_chapter_creates_folder_and_uploads_every_file(self):
-        all_chapters = {"dublin": "Dublin"}
-        badge_children = {sync_badges.BADGES_PARENT: []}  # no existing badge folders
-        create_folder, upload_new, upload_update, build = self._run_main(
-            ["--write", "--chapter", "Dublin"], all_chapters, badge_children)
+        all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+        children_by_folder_id = {"chapter-fid": []}  # no Badges/ subfolder yet
+        create_folder, upload_new, upload_update, badges_build, agent_build = self._run_main(
+            ["--write", "--chapter", "Dublin"], all_chapters, children_by_folder_id)
 
-        create_folder.assert_called_once_with("dublin", sync_badges.BADGES_PARENT)
-        build.assert_called_once_with("Dublin", mock.ANY, "dublin")
-        self.assertEqual(upload_new.call_count, 4)
+        create_folder.assert_called_once_with(sync_badges.BADGES_SUBFOLDER, "chapter-fid")
+        badges_build.assert_called_once_with("Dublin", mock.ANY, "dublin")
+        agent_build.assert_called_once_with("Dublin", mock.ANY, "dublin")
+        self.assertEqual(upload_new.call_count, 6)
         upload_update.assert_not_called()
 
     def test_existing_folder_only_uploads_the_files_actually_missing(self):
-        all_chapters = {"dublin": "Dublin"}
-        badge_children = {
-            sync_badges.BADGES_PARENT: [{"id": "folder-id", "name": "dublin", "mimeType": sync_badges.FOLDER}],
-            "folder-id": [{"id": "existing-svg", "name": "organizer_badge_dublin_colour.svg"}],
+        all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+        children_by_folder_id = {
+            "chapter-fid": [{"id": "badges-fid", "name": "Badges", "mimeType": sync_badges.FOLDER}],
+            "badges-fid": [{"id": "existing-svg", "name": "organizer_badge_dublin_colour.svg"}],
         }
-        create_folder, upload_new, upload_update, build = self._run_main(
-            ["--write", "--chapter", "Dublin"], all_chapters, badge_children)
+        create_folder, upload_new, upload_update, badges_build, agent_build = self._run_main(
+            ["--write", "--chapter", "Dublin"], all_chapters, children_by_folder_id)
 
         # The already-present file is left untouched (neither uploaded nor
-        # updated) -- only the 3 genuinely missing files are created.
+        # updated) -- only the 5 genuinely missing files are created.
         create_folder.assert_not_called()
         upload_update.assert_not_called()
-        self.assertEqual(upload_new.call_count, 3)
+        self.assertEqual(upload_new.call_count, 5)
+        badges_build.assert_called_once()
+        agent_build.assert_called_once()
+
+    def test_only_agent_builder_runs_when_only_agent_files_are_missing(self):
+        all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+        children_by_folder_id = {
+            "chapter-fid": [{"id": "badges-fid", "name": "Badges", "mimeType": sync_badges.FOLDER}],
+            "badges-fid": [{"id": n, "name": n} for n in [
+                "organizer_badge_dublin_colour.svg", "organizer_badge_dublin_white.svg",
+                "organizer_badge_dublin_colour_1000.png", "organizer_badge_dublin_white_1000.png",
+            ]],
+        }
+        create_folder, upload_new, upload_update, badges_build, agent_build = self._run_main(
+            ["--write", "--chapter", "Dublin"], all_chapters, children_by_folder_id)
+
+        badges_build.assert_not_called()
+        agent_build.assert_called_once()
+        self.assertEqual(upload_new.call_count, 2)
 
     def test_regenerate_updates_the_existing_file_in_place(self):
-        all_chapters = {"dublin": "Dublin"}
-        badge_children = {
-            sync_badges.BADGES_PARENT: [{"id": "folder-id", "name": "dublin", "mimeType": sync_badges.FOLDER}],
-            "folder-id": [{"id": "existing-svg", "name": "organizer_badge_dublin_colour.svg"}],
+        all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+        children_by_folder_id = {
+            "chapter-fid": [{"id": "badges-fid", "name": "Badges", "mimeType": sync_badges.FOLDER}],
+            "badges-fid": [{"id": "existing-svg", "name": "organizer_badge_dublin_colour.svg"}],
         }
-        create_folder, upload_new, upload_update, build = self._run_main(
-            ["--write", "--regenerate", "--chapter", "Dublin"], all_chapters, badge_children)
+        create_folder, upload_new, upload_update, badges_build, agent_build = self._run_main(
+            ["--write", "--regenerate", "--chapter", "Dublin"], all_chapters, children_by_folder_id)
 
         create_folder.assert_not_called()
         upload_update.assert_called_once()
         self.assertEqual(upload_update.call_args.args[0], "existing-svg")
-        self.assertEqual(upload_new.call_count, 3)  # the other 3 needed files
+        self.assertEqual(upload_new.call_count, 5)  # the other 5 needed files
 
     def test_plan_only_never_touches_drive(self):
-        all_chapters = {"dublin": "Dublin"}
-        badge_children = {sync_badges.BADGES_PARENT: []}
-        create_folder, upload_new, upload_update, build = self._run_main(
-            ["--chapter", "Dublin"], all_chapters, badge_children)  # no --write
+        all_chapters = {"dublin": {"name": "Dublin", "folder_id": "chapter-fid"}}
+        children_by_folder_id = {"chapter-fid": []}
+        create_folder, upload_new, upload_update, badges_build, agent_build = self._run_main(
+            ["--chapter", "Dublin"], all_chapters, children_by_folder_id)  # no --write
 
         create_folder.assert_not_called()
         upload_new.assert_not_called()
         upload_update.assert_not_called()
-        build.assert_not_called()
+        badges_build.assert_not_called()
+        agent_build.assert_not_called()
 
 
 class TestScrubbedEnv(unittest.TestCase):


### PR DESCRIPTION
## Summary
Follow-up to #38. Two changes, both requested after that PR merged:

1. **Destination change**: badges now live in a `Badges/` subfolder inside each chapter's own Drive folder (alongside its existing `Icons/`, `Event Templates (…)/`, etc.) instead of a shared standalone chapter-badges folder.
2. **New badge style**: `make_agent_badge.py` draws from the real AAIF design system — embedded Instrument Sans (`report_style.font_css()`), ink/paper/hairline tokens read live from `design/aaif-tokens.css`, and the chapter's own agent mascot (`agent_art.chapter_scene()`/`agent_art.agent()` — the same deterministic per-chapter colour already used for that chapter's `Icons/` folder and decks) — rendered via headless Chrome (DESIGN.md's one allowed renderer). The original hand-tuned orange badge (`make_badges.py`) is kept as-is per explicit confirmation; both styles now live side by side, 6 files per chapter.

## Changesets

### 1. `sync_badges.py` retargeted to per-chapter `Badges/` folders
`canonical_chapters()` now also returns each chapter's Drive folder id; a new `find_badges_subfolder()` locates (or, on write, creates) that chapter's own `Badges/` subfolder. `STYLES` holds each generator **module** (not a bound function, deliberately — so `mock.patch("module.build")` stays effective) so a style's builder is only invoked for the files actually missing.

### 2. `make_agent_badge.py` — the design-system badge
Intentionally takes the `lib/aaif_events` coupling AGENTS.md otherwise asks skill scripts to avoid, for the same reason `restyle_design_system.py` does. Palette reads live from the design tokens (not a hardcoded copy — caught and fixed during self-review). Chapter display names (untrusted — any accepted organizer can rename their own chapter folder) are XML-escaped before reaching the generated SVG, mirroring the fix already in `make_badges.py`.

### 3. `migrate_legacy_badges.py` — one-time migration
Moves (Drive reparent — `addParents`/`removeParends`, not a re-upload) every file out of the old shared parent into each chapter's new `Badges/` folder, verifying the reparent actually applied both halves rather than trusting a 200 response. `--trash-empty` is resilient per-folder (logs every skip, circuit-breaks on repeated identical failures) and re-checks the destination immediately before creating it.

### 4. Tests
47 tests total (up from 8 before #38, 41 after this PR's first commit, closed to 47 during self-review): write-path dispatch (new chapter / partial folder / `--regenerate` / plan-only / ring-only / agent-only, per style), `list_children` pagination, `_gws` retry/backoff, the migration's slug-matching/orphan-detection/partial-overlap/resilient-trash logic, `move_file`'s new parent-verification, and SVG-escaping regression tests for both generators (one of which was caught during self-review as vacuous and rewritten).

## Test Plan
- [x] 47/47 unit tests pass across all four test files
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Live-tested the full pipeline against production Drive:
  - Migrated all 88 remaining chapters' existing badges (352 files) into their own `Badges/` folders — verified via a full plan-mode re-check (89/89 chapters report a `Badges/` subfolder)
  - Generated and uploaded the new agent-mascot badge for all 89 chapters (178 files); transient network timeouts mid-batch were handled correctly by the `retries=1` non-idempotent-write guard (failed loudly rather than risking a duplicate; idempotent re-runs picked up cleanly)
  - `--trash-empty`: 28 of 88 emptied legacy folders trashed; the other 60 hit a real permissions restriction and were left in place (harmless) — this run surfaced the resilience bug fixed in changeset 3
  - Final state confirmed clean: `sync_badges.py` reports "Up to date" for all 89 chapters; `migrate_legacy_badges.py` reports "Nothing to migrate"
- [x] Self-review via `hero-skills:review-pr` — 6 parallel review agents; 3 Critical, 6 Important, 4 Suggestion findings, all fixed (see PR comments for details)

_Generated using hero-skills._