### PR TITLE
fix(sync-chapters): revert alarmist merge guard, remove pin phase, record Seattle rename

### DIFF
--- a/skills/aaif-sync-chapters/SKILL.md
+++ b/skills/aaif-sync-chapters/SKILL.md
@@ -80,9 +80,7 @@ a scheduled CI job, and two conventions make that workable:
   `2` when its report proposes changes (or, for `sync_resources`, when a filled
   channel cell is malformed), and anything else on failure. The runner
   aggregates the same way: `0` all clean, `2` drift somewhere, `1` any failure.
-  `sync_access` counts pending grants and a pending lock as drift, but **not**
-  pending banner pins — those are a standing human decision and would read as
-  drift every night forever.
+  `sync_access` counts pending grants and a pending lock as drift.
 - **The runner's stdout never names a person.** This repo is public and a CI log
   is a publication, so the summary is engine names, outcomes, durations and log
   paths only. The full reports — which do carry names, emails and per-person
@@ -117,8 +115,7 @@ person as a side effect — that is a human's call every time. The nightly runs
 `access` in report mode, marks the line `(report mode — never written
 unattended)`, and if the report has pending grants or a pending lock it exits
 `2` with an explicit `NEEDS A HUMAN` note telling the operator to read
-`access.log` and run `sync_access.py --write` by hand (the pin phase needs the
-further explicit `--pins`; pending pins stay named in the report).
+`access.log` and run `sync_access.py --write` by hand.
 
 The run directory is created `0700` and each engine log is opened `0600` —
 the logs hold names and emails, and a CI checkout is often world-readable.
@@ -637,28 +634,20 @@ require `--i-have-approval` (refused at parse time otherwise) — the same conse
 the Slack write steps demand.
 
 Moves the Chapters folder off its public link-share and onto per-chapter grants.
-Report-only by default. Three phases, and **the order is not negotiable**:
+Report-only by default. Two phases, and **the order is not negotiable**:
 
 Numbered as the console prints them:
 
-1. **pin** — give each banner its own `anyone:reader`. Usually a **no-op** (see
-   below), and not needed for the website; it exists for the case where
-   something public genuinely does live in the tree.
-2. **grant** — give each accepted organizer **`writer`** (the `--role` default)
+1. **grant** — give each accepted organizer **`writer`** (the `--role` default)
    on their chapter folder. Must precede the lock: the public link is currently
    their only access.
-3. **lock** — remove `anyone:reader` from Chapters/.
+2. **lock** — remove `anyone:reader` from Chapters/.
 
-`--write` runs **grant then lock**. The pin phase runs only behind the explicit
-**`--pins`** flag (`--write --pins` runs all three, pin first) or as
-`--phase pin` — publishing a file to the whole internet is a standing human
-decision, never a side effect of syncing grants, and `nightly.py` must never
-pass `--pins`. Unpinned banners stay named in every report and write run so the
-pending decision is visible. `--phase pin|grant|lock` runs one phase, and the
-run verifies whatever it ran; the final `Verified:` line claims **only** the
-phases that actually ran and checked something. **`lock` refuses to run when
-any grant failed** — locking then would leave those organizers with no access
-at all; `--lock-anyway` overrides.
+`--write` runs **grant then lock**. `--phase grant|lock` runs one phase, and
+the run verifies whatever it ran; the final `Verified:` line claims **only**
+the phases that actually ran and checked something. **`lock` refuses to run
+when any grant failed** — locking then would leave those organizers with no
+access at all; `--lock-anyway` overrides.
 
 > **The website does not depend on this share — verified, not assumed.** The
 > chapters feed's `Image` column is full of `lh3.googleusercontent.com/d/<id>`
@@ -667,14 +656,10 @@ at all; `--lock-anyway` overrides.
 > was loaded and inspected on 2026-08-07: 26 images, **all** from `cdn.sanity.io`,
 > none from Drive. Chapter content and imagery live in Sanity; the Drive banners
 > are source assets. A column full of image URLs is not evidence that anything
-> fetches them — load the page and look.
-
-> **`pin` is a no-op while the parent is still shared.** Drive merges a child's
-> `anyone:reader` into the inherited one, returns `200` with a permission id, and
-> stores nothing new — the file still reads `inherited: true`. A child can only
-> hold its own public share *after* the parent's is removed. Never trust the
-> phase's "N changes" line; re-read the permission and check
-> `permissionDetails[].inherited`.
+> fetches them — load the page and look. Nothing in this tree needs a public
+> share (2026-09-03, user-decided): a `pin` phase used to exist for making a
+> banner directly public, on the theory that something might genuinely need it;
+> it never did, and was removed.
 
 - **`assert_all_accepted()` is the last gate before write** and re-reads the
   intake through a different code path than the filter that built the plan.
@@ -1038,9 +1023,8 @@ After any run (and after editing the engine):
   of every written doc proposes zero changes"; `sync_crm` "a fresh read
   of every written workbook proposes zero changes"; `sync_access` a composed
   line naming only the phases that ran (e.g. "every accepted organizer holds
-  their grant; Chapters/ is not link-shared" — the banner claim appears only
-  after a pin run); `sync_resources` "a fresh read of every written cell
-  matches the proposal".
+  their grant; Chapters/ is not link-shared"); `sync_resources` "a fresh read
+  of every written cell matches the proposal".
 - Spot-check one touched row in the sheet: `Organizers` merged correctly, the
   MLOps and Luma columns untouched, and the version history shows a single edit
   for the whole sync.

