### PR TITLE
fix(sync-chapters): rename #welcome-cyprus to #cyprus

### DIFF
--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -215,13 +215,23 @@ OPTIONAL_SCOPES = {
 #: fails with `name_taken` on the one that matters.
 CHANNEL_RENAMES = {
     "bangalore": "bengaluru",
-    # 2026-09-10 (user-decided, per-channel): #welcome-cyprus is a country room
-    # wearing a `welcome-` prefix from whatever it was first opened as. Every
-    # other country room on this estate is the bare country name (#greece,
-    # #ireland, #austria, #taiwan), and the odd name is why it was nearly left
-    # out of the #general country directory as "probably an onboarding room".
-    # A rename keeps the id, all 7 members and the history; #cyprus is free.
-    "welcome-cyprus": "cyprus",
+    # APPLIED 2026-09-10 and deliberately NOT left as a live entry:
+    # #welcome-cyprus -> #cyprus (id C09N3B8NU21, 7 members and history kept).
+    # It was a country room wearing a `welcome-` prefix from whatever it was
+    # first opened as; every other country room here is the bare country name
+    # (#greece, #ireland, #austria, #taiwan), and the odd name is why it was
+    # nearly left out of the #general country directory as "probably an
+    # onboarding room".
+    #
+    # The entry is a comment rather than a mapping for the reason the block
+    # below records: an applied rename whose OLD name someone later recreates
+    # re-plans, finds its target held by a room nothing frees, and refuses the
+    # WHOLE run — no creates, no ops seed, no folder links, until a human edits
+    # this map. That is not hypothetical here: #welcome-cyprus is still named in
+    # the #general country directory post, so anyone re-reading it could open
+    # the old name by hand. Simulated before removing:
+    #     live = {"cyprus", "welcome-cyprus"}
+    #     -> BLOCKED [("welcome-cyprus", "cyprus")] -> "REFUSING: 1 rename(s)"
     "london-organizers": "london-organizers-deprecated",
     "london-meetup-organizers": "london-organizers",
     "bay-area-sf-organizers": "bay-area-organizers",

--- a/skills/aaif-sync-chapters/scripts/provision_channels.py
+++ b/skills/aaif-sync-chapters/scripts/provision_channels.py
@@ -215,6 +215,13 @@ OPTIONAL_SCOPES = {
 #: fails with `name_taken` on the one that matters.
 CHANNEL_RENAMES = {
     "bangalore": "bengaluru",
+    # 2026-09-10 (user-decided, per-channel): #welcome-cyprus is a country room
+    # wearing a `welcome-` prefix from whatever it was first opened as. Every
+    # other country room on this estate is the bare country name (#greece,
+    # #ireland, #austria, #taiwan), and the odd name is why it was nearly left
+    # out of the #general country directory as "probably an onboarding room".
+    # A rename keeps the id, all 7 members and the history; #cyprus is free.
+    "welcome-cyprus": "cyprus",
     "london-organizers": "london-organizers-deprecated",
     "london-meetup-organizers": "london-organizers",
     "bay-area-sf-organizers": "bay-area-organizers",


### PR DESCRIPTION
## Summary

`#welcome-cyprus` is a country room wearing a `welcome-` prefix from whatever it was first opened as. Every other country room on this estate is the bare country name — `#greece`, `#ireland`, `#austria`, `#taiwan` — and the odd name is why it was nearly dropped from the `#general` country directory as "probably an onboarding room". The name was the only evidence, and it was wrong.

## Changesets

### `fix(sync-chapters): rename #welcome-cyprus to #cyprus`
**Files:** `provision_channels.py` (+8)

One entry added to `CHANNEL_RENAMES`, with the reasoning recorded inline. Done through the map rather than a one-off script because this file renames only what the map lists — working around that to save a PR would undermine the rule.

**Already applied** (2026-09-10, per-channel permission, `--write --i-have-approval`): the report planned exactly one rename and nothing else, and the run reported `1 applied, 0 failed`.

Verified after: the room keeps id `C09N3B8NU21`, all 7 members and its full history; `#welcome-cyprus` no longer resolves. `#cyprus` was free beforehand. The `Countries` tab row was updated to match.

## Test Plan

- [x] Report mode planned exactly 1 rename, 0 creates, 0 merges, 0 archives
- [x] Applied: `renamed #welcome-cyprus -> #cyprus`, 1 applied / 0 failed
- [x] Verified live: same channel id, 7 members retained
- [x] Countries tab row 38 updated
- [x] 40 skill test suites pass; `pre-commit run --all-files` clean

### Follow-up

Slack posts a "renamed the channel" system message. Per the standing convention those get deleted by hand — `chat.delete` is deliberately absent from `WRITE_METHODS` and should stay that way.

_Generated using hero-skills._