--- a/skills/aaif-sync-chapters/scripts/nightly.py
+++ b/skills/aaif-sync-chapters/scripts/nightly.py
@@ -26,11 +26,7 @@ The Slack write steps (provision_channels.py, invite_organizers.py,
 prune_organizers.py) are deliberately NOT here: they carry their own
 --i-have-approval gate because they notify or affect real people, and a nightly
 job must never hold that approval. sync_resources' Slack half degrades to
-folder-only on a dead token, which is the right nightly behaviour. For the same
-reason this runner passes ONLY --write and must never pass sync_access's
---pins: publishing a banner to the internet is a standing human decision, and
-the engine leaves it pending (and visible in its report) until someone runs
-`sync_access.py --write --pins` by hand.
+folder-only on a dead token, which is the right nightly behaviour.
 
 The `access` engine goes further: it NEVER receives --write from this runner,
 even under `nightly.py --write`. Its grants hand standing Drive access to

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -168,15 +168,18 @@ CHANNEL_RENAMES = {
     # #austin-area / #austin-area-organizers became #austin-tx /
     # #austin-tx-organizers.
     "meetup-seattle-organizers": "seattle-wa-organizers",
-    # 2026-09-03: #seattle-wa-organizers (the room the rename above landed on)
-    # turned out to be the wrong one — #seattle-chapter-leads (2026, 14
-    # members, active) is the real organizer room; #seattle-wa-organizers sat
-    # unused and was archived. Reclaim the qualified name for the real room;
-    # its name is free (archived rooms don't hold their name against
-    # order_renames' `taken` set). #seattle-organizers (unqualified) is an
-    # invisible private squatter — unreachable by this token — which is why
-    # the qualified name exists at all.
-    "seattle-chapter-leads": "seattle-wa-organizers",
+    # APPLIED 2026-09-03 and removed from this map (same hazard as the block
+    # above: a junk #seattle-chapter-leads recreated under the freed old name
+    # would re-plan this rename against a room that genuinely holds the
+    # target, and block the whole run): seattle-chapter-leads ->
+    # seattle-wa-organizers. #seattle-wa-organizers (the room the rename above
+    # landed on) turned out to be the wrong one — #seattle-chapter-leads
+    # (2026, 14 members, active) was the real organizer room;
+    # #seattle-wa-organizers sat unused and was archived, freeing its name
+    # (archived rooms don't hold their name against order_renames' `taken`
+    # set) for the real room to reclaim. #seattle-organizers (unqualified) is
+    # an invisible private squatter — unreachable by this token — which is
+    # why the qualified name exists at all.
     "washington-dc-the-capital": "washington-dc",
     # Austin, full history: #austin is squatted with no path to free it on the
     # Pro plan. 2026-08-21 parked the chapter on its historical #austin-area

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -168,6 +168,15 @@ CHANNEL_RENAMES = {
     # #austin-area / #austin-area-organizers became #austin-tx /
     # #austin-tx-organizers.
     "meetup-seattle-organizers": "seattle-wa-organizers",
+    # 2026-09-03: #seattle-wa-organizers (the room the rename above landed on)
+    # turned out to be the wrong one — #seattle-chapter-leads (2026, 14
+    # members, active) is the real organizer room; #seattle-wa-organizers sat
+    # unused and was archived. Reclaim the qualified name for the real room;
+    # its name is free (archived rooms don't hold their name against
+    # order_renames' `taken` set). #seattle-organizers (unqualified) is an
+    # invisible private squatter — unreachable by this token — which is why
+    # the qualified name exists at all.
+    "seattle-chapter-leads": "seattle-wa-organizers",
     "washington-dc-the-capital": "washington-dc",
     # Austin, full history: #austin is squatted with no path to free it on the
     # Pro plan. 2026-08-21 parked the chapter on its historical #austin-area

--- a/skills/aaif-sync-chapters/scripts/sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/sync_access.py
@@ -23,23 +23,14 @@ loaded and inspected on 2026-08-07 and every one of its 26 images comes from
 are source assets, not what visitors fetch. Verify with the live page before ever
 concluding otherwise — the feed column is not evidence.
 
-A `pin` phase exists for the case where something public genuinely does live in
-the tree. It is a NO-OP while the parent is still shared: Drive merges a child's
-`anyone:reader` into the inherited one and reports success, so a child can only
-hold its own public share AFTER the parent's is gone. Never trust its "N changes"
-line — re-read the permission and check `permissionDetails[].inherited`.
-
-Pinning runs ONLY behind the explicit `--pins` flag (or `--phase pin`).
-Publishing a file to the whole internet is a standing human decision, not
-drift: the site serves from Sanity, nothing needs the banners public, and an
-unattended `--write` (nightly.py, which must never pass `--pins`) has no
-business making that call. `--write` alone therefore runs grant + lock; the
-report keeps naming any unpinned banners so the pending decision stays visible.
+Nothing in this tree needs a public share (2026-09-03: the `pin` phase that
+used to exist for that — making a banner directly public — was removed; the
+site serves from Sanity, never from a directly-shared Drive file, so there was
+never a real case for it). `--write` runs grant then lock, always.
 
 Usage:
   python3 sync_access.py                    # full plan, changes nothing
   python3 sync_access.py --write            # apply grant + lock, in order
-  python3 sync_access.py --write --pins     # also run the pin phase first
   python3 sync_access.py --write --phase grant
   python3 sync_access.py --role reader      # grant something other than writer
   python3 sync_access.py --write --mail-if-required --i-have-approval
@@ -50,10 +41,10 @@ Usage:
   python3 sync_access.py --write --lock-anyway        # lock even though some
                                             # organizers could not be granted
 """
-import argparse, os, re, sys
+import argparse, os, sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from sync_chapters import (CHAPTERS_ID, CHAPTERS_TAB, INTAKE_ID, gws_json, get_values,
+from sync_chapters import (INTAKE_ID, gws_json, get_values,
                            cell, fold_city, header_index)
 # ROLE_TABS is deliberately NOT imported: folder access reads ACCESS_TABS only,
 # and having the wider constant in scope is how the escalation crept in before.
@@ -157,58 +148,13 @@ def perms(file_id):
             det = p.get("permissionDetails") or []
             # Default to inherited=True when the API doesn't say. The permissive
             # answer (False = "this is our own direct grant") would classify a
-            # merely-inherited share as pinned/granted, skip the work, and then
-            # skip the verification too.
+            # merely-inherited share as granted, skip the work, and then skip
+            # the verification too.
             own = True if not det else any(d.get("inherited") for d in det)
             out.append(dict(p, inherited=own))
         token = res.get("nextPageToken")
         if not token:
             return out
-
-
-def direct_public(file_id):
-    """True when this file carries its OWN anyone:reader, not an inherited one.
-    An inherited share disappears with the parent's; a direct one survives."""
-    return any(p["type"] == "anyone" and not p["inherited"] for p in perms(file_id))
-
-
-_DRIVE_ID_RE = re.compile(r"(?:/d/|[?&]id=)([A-Za-z0-9_-]{20,})")
-
-
-def banner_ids():
-    """{folded city -> {city, file_id, url}} for each chapter's banner asset.
-
-    Resolved from the feed's `Image` column rather than by globbing for a file
-    named `Web Banner.png`, so a cell pointing somewhere unexpected is visible
-    rather than silently replaced by whatever the glob found.
-
-    These are the Drive SOURCE assets the feed points at — NOT what visitors
-    fetch. See the module docstring: the site serves its imagery from Sanity.
-
-    Keyed with fold_city, matching every other city-to-folder comparison in this
-    skill. Plain fold() leaves punctuation intact, so a feed spelling of
-    `Washington, DC` missed the `Washington DC` folder and the chapter was
-    reported as having no resolvable image at all.
-    """
-    rows = get_values(CHAPTERS_ID, "'%s'!A:AZ" % CHAPTERS_TAB)
-    if not rows:
-        sys.exit("ABORT: chapters feed tab %r came back empty." % CHAPTERS_TAB)
-    headers = [h.strip() for h in rows[0]]
-    i_img, i_city = header_index(headers, CHAPTERS_TAB, "Image", "City")
-    out = {}
-    for row in rows[1:]:
-        url, city = cell(row, i_img), cell(row, i_city)
-        if not (url and city):
-            continue
-        # Both forms Drive hands out: `/d/<id>` and `?id=<id>`. An unrecognised
-        # shape yields "" and is reported, never silently treated as absent.
-        m = _DRIVE_ID_RE.search(url)
-        key = fold_city(city)
-        if key in out:
-            print("  !! duplicate feed row for %r — the later one wins" % city,
-                  file=sys.stderr)
-        out[key] = {"city": city, "file_id": m.group(1) if m else "", "url": url}
-    return out
 
 
 # Folder access is for ORGANIZERS ONLY — deliberately narrower than the CRM,
@@ -229,21 +175,9 @@ def plan(role):
         pp, _, _ = read_role_tab(tab, {})
         people += pp
     by_folder, orphans, near = match_chapters(merge_people(people), folders)
-    imgs = banner_ids()
 
-    pins, grants, already_pinned, already_granted, no_banner = [], [], [], [], []
-    already_pinned_ids, already_granted_ids, stale = [], [], []
+    grants, already_granted, already_granted_ids, stale = [], [], [], []
     for f in folders:
-        img = imgs.get(fold_city(f["name"]))
-        if not img or not img["file_id"]:
-            no_banner.append(f["name"])
-        elif direct_public(img["file_id"]):
-            already_pinned.append(f["name"])
-            already_pinned_ids.append((f["name"], img["file_id"]))
-        else:
-            pins.append({"chapter": f["name"], "folder_id": f["id"],
-                         "file_id": img["file_id"], "url": img["url"]})
-
         want = by_folder.get(f["id"], [])
         # Read permissions for EVERY chapter, including the ones with no accepted
         # organizer. Skipping those hid their stale grants entirely — and a
@@ -273,32 +207,13 @@ def plan(role):
 
     parent = perms(CHAPTERS_PARENT)
     public = [p for p in parent if p["type"] == "anyone"]
-    return {"pins": pins, "grants": grants, "already_pinned": already_pinned,
-            "already_granted": already_granted, "no_banner": no_banner,
+    return {"grants": grants, "already_granted": already_granted,
             "public": public, "parent": parent, "orphans": orphans, "near": near,
-            "already_pinned_ids": already_pinned_ids,
             "already_granted_ids": already_granted_ids, "stale": stale, "role": role}
 
 
 def report(p, role):
-    print("PHASE 1 — pin the website's banner images (make each one directly public)")
-    print("  %d banner(s) need their own anyone:reader; %d already have one."
-          % (len(p["pins"]), len(p["already_pinned"])))
-    for x in p["pins"][:6]:
-        print("     %-20s %s" % (x["chapter"], x["file_id"]))
-    if len(p["pins"]) > 6:
-        print("     … and %d more" % (len(p["pins"]) - 6))
-    if p["pins"]:
-        # Keep the standing decision visible without letting an unattended
-        # --write make it: pins never run unless explicitly asked for.
-        print("  (pins run ONLY with --pins or --phase pin — a plain --write "
-              "applies grant + lock and leaves these pending)")
-    if p["no_banner"]:
-        print("  !! %d chapter(s) have no resolvable Image id on the feed (the cell is "
-              "empty or not a Drive URL): %s"
-              % (len(p["no_banner"]), ", ".join(p["no_banner"])))
-
-    print("\nPHASE 2 — grant each accepted organizer %r on their own chapter folder" % role)
+    print("PHASE 1 — grant each accepted organizer %r on their own chapter folder" % role)
     print("  %d new grant(s) across %d chapter(s); %d already in place."
           % (len(p["grants"]), len({g["chapter"] for g in p["grants"]}), len(p["already_granted"])))
     by_ch = {}
@@ -309,7 +224,7 @@ def report(p, role):
     if len(by_ch) > 6:
         print("     … and %d more chapter(s)" % (len(by_ch) - 6))
 
-    print("\nPHASE 3 — remove the public share from the Chapters folder")
+    print("\nPHASE 2 — remove the public share from the Chapters folder")
     if not p["public"]:
         print("  Nothing to remove — the folder is already not link-shared.")
     for x in p["public"]:
@@ -340,46 +255,6 @@ def report(p, role):
     print("\nNet effect: %d chapter-folder grant(s) at %r for accepted organizers, and "
           "the CRMs stop being readable by anyone with the link."
           % (len(p["grants"]) + len(p["already_granted"]), role))
-    print("           (%d Drive banner(s) would hold their own public share. The "
-          "website itself serves from Sanity and is unaffected either way.)"
-          % (len(p["pins"]) + len(p["already_pinned"])))
-
-
-def apply_pins(p):
-    """Give each banner its own anyone:reader — validated, then re-read.
-
-    The file id is string-sliced out of a spreadsheet cell that anyone with edit
-    access to the chapters feed can change. Without checking what it points at,
-    aiming an `Image` cell at a CRM file id would make that CRM permanently
-    world-readable — and `lock` only touches the parent, so the grant survives
-    the very step meant to make things private.
-    """
-    landed = 0
-    for x in p["pins"]:
-        meta = gws_json("drive", "files", "get", params={
-            "fileId": x["file_id"], "supportsAllDrives": True,
-            "fields": "id,name,mimeType,parents"})
-        if not meta.get("mimeType", "").startswith("image/"):
-            sys.exit("ABORT: %s's Image cell points at %r (%s), which is not an image. "
-                     "Nothing further was pinned." % (x["chapter"], meta.get("name"),
-                                                      meta.get("mimeType")))
-        if x["folder_id"] not in (meta.get("parents") or []):
-            sys.exit("ABORT: %s's Image cell points at %r, which does not live in that "
-                     "chapter's folder. Nothing further was pinned."
-                     % (x["chapter"], meta.get("name")))
-        gws_json("drive", "permissions", "create",
-                 params={"fileId": x["file_id"], "supportsAllDrives": True},
-                 body={"type": "anyone", "role": "reader"})
-        # Drive merges a duplicate anyone:reader into the inherited one and
-        # returns 200 having stored nothing, so the create call proves nothing.
-        if not direct_public(x["file_id"]):
-            sys.exit("ABORT: pinning %s returned success but the file still has no "
-                     "direct anyone:reader — Drive merged it into the parent's "
-                     "inherited share. The parent must be unshared FIRST. Do not "
-                     "run lock." % x["chapter"])
-        landed += 1
-        print("  pinned %s" % x["chapter"])
-    return landed
 
 
 def assert_all_accepted(grants):
@@ -510,9 +385,9 @@ def verify(p, ran):
 
     Every check here re-reads remote truth. Three earlier weaknesses are closed:
 
-      * it verified only the PLANNED pins/grants, so anything the plan
-        classified as `already_*` — i.e. exactly the case where the
-        classification was wrong — was never checked;
+      * it verified only the PLANNED grants, so anything the plan classified
+        as `already_granted` — i.e. exactly the case where the classification
+        was wrong — was never checked;
       * it sampled `grants[:5]` of ninety-odd, so a systematic failure past the
         fifth passed clean;
       * it accepted ANY permission for the address, so an inherited or
@@ -522,14 +397,6 @@ def verify(p, ran):
     checks that iterated nothing.
     """
     bad, checked = [], 0
-    if "pin" in ran:
-        # `already_pinned` is an assertion the plan made from an earlier read —
-        # re-verify it rather than trusting it.
-        for x in p["pins"] + [{"chapter": c, "file_id": i}
-                              for c, i in p.get("already_pinned_ids", [])]:
-            checked += 1
-            if not direct_public(x["file_id"]):
-                bad.append("banner for %s is still not directly public" % x["chapter"])
     if "grant" in ran:
         want = [(g["chapter"], g["folder_id"], g["email"], g["role"]) for g in p["grants"]]
         want += [(c, fid, e, p["role"]) for c, fid, e in p.get("already_granted_ids", [])]
@@ -557,23 +424,15 @@ def verify(p, ran):
     return bad
 
 
-def phases_to_run(phase, pins):
-    """The pin/grant/lock subset this invocation applies, in order.
+def phases_to_run(phase):
+    """The grant/lock subset this invocation applies, in order.
 
-    `--phase` names exactly one — pin included, because naming it IS the
-    explicit consent. Without `--phase`, `--write` runs grant + lock; pin
-    joins only under `--pins`, so an unattended write (nightly.py never
-    passes `--pins`) can never publish a file to the internet as a side
-    effect of syncing grants.
-
-    `phase` and `pins` never arrive together: main() rejects `--phase --pins`
-    at parse time (the combination used to discard --pins silently, and a
-    silently dropped consent flag is the one thing a consent flag must not
-    be), so the `if phase` early return cannot swallow a pin request.
+    `--phase` names exactly one; without it, `--write` always runs grant then
+    lock.
     """
     if phase:
         return [phase]
-    return (["pin"] if pins else []) + ["grant", "lock"]
+    return ["grant", "lock"]
 
 
 def main():
@@ -581,12 +440,8 @@ def main():
     ap.add_argument("--write", action="store_true", help="apply (default: report only)")
     ap.add_argument("--role", default="writer", choices=("writer", "reader", "commenter"),
                     help="role granted to each organizer on their chapter (default: writer)")
-    ap.add_argument("--phase", choices=("pin", "grant", "lock"),
-                    help="apply only one phase (default with --write: grant "
-                         "then lock; add --pins to run pin first)")
-    ap.add_argument("--pins", action="store_true",
-                    help="also run the pin phase (make each banner directly "
-                         "public) — never run by a plain --write or by nightly.py")
+    ap.add_argument("--phase", choices=("grant", "lock"),
+                    help="apply only one phase (default with --write: grant then lock)")
     ap.add_argument("--notify", action="store_true",
                     help="let Drive email EVERY organizer about their new access")
     ap.add_argument("--lock-anyway", action="store_true",
@@ -610,42 +465,27 @@ def main():
     if a.i_have_approval and not (a.notify or a.mail_if_required):
         print("NOTE: --i-have-approval is inert without --notify or "
               "--mail-if-required; nothing will be emailed.", file=sys.stderr)
-    # Refuse, never reinterpret: both flags speak for the pin phase, and each
-    # combination below used to be silently inert — the worst behaviour for a
-    # flag whose whole job is recording explicit human consent.
-    if a.phase and a.pins:
-        ap.error("--pins cannot be combined with --phase: --phase names the ONE "
-                 "phase to run, so --pins would be discarded. Use --phase pin "
-                 "to run pins alone, or drop --phase to run pin + grant + lock.")
-    if a.pins and not a.write:
-        ap.error("--pins does nothing without --write — the report already "
-                 "shows pending pins. Add --write to apply them.")
 
     p = plan(a.role)
     report(p, a.role)
     if not a.write:
         print("\nReport only — nothing was changed. Re-run with --write to apply.")
-        # Shared engine exit convention: report mode exits 0 when in sync, 2 when
-        # it proposes changes (consumed by nightly.py). Pending banner pins are
-        # NOT drift: the site serves from Sanity, so pinning is a standing human
-        # decision, and counting it would report drift every night forever.
+        # Shared engine exit convention: report mode exits 0 when in sync, 2
+        # when it proposes changes (consumed by nightly.py).
         return 2 if (p["grants"] or p["public"]) else 0
 
     # Same rule in write mode: with nothing to grant and nothing to lock, do
-    # NOT run the phases (pins are a standing decision, not drift) and do NOT
-    # print the "Verified:" line — nightly.py reads that marker as "wrote",
-    # so printing it unconditionally would label every in-sync write night
-    # "wrote+verified" and exit 2 forever. The other engines' no-drift early
-    # return, in this engine's terms.
-    if not a.phase and not (p["grants"] or p["public"] or (a.pins and p["pins"])):
+    # NOT run the phases and do NOT print the "Verified:" line — nightly.py
+    # reads that marker as "wrote", so printing it unconditionally would
+    # label every in-sync write night "wrote+verified" and exit 2 forever.
+    # The other engines' no-drift early return, in this engine's terms.
+    if not a.phase and not (p["grants"] or p["public"]):
         print("\nNo changes needed — every accepted organizer holds their "
-              "grant and the folder is not link-shared. (Pending banner pins, "
-              "if any, are a standing decision: run --pins or --phase pin "
-              "explicitly.)")
+              "grant and the folder is not link-shared.")
         return 0
 
-    selected = phases_to_run(a.phase, a.pins)
-    order = [("pin", apply_pins, (p,)), ("grant", apply_grants, (p, a.notify, a.mail_if_required)),
+    selected = phases_to_run(a.phase)
+    order = [("grant", apply_grants, (p, a.notify, a.mail_if_required)),
              ("lock", apply_lock, (p,))]
     grant_failures = []
     for name, fn, args in order:
@@ -673,11 +513,6 @@ def main():
             n, grant_failures = n
         print("  phase %r: %d change(s)" % (name, n))
 
-    if p["pins"] and "pin" not in selected:
-        # The skipped standing decision stays visible on every write run.
-        print("\nNOTE: %d banner(s) still lack their own public share — pins run "
-              "only with --pins or --phase pin." % len(p["pins"]))
-
     # Verify whatever ran, including a single --phase. `--write --phase lock` is
     # the most destructive invocation available and used to be the one path with
     # no re-read at all, reporting a PLANNED count as its result.
@@ -689,12 +524,8 @@ def main():
         for b in bad:
             print("  " + b)
         return 1
-    # Claim only what this run actually re-read — the old fixed line said
-    # "banners are directly public" even on runs that never touched a pin,
-    # or when zero pins exist to check.
+    # Claim only what this run actually re-read.
     bits = []
-    if "pin" in selected and (p["pins"] or p["already_pinned_ids"]):
-        bits.append("every banner holds its own public share")
     if "grant" in selected and (p["grants"] or p["already_granted_ids"]):
         bits.append("every accepted organizer holds their grant")
     if "lock" in selected:

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -1223,10 +1223,11 @@ def merge_people(people, blocked=None):
                     blocked.append({
                         "row": p["row"], "tab": tab, "name": p["name"],
                         "why": "status %r — a second role application under "
-                               "an already-accepted person's email (%r); held "
+                               "an already-accepted person's email (%s); held "
                                "until per-role CRM tabs exist to keep the two "
                                "applications separate rather than merged into "
-                               "one row." % (p["status"], cur["name"])})
+                               "one row. Review the intake row."
+                               % (p["status"], redact_name(cur["name"]))})
                 continue
             if cur is None:
                 m = dict(p, tabs=[tab], rows=[p["row"]], statuses=[p["status"]])
@@ -1729,9 +1730,10 @@ def _run(args, workdir):
               % (len({fold_email(p["email"]) for p in held}),
                  len({fold_city(p["city"]) for p in held}), SELF_SERVE_MIN))
     if merge_blocked:
-        print("Held    : %d second-role application(s) under an already-accepted "
+        print("Held (2nd role): %d application(s) sharing an already-accepted "
               "person's email — held, not merged into their CRM row (per-role "
-              "tabs will carry these separately) — --verbose lists them."
+              "tabs will carry these separately) — --verbose lists them; "
+              "review those intake rows."
               % len(merge_blocked))
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 

--- a/skills/aaif-sync-chapters/scripts/sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/sync_crm.py
@@ -1197,11 +1197,20 @@ def merge_people(people, blocked=None):
     public and email is the merge key, so a stranger submitting under an
     accepted organizer's address would otherwise fill that person's blank CRM
     cells and restamp their Notes — attacker content attributed to a trusted
-    identity. Refused rows are appended to `blocked` (rejection-shaped, for
-    the report) when the caller passes a list; the legitimate mixed case — one
-    person pipeline in one role and accepted in another — still merges when
-    the pipeline row seeds first (ROLE_TABS order), which is how a real
-    person's rows arrive, and is covered by the tests either way.
+    identity. This is deliberately unconditional, including when the second
+    row carries the SAME name as the accepted person (2026-09-03, reverted a
+    same-day same-name carve-out): merging two role applications into one row
+    is not this engine's call to make on its own — a person accepted in one
+    role who later applies for a second (Speaker/Host, still pending that
+    role's own review) is expected to stay a held, unmerged row until CRM
+    workbooks grow separate per-role tabs; that follow-up decides how the two
+    applications actually come together, and this function must not guess at
+    it by combining them into one "Organizer/Speaker" cell. Refused rows are
+    appended to `blocked` (rejection-shaped, for the report) when the caller
+    passes a list; the legitimate mixed case — one person pipeline in one role
+    and accepted in another — still merges when the pipeline row seeds first
+    (ROLE_TABS order), which is how a real person's rows arrive, and is
+    covered by the tests either way.
     """
     merged = {}
     for tab in ROLE_TABS:                       # priority order
@@ -1213,10 +1222,11 @@ def merge_people(people, blocked=None):
                 if blocked is not None:
                     blocked.append({
                         "row": p["row"], "tab": tab, "name": p["name"],
-                        "why": "status %r — same email as an accepted person's "
-                               "CRM row; refusing to merge an unvetted "
-                               "submission into it. Review the intake row."
-                               % p["status"]})
+                        "why": "status %r — a second role application under "
+                               "an already-accepted person's email (%r); held "
+                               "until per-role CRM tabs exist to keep the two "
+                               "applications separate rather than merged into "
+                               "one row." % (p["status"], cur["name"])})
                 continue
             if cur is None:
                 m = dict(p, tabs=[tab], rows=[p["row"]], statuses=[p["status"]])
@@ -1719,9 +1729,9 @@ def _run(args, workdir):
               % (len({fold_email(p["email"]) for p in held}),
                  len({fold_city(p["city"]) for p in held}), SELF_SERVE_MIN))
     if merge_blocked:
-        print("SECURITY: %d not-yet-accepted intake row(s) share an email with "
-              "an accepted person and were NOT merged into their CRM row — "
-              "--verbose lists them; review those intake rows."
+        print("Held    : %d second-role application(s) under an already-accepted "
+              "person's email — held, not merged into their CRM row (per-role "
+              "tabs will carry these separately) — --verbose lists them."
               % len(merge_blocked))
     print("Chapters: %d folder(s) in scope.\n" % len(folders))
 

--- a/skills/aaif-sync-chapters/scripts/test_sync_access.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_access.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import sync_access
-from sync_access import ACCESS_TABS, banner_ids, canon_email
+from sync_access import ACCESS_TABS, canon_email
 
 fails = 0
 def check(label, got, want):
@@ -76,54 +76,6 @@ check("+tags are kept off gmail",
       canon_email("a+tag@fastmail.com"), "a+tag@fastmail.com")
 check("blank stays blank", canon_email(""), "")
 
-
-# ---------------------------------------------------------------------------
-# banner_ids — city key and URL parsing
-# ---------------------------------------------------------------------------
-FEED_HEADERS = ["Title", "City", "Country", "Generated Geolocation", "Summary",
-                "Image", "CTA", "URL for CTA", "Organizers", "Chapter Luma Link",
-                "MLOps Community Organizers"]
-ID_A, ID_B = "1usAa88CR88_XUlMp35tFoF2OIv1mf3IO", "1Q-OzWVYW1lzjI_Hlu6QvY8bNBZYXlodH"
-
-
-def feed_row(city, image):
-    row = [""] * len(FEED_HEADERS)
-    row[FEED_HEADERS.index("City")] = city
-    row[FEED_HEADERS.index("Image")] = image
-    return row
-
-
-def banners_over(rows):
-    with mock.patch.object(sync_access, "get_values", return_value=rows):
-        return banner_ids()
-
-
-got = banners_over([FEED_HEADERS,
-                    feed_row("Washington, DC", "https://lh3.googleusercontent.com/d/" + ID_A),
-                    feed_row("Montréal", "https://drive.google.com/uc?id=" + ID_B),
-                    feed_row("Nowhere", "not a drive url"),
-                    feed_row("", "https://lh3.googleusercontent.com/d/" + ID_A)])
-# fold_city, not fold: plain fold leaves punctuation intact, so the feed's
-# 'Washington, DC' missed the 'Washington DC' folder and the chapter was
-# reported as having no image at all — then never pinned, then locked.
-check("city key is punctuation-folded", "washington dc" in got, True)
-check("city key is accent-folded", "montreal" in got, True)
-check("the /d/<id> form parses", got["washington dc"]["file_id"], ID_A)
-check("the ?id=<id> form parses", got["montreal"]["file_id"], ID_B)
-check("an unrecognised URL yields no id, not a bogus one",
-      got["nowhere"]["file_id"], "")
-check("a row with no city is skipped", len(got), 3)
-check("the original city spelling is preserved for the report",
-      got["washington dc"]["city"], "Washington, DC")
-
-check("a missing Image column aborts rather than planning a lock",
-      aborts(lambda: banners_over([[h for h in FEED_HEADERS if h != "Image"]])), True)
-check("an empty feed aborts", aborts(lambda: banners_over([])), True)
-
-# A trailing-fragment URL must not produce a truncated-but-plausible id.
-frag = banners_over([FEED_HEADERS,
-                     feed_row("Boston", "https://lh3.googleusercontent.com/d/%s#gid=1" % ID_A)])
-check("a URL fragment does not corrupt the id", frag["boston"]["file_id"], ID_A)
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +211,7 @@ check("a failure mid-batch does not abandon the remaining grants",
 # night on any chapter the tree owner organizes — and loosening it to accept any
 # inherited role would pass with no grant made at all.
 def run_verify(perm_rows):
-    p = {"grants": [], "pins": [], "already_pinned_ids": [],
+    p = {"grants": [],
          "already_granted_ids": [("Boston", "F1", "a@x.com")], "role": "writer"}
     with mock.patch.object(sync_access, "perms", lambda fid: perm_rows):
         return sync_access.verify(p, ["grant"])
@@ -281,38 +233,20 @@ check("a direct writer passes",
       run_verify([{"type": "user", "emailAddress": "a@x.com",
                    "role": "writer", "inherited": False}]), [])
 
-# --- phases_to_run: pinning is a standing human decision, never a default -------
-# nightly.py passes only --write, so the unattended path must never publish a
-# banner to the internet as a side effect of syncing grants.
-check("a plain --write runs grant + lock only",
-      sync_access.phases_to_run(None, False), ["grant", "lock"])
-check("--pins adds the pin phase, first",
-      sync_access.phases_to_run(None, True), ["pin", "grant", "lock"])
-check("--phase pin is explicit consent on its own",
-      sync_access.phases_to_run("pin", False), ["pin"])
+# --- phases_to_run: --write always runs grant + lock, in order -----------------
+check("a plain --write runs grant + lock",
+      sync_access.phases_to_run(None), ["grant", "lock"])
 check("--phase runs exactly the named phase",
-      [sync_access.phases_to_run(p, False) for p in ("grant", "lock")],
+      [sync_access.phases_to_run(p) for p in ("grant", "lock")],
       [["grant"], ["lock"]])
 
 
-# --- the flag combinations that used to be silently inert ----------------------
-# `--phase X --pins` discarded --pins (phases_to_run returns [phase]), and
-# `--pins` without `--write` did nothing at all — the worst behaviours for a
-# flag whose whole job is recording explicit consent. Both must now refuse at
-# parse time, before plan() touches the network (asserted by the plan mock).
 def _main_with(argv):
     with mock.patch.object(sync_access, "plan",
                            side_effect=AssertionError("plan() must not run")), \
          mock.patch.object(sys, "argv", ["sync_access.py"] + argv):
         return aborts(sync_access.main)
 
-
-check("--phase with --pins is refused loudly, never discarded",
-      _main_with(["--write", "--phase", "grant", "--pins"]), True)
-check("--phase pin with --pins is refused too — one spelling per consent",
-      _main_with(["--write", "--phase", "pin", "--pins"]), True)
-check("--pins without --write is refused, not silently inert",
-      _main_with(["--pins"]), True)
 
 # --notify / --mail-if-required make Drive email real people: the same
 # --i-have-approval consent the Slack write steps require, refused at parse
@@ -401,7 +335,7 @@ check("both remediation hints name the consent flag",
        _src.count("(or pass --mail-if-required \"\n                     \"--i-have-approval)")), (1, 1))
 
 # --- redaction through the whole report: no fixture email or full name survives --
-_plan = {"pins": [], "already_pinned": [], "no_banner": [], "already_granted": [],
+_plan = {"already_granted": [],
          "grants": [{"chapter": "Boston", "email": "ada@x.com",
                      "name": "Ada Lovelace", "role": "writer"}],
          "public": [], "near": [],

--- a/skills/aaif-sync-chapters/scripts/test_sync_crm.py
+++ b/skills/aaif-sync-chapters/scripts/test_sync_crm.py
@@ -169,9 +169,13 @@ check("merge dedupes identical expertise", both[0]["expertise"], "Agents")
 check("merge keeps different cities apart",
       len(merge_people([person("A", "a@x.io", "Boston"), person("A", "a@x.io", "Berlin")])), 2)
 
-# Security guard: a NOT-yet-accepted row never merges into an all-accepted
-# person — the public form + email-keyed merge would otherwise let a stranger
-# writing under an accepted organizer's address fill their CRM row.
+# Guard: a NOT-yet-accepted row never merges into an all-accepted person, even
+# when the two rows share a name (2026-09-03: a same-name carve-out was tried
+# and reverted the same day — combining two role applications into one row is
+# not this function's call; a person's second role stays a held, unmerged
+# row until CRM workbooks grow separate per-role tabs). The public form +
+# email-keyed merge would otherwise let a stranger writing under an accepted
+# organizer's address fill their CRM row, so the block stays unconditional.
 _blk = []
 guarded = merge_people(
     [person("Ada", "ada@x.io", "Boston", "Organizers", "Accepted"),
@@ -182,11 +186,17 @@ check("a pipeline row does not merge into an all-accepted person",
 check("...its content does not reach the person's record",
       "totally a real talk" in guarded[0]["interest"], False)
 check("...and the refusal is reported in rejection shape",
-      (len(_blk), sorted(_blk[0]), "refusing to merge" in _blk[0]["why"]),
+      (len(_blk), sorted(_blk[0]), "held" in _blk[0]["why"]),
       (1, ["name", "row", "tab", "why"], True))
 check("without a blocked list the row is still refused",
       merge_people([person("Ada", "ada@x.io", "B", "Organizers", "Accepted"),
                     person("M", "ada@x.io", "B", "Speakers", "New")])[0]["tabs"],
+      ["Organizers"])
+check("a SAME-name second-role application is still held, not merged",
+      merge_people(
+          [person("Ada Lovelace", "ada2@x.io", "Boston", "Organizers", "Accepted"),
+           person("ADA  Lovelace", "ada2@x.io", "Boston", "Speakers", "Prospect",
+                  interest="I want to be a speaker")])[0]["tabs"],
       ["Organizers"])
 
 # --- the Status / Interested-in split (2026-08-25) --------------------------


### PR DESCRIPTION
## Summary
- Reverts a same-day patch to `sync_crm.py`'s merge guard that let a second-role application merge into an already-accepted organizer's row; relabels the (still-unconditional) refusal away from alarmist "SECURITY" language.
- Removes `sync_access.py`'s `pin` phase entirely — nothing in the Chapters tree needs a public share; the site serves imagery from Sanity, never a directly-shared Drive banner.
- Records the Seattle organizer-channel reclaim (`#seattle-chapter-leads` → `#seattle-wa-organizers`) already applied by hand.

## Changesets

### 1. `fix(sync-chapters): stop merging a second role application into an accepted organizer's row`
**Files:** `sync_crm.py`, `test_sync_crm.py`
The merge-block condition and its report line are reverted to unconditional; only the framing changes from "SECURITY" to a neutral "held for per-role tabs" note.

### 2. `feat(sync-chapters): remove sync_access's pin phase`
**Files:** `sync_access.py`, `test_sync_access.py`, `nightly.py`, `SKILL.md`
Drops `--pins`, `--phase pin`, `banner_ids()`, `direct_public()`, and the PHASE 1 banner report section. `--write` now always runs grant then lock.

### 3. `docs(sync-chapters): record the Seattle organizer-channel reclaim`
**Files:** `provision_channels.py`
Documents an already-applied Slack rename as decision history, matching the file's existing convention.

## Test Plan
- [x] `test_sync_crm.py`, `test_sync_access.py`, `test_nightly.py` all pass
- [x] `check_tooling_banner.py`, `check_no_secret_args.py`, `check_workflows.py` all pass
- [x] `pre-commit run --files ...` passes on every changed file
- [x] Ran `sync_access.py` (report mode) live against production data to confirm the pin-free report renders correctly

_Generated using hero-skills